### PR TITLE
Fix flaky and broken tests across E2E and unit suites

### DIFF
--- a/Tests/E2E/fixtures/game-data.ts
+++ b/Tests/E2E/fixtures/game-data.ts
@@ -99,6 +99,26 @@ function makeNearSolvedCells(emptyRow = 0, emptyCol = 0): CellModel[] {
 }
 
 /**
+ * Builds 81 cells with TWO empty user-editable cells.
+ * Filling only one of them won't solve the board, so isSolved() stays false.
+ */
+function makeNearSolvedCellsWith2Empty(
+  emptyRow1 = 0, emptyCol1 = 0,
+  emptyRow2 = 0, emptyCol2 = 1,
+): CellModel[] {
+  const cells: CellModel[] = [];
+  for (let r = 0; r < 9; r++) {
+    for (let c = 0; c < 9; c++) {
+      const isEmpty =
+        (r === emptyRow1 && c === emptyCol1) ||
+        (r === emptyRow2 && c === emptyCol2);
+      cells.push(isEmpty ? makeEmptyCell(r, c) : makeCell(r, c, SOLVED_BOARD[r][c], true));
+    }
+  }
+  return cells;
+}
+
+/**
  * Builds a fully solved 81-cell board.
  * Cell (0,0) is user-placed (isFixed=false) to reflect that the user filled it in.
  */
@@ -176,6 +196,30 @@ export function makeSolvedGame(): GameModel {
     moveHistory: [{ row: EMPTY_CELL_ROW, column: EMPTY_CELL_COL, value: EMPTY_CELL_VALUE, isValid: true }],
     statistics: makeStats({ totalMoves: 1, invalidMoves: 0, playDuration: '00:01:00' }),
   });
+}
+
+/**
+ * A game with TWO empty cells — cell (0,0) and cell (0,1) — so that filling
+ * cell (0,0) does NOT complete the board and isSolved() stays false.
+ * Use this as `initialGame` in cell-interaction tests.
+ */
+export function makeTestGameForInteraction(): GameModel {
+  return makeTestGame({
+    cells: makeNearSolvedCellsWith2Empty(EMPTY_CELL_ROW, EMPTY_CELL_COL, 0, 1),
+  });
+}
+
+/**
+ * State after the user places EMPTY_CELL_VALUE in cell (0,0) while cell (0,1)
+ * is still empty. isSolved() returns false so no victory display is triggered.
+ * Use as `gameAfterMove` in cell-interaction tests.
+ */
+export function makeTestGameAfterInteractionMove(): GameModel {
+  const cells = makeNearSolvedCellsWith2Empty(EMPTY_CELL_ROW, EMPTY_CELL_COL, 0, 1);
+  const cell = cells.find(c => c.row === EMPTY_CELL_ROW && c.column === EMPTY_CELL_COL)!;
+  cell.value = EMPTY_CELL_VALUE;
+  cell.hasValue = true;
+  return makeTestGame({ cells });
 }
 
 /**

--- a/Tests/E2E/tests/game.spec.ts
+++ b/Tests/E2E/tests/game.spec.ts
@@ -9,6 +9,8 @@ import {
   makeTestGameWithMove,
   makeTestGameWithStats,
   makeSolvedGame,
+  makeTestGameForInteraction,
+  makeTestGameAfterInteractionMove,
 } from '../fixtures/game-data';
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -58,8 +60,8 @@ test.describe('Game Page – Board', () => {
 test.describe('Game Page – Cell Interaction', () => {
   test('clicking a number button places a value in the selected cell', async ({ page, gamePage }) => {
     await setupApiMocks(page, {
-      initialGame: makeTestGame(),
-      gameAfterMove: makeTestGameWithMove(),
+      initialGame: makeTestGameForInteraction(),
+      gameAfterMove: makeTestGameAfterInteractionMove(),
     });
     await gamePage.goto(TEST_GAME_ID);
 
@@ -72,8 +74,8 @@ test.describe('Game Page – Cell Interaction', () => {
 
   test('pressing a number key on the keyboard places a value in the selected cell', async ({ page, gamePage }) => {
     await setupApiMocks(page, {
-      initialGame: makeTestGame(),
-      gameAfterMove: makeTestGameWithMove(),
+      initialGame: makeTestGameForInteraction(),
+      gameAfterMove: makeTestGameAfterInteractionMove(),
     });
     await gamePage.goto(TEST_GAME_ID);
 

--- a/src/backend/Tests/Blazor/Services/GameTimerTests.cs
+++ b/src/backend/Tests/Blazor/Services/GameTimerTests.cs
@@ -118,7 +118,7 @@ public class GameTimerTests : IDisposable
 
         // Act
         _timer.Start();
-        await Task.Delay(_interval * 5);
+        await Task.Delay(_interval * 10);
         _timer.Pause();
 
         // Assert


### PR DESCRIPTION
## Summary

- **E2E cell interaction tests** (`game.spec.ts`): The `initialGame`/`gameAfterMove` fixtures used `makeTestGame()` — a near-solved board with only one empty cell. Placing any value on that cell produced a fully solved board, which caused `isSolved()` to return `true` and replaced the game board with the victory overlay before the assertion could run. Added `makeTestGameForInteraction()` (two empty cells) and `makeTestGameAfterInteractionMove()` (one filled, one still empty) so the board stays visible after the move.

- **`GameTimerTests.OnTick_ShouldFireAtInterval`** (`GameTimerTests.cs`): The test waited only `_interval × 5` (50 ms at a 10 ms interval) before asserting ≥ 3 ticks. Under CI scheduling jitter this gave only 2 ticks. Doubled the wait to `_interval × 10` for reliable headroom.

## Test plan

- [x] `dotnet test` — 710/710 passing (was 709/710)
- [x] `npm run test` in `Sudoku.React` — 139/139 passing
- [x] `npx playwright test --project=react` in `Tests/E2E` — 26/26 passing (was 24/26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)