### PR TITLE
bugfix: makeMove causes null ref exception

### DIFF
--- a/src/frontend/Sudoku.React/src/api/apiClient.ts
+++ b/src/frontend/Sudoku.React/src/api/apiClient.ts
@@ -41,24 +41,30 @@ export const apiClient = {
   deleteGame: (alias: string, gameId: string): Promise<void> =>
     request(`/api/players/${alias}/games/${gameId}`, { method: 'DELETE' }),
 
-  makeMove: (
+  makeMove: async (
     alias: string,
     gameId: string,
     row: number,
     column: number,
     value: number | null,
     playDuration: string
-  ): Promise<GameModel> =>
-    request(`/api/players/${alias}/games/${gameId}/actions`, {
+  ): Promise<GameModel> => {
+    await request(`/api/players/${alias}/games/${gameId}/actions`, {
       method: 'PUT',
       body: JSON.stringify({ row, column, value, playDuration }),
-    }),
+    });
+    return request(`/api/players/${alias}/games/${gameId}`);
+  },
 
-  resetGame: (alias: string, gameId: string): Promise<GameModel> =>
-    request(`/api/players/${alias}/games/${gameId}/actions/reset`, { method: 'POST' }),
+  resetGame: async (alias: string, gameId: string): Promise<GameModel> => {
+    await request(`/api/players/${alias}/games/${gameId}/actions/reset`, { method: 'POST' });
+    return request(`/api/players/${alias}/games/${gameId}`);
+  },
 
-  undoMove: (alias: string, gameId: string): Promise<GameModel> =>
-    request(`/api/players/${alias}/games/${gameId}/actions/undo`, { method: 'POST' }),
+  undoMove: async (alias: string, gameId: string): Promise<GameModel> => {
+    await request(`/api/players/${alias}/games/${gameId}/actions/undo`, { method: 'POST' });
+    return request(`/api/players/${alias}/games/${gameId}`);
+  },
 
   updateStatus: (alias: string, gameId: string, status: string): Promise<void> =>
     request(`/api/players/${alias}/games/${gameId}/status/${status}`, { method: 'PATCH' }),

--- a/src/frontend/Sudoku.React/src/api/apiClient.ts
+++ b/src/frontend/Sudoku.React/src/api/apiClient.ts
@@ -69,38 +69,44 @@ export const apiClient = {
   updateStatus: (alias: string, gameId: string, status: string): Promise<void> =>
     request(`/api/players/${alias}/games/${gameId}/status/${status}`, { method: 'PATCH' }),
 
-  addPossibleValue: (
+  addPossibleValue: async (
     alias: string,
     gameId: string,
     row: number,
     column: number,
     value: number
-  ): Promise<GameModel> =>
-    request(`/api/players/${alias}/games/${gameId}/possible-values`, {
+  ): Promise<GameModel> => {
+    await request(`/api/players/${alias}/games/${gameId}/possible-values`, {
       method: 'POST',
       body: JSON.stringify({ row, column, value }),
-    }),
+    });
+    return request(`/api/players/${alias}/games/${gameId}`);
+  },
 
-  removePossibleValue: (
+  removePossibleValue: async (
     alias: string,
     gameId: string,
     row: number,
     column: number,
     value: number
-  ): Promise<GameModel> =>
-    request(`/api/players/${alias}/games/${gameId}/possible-values`, {
+  ): Promise<GameModel> => {
+    await request(`/api/players/${alias}/games/${gameId}/possible-values`, {
       method: 'DELETE',
       body: JSON.stringify({ row, column, value }),
-    }),
+    });
+    return request(`/api/players/${alias}/games/${gameId}`);
+  },
 
-  clearPossibleValues: (
+  clearPossibleValues: async (
     alias: string,
     gameId: string,
     row: number,
     column: number
-  ): Promise<GameModel> =>
-    request(`/api/players/${alias}/games/${gameId}/possible-values/clear`, {
+  ): Promise<GameModel> => {
+    await request(`/api/players/${alias}/games/${gameId}/possible-values/clear`, {
       method: 'DELETE',
       body: JSON.stringify({ row, column }),
-    }),
+    });
+    return request(`/api/players/${alias}/games/${gameId}`);
+  },
 };


### PR DESCRIPTION
## Description
Updated makeMove, resetGame, and undoMove so they all make a second call to getGame so that the GameModel is satisfied with the return results.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Updated makeMove, resetGame, and undoMove so they all make a second call to getGame so that the GameModel is satisfied with the return results.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

## Screenshots (if applicable)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)