### PR TITLE
Fix prod failure page: disable Easy Auth on API and guard null game session

### DIFF
--- a/infra/modules/compute.bicep
+++ b/infra/modules/compute.bicep
@@ -188,6 +188,19 @@ resource apiAppSettings 'Microsoft.Web/sites/config@2023-12-01' = {
   }
 }
 
+resource apiAppAuthSettings 'Microsoft.Web/sites/config@2023-12-01' = {
+  parent: apiApp
+  name: 'authsettingsV2'
+  properties: {
+    globalValidation: {
+      requireAuthentication: false
+    }
+    platform: {
+      enabled: false
+    }
+  }
+}
+
 output webAppUrl string = webApp.properties.defaultHostName
 output apiAppUrl string = apiApp.properties.defaultHostName
 output apiAppId string = apiApp.id

--- a/src/frontend/Sudoku.Blazor/Services/GameStatisticsManager.cs
+++ b/src/frontend/Sudoku.Blazor/Services/GameStatisticsManager.cs
@@ -31,6 +31,7 @@ public partial class GameManager : IGameStatisticsManager
     /// <returns>A task that represents the asynchronous operation of ending the session.</returns>
     public async Task EndSession()
     {
+        if (Game == null) return;
         Game.Status = Game.IsSolved() ? GameStatus.Completed : GameStatus.Abandoned;
         gameTimer.OnTick -= OnTimerTick;
         gameTimer.Reset();
@@ -45,6 +46,7 @@ public partial class GameManager : IGameStatisticsManager
     /// <returns>A task that represents the asynchronous operation.</returns>
     public async Task PauseSession()
     {
+        if (Game == null) return;
         Game.Status = GameStatus.Paused;
         gameTimer.OnTick -= OnTimerTick;
         gameTimer.Pause();
@@ -76,6 +78,7 @@ public partial class GameManager : IGameStatisticsManager
     /// <returns>A task that represents the asynchronous operation. The task completes when the session is successfully resumed.</returns>
     public Task ResumeSession()
     {
+        if (Game == null) return Task.CompletedTask;
         Game.Status = GameStatus.InProgress;
         var playDuration = CurrentStatistics.PlayDuration;
         gameTimer.OnTick += OnTimerTick;
@@ -91,6 +94,7 @@ public partial class GameManager : IGameStatisticsManager
     /// <returns>A task that represents the asynchronous operation of starting a new session.</returns>
     public async Task StartNewSession()
     {
+        if (Game == null) return;
         Game.Status = GameStatus.InProgress;
         CurrentStatistics.Reset();
         gameTimer.Reset();


### PR DESCRIPTION
## What broke
The production Blazor app was showing a failure page whenever a user tried to load a saved game. Diagnosed via App Insights telemetry.

## Root causes

### 1. Easy Auth blocking all Blazor → API calls (critical)
Azure Easy Auth (`requireAuthentication: true`) was enabled on the `XenobiasoftSudokuApi-prod` App Service — likely turned on manually via the Portal. The Blazor server makes server-to-server HTTP calls with no auth token, so every call to `GET /api/players/{alias}/games/{id}` returned **401 Unauthorized**. `LoadGameAsync` treats any non-success response as a failure and throws, which navigates the user to `/Error`.

The React SWA is unaffected because it routes API calls through the SWA linked-backend proxy, which bypasses the App Service's Easy Auth.

**Fix:** Added `authsettingsV2` Bicep resource to `compute.bicep` that explicitly disables Easy Auth on the API App Service, codifying the intent in IaC so it can't be accidentally re-enabled via the Portal.

### 2. NullReferenceException on navigation after failed load (medium)
The navigation handler (`OnLocationChanging`) is registered in `InitializeGameAsync` **before** `LoadGameAsync` is called. When the load fails and Blazor navigates to `/Error`, the handler fires and calls `PauseSession()` — but `Game` is null because the load never completed. Same risk exists in `EndSession`, `ResumeSession`, and `StartNewSession`.

**Fix:** Added `if (Game == null) return;` guards to all four session lifecycle methods in `GameStatisticsManager.cs`.

## Test plan
- [ ] Merge and confirm the next prod deployment applies the Bicep change (Easy Auth disabled)
- [ ] Manually verify a saved game loads successfully in prod after deployment
- [ ] Confirm no new exceptions appear in App Insights for `XenobiasoftSudoku-prod`
- [ ] If you need an immediate fix before the next deploy: disable Easy Auth manually in the Azure Portal under `XenobiasoftSudokuApi-prod → Authentication`

🤖 Generated with [Claude Code](https://claude.com/claude-code)