### PR TITLE
Fixed cell styling when in pencil mode

### DIFF
--- a/src/frontend/Sudoku.React/src/components/CellInput.module.css
+++ b/src/frontend/Sudoku.React/src/components/CellInput.module.css
@@ -3,7 +3,20 @@
 }
 
 .cell {
+  background-color: #FAEBD7;
   position: relative;
+}
+
+.highlight {
+  background-color: #d8eef8 !important;
+}
+
+.selected {
+  background-color: #b8d8f0 !important;
+}
+
+.invalid {
+  background-color: #ffdddd !important;
 }
 
 .cell input,

--- a/src/frontend/Sudoku.React/src/components/CellInput.tsx
+++ b/src/frontend/Sudoku.React/src/components/CellInput.tsx
@@ -59,7 +59,7 @@ export default function CellInput({
         value={cell.hasValue && cell.value !== null ? cell.value.toString() : ''}
         onClick={handleClick}
         onChange={() => {}}
-        style={cell.possibleValues.length > 0 && !cell.hasValue ? { opacity: 0 } : undefined}
+        style={cell.possibleValues.length > 0 && !cell.hasValue ? { backgroundColor: 'transparent' } : undefined}
       />
     </td>
   );


### PR DESCRIPTION
## Description
When entering possible values in a cell (pencil mode), the cell lost all styling and turned white with no cell border. Added styling to the cell background in pencil mode.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Added default background color of cell
- Added override background color of cell for .highlight, .selected, .invalid states
- Set cell background color as transparent when editing

## Testing

- [ ] I have tested these changes locally
- [ ] All existing tests pass
- [ ] I have added new tests (if applicable)

## Screenshots (if applicable)

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)