### PR TITLE
Skip deployment jobs when only documentation files change

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,25 @@ permissions:
   pull-requests: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'infra/**'
+              - 'Tests/**'
+              - '**/*.csproj'
+              - '**/*.sln'
+              - 'package*.json'
+              - '.github/workflows/**'
+
   build:
     runs-on: ubuntu-latest
 
@@ -177,8 +196,8 @@ jobs:
           path: TestResults
 
   deploy-infra:
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [test, changes]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     environment: production
 
@@ -290,7 +309,8 @@ jobs:
           package: ${{ github.workspace }}/publish-mcp
 
   deploy-swa:
-    needs: [deploy-infra, build-frontend]
+    needs: [deploy-infra, build-frontend, changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     environment: production
 


### PR DESCRIPTION
## Description

Adds path-based change detection to the CI pipeline so that deployment jobs are automatically skipped when only documentation files (markdown, docs) are modified. Build and test still run to keep commit status green.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Other (please describe): CI/CD optimization — skip unnecessary deployments

## Changes Made

- Added a `changes` job using `dorny/paths-filter@v3` that outputs `code: true/false` based on whether `src/**`, `infra/**`, `Tests/**`, `*.csproj`, `*.sln`, `package*.json`, or `.github/workflows/**` were modified
- Updated `deploy-infra` to `needs: [test, changes]` and added `needs.changes.outputs.code == 'true'` to its `if:` condition
- Updated `deploy-swa` to `needs: [deploy-infra, build-frontend, changes]` with matching `if:` condition
- `deploy-apps` is skipped transitively (it depends on `deploy-infra`)

## Testing

- [ ] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

Verify by pushing a docs-only commit and confirming the three deploy jobs show as **Skipped** in the Actions UI, while `build` and `test` still complete successfully.

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)