### PR TITLE
feature/switch-prod-to-use-managed-identity

### DIFF
--- a/src/backend/Sudoku.Api/Sudoku.Api.csproj
+++ b/src/backend/Sudoku.Api/Sudoku.Api.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
+    <UserSecretsId>ad4f17c2-6632-4118-877d-674d27822499</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/backend/Sudoku.Api/appsettings.Production.json
+++ b/src/backend/Sudoku.Api/appsettings.Production.json
@@ -11,5 +11,9 @@
             "Enabled": true,
             "RefreshInterval": 30
         }
+    },
+    "CosmosDb": {
+        "UseManagedIdentity": true,
+        "AccountEndpoint": "https://cosmos-sudoku-prod.documents.azure.com:443/"
     }
 }

--- a/src/backend/Sudoku.Infrastructure/Configuration/CosmosDbOptions.cs
+++ b/src/backend/Sudoku.Infrastructure/Configuration/CosmosDbOptions.cs
@@ -7,4 +7,6 @@ public class CosmosDbOptions
     public string ContainerName { get; set; } = "games";
     public string DatabaseName { get; set; } = "sudoku";
     public bool DisableSslValidation { get; set; }
+    public bool UseManagedIdentity { get; set; }
+    public string? AccountEndpoint { get; set; }
 }

--- a/src/backend/Sudoku.Infrastructure/Configuration/InfrastructureServiceCollectionExtensions.cs
+++ b/src/backend/Sudoku.Infrastructure/Configuration/InfrastructureServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Azure.Identity;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
@@ -41,14 +42,7 @@ public static class InfrastructureServiceCollectionExtensions
         {
             services.AddSingleton<CosmosClient>(serviceProvider =>
             {
-                var connectionString = configuration.GetConnectionString("CosmosDb");
-            
-                if (string.IsNullOrEmpty(connectionString))
-                {
-                    throw new InvalidOperationException(
-                        "CosmosDb connection string not found. Please ensure it's configured in configuration " +
-                        "with the key 'ConnectionStrings:cosmosdb' or 'ConnectionStrings:CosmosDb'.");
-                }
+                var cosmosDbOptions = configuration.GetSection(CosmosDbOptions.SectionName).Get<CosmosDbOptions>();
 
                 var clientOptions = new CosmosClientOptions
                 {
@@ -58,9 +52,7 @@ public static class InfrastructureServiceCollectionExtensions
                     MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(15)
                 };
 
-                var cosmosDbOptions = configuration.GetSection(CosmosDbOptions.SectionName).Get<CosmosDbOptions>();
-
-                if (cosmosDbOptions.DisableSslValidation)
+                if (cosmosDbOptions?.DisableSslValidation == true)
                 {
                     clientOptions.HttpClientFactory = () =>
                     {
@@ -71,6 +63,26 @@ public static class InfrastructureServiceCollectionExtensions
 
                         return new HttpClient(httpMessageHandler);
                     };
+                }
+
+                if (cosmosDbOptions?.UseManagedIdentity == true)
+                {
+                    if (string.IsNullOrEmpty(cosmosDbOptions.AccountEndpoint))
+                    {
+                        throw new InvalidOperationException(
+                            "CosmosDb:AccountEndpoint must be set when CosmosDb:UseManagedIdentity is true.");
+                    }
+
+                    return new CosmosClient(cosmosDbOptions.AccountEndpoint, new DefaultAzureCredential(), clientOptions);
+                }
+
+                var connectionString = configuration.GetConnectionString("CosmosDb");
+
+                if (string.IsNullOrEmpty(connectionString))
+                {
+                    throw new InvalidOperationException(
+                        "CosmosDb connection string not found. Please ensure it's configured in configuration " +
+                        "with the key 'ConnectionStrings:CosmosDb', or set CosmosDb:UseManagedIdentity to true.");
                 }
 
                 return new CosmosClient(connectionString, clientOptions);


### PR DESCRIPTION
## Description
Switched the API to use managed identity to access Cosmos DB for prod.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Updated appsettings.production.json to include CosmosDB settings
- Added additional props to CosmosDBOptions
- Updated configuration to use managed identity

## Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass
- [ ] I have added new tests (if applicable)

## Screenshots (if applicable)

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)