### PR TITLE
Fix SWA linked backend blocking API access for Blazor app

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -176,6 +176,7 @@ module staticwebapp 'modules/staticwebapp.bicep' = {
     customDomainName: swaCustomDomainName
     enableCustomDomain: enableSwaCustomDomain
     apiAppResourceId: compute.outputs.apiAppId
+    apiAppName: apiAppName
   }
 }
 

--- a/infra/modules/staticwebapp.bicep
+++ b/infra/modules/staticwebapp.bicep
@@ -11,6 +11,9 @@ param enableCustomDomain bool = false
 @description('Resource ID of the API App Service to link as a backend. SWA will proxy /api/* requests to it.')
 param apiAppResourceId string
 
+@description('Name of the API App Service. Used to reset Easy Auth after SWA linking re-enables it.')
+param apiAppName string
+
 var tags = {
   environment: environment
   project: 'XenobiaSoftSudoku'
@@ -33,6 +36,27 @@ resource staticWebAppLinkedBackend 'Microsoft.Web/staticSites/linkedBackends@202
   properties: {
     backendResourceId: apiAppResourceId
     region: location
+  }
+}
+
+// SWA's linkedBackend creation automatically re-enables Easy Auth on the API App Service
+// and configures it to only accept SWA-issued tokens. Reset it here (after linking) so
+// direct callers (e.g. the Blazor App Service) are not blocked by the injected auth layer.
+resource existingApiApp 'Microsoft.Web/sites@2023-12-01' existing = {
+  name: apiAppName
+}
+
+resource apiAuthDisabledAfterLinking 'Microsoft.Web/sites/config@2023-12-01' = {
+  parent: existingApiApp
+  name: 'authsettingsV2'
+  dependsOn: [staticWebAppLinkedBackend]
+  properties: {
+    globalValidation: {
+      requireAuthentication: false
+    }
+    platform: {
+      enabled: false
+    }
   }
 }
 

--- a/src/frontend/Sudoku.React/public/staticwebapp.config.json
+++ b/src/frontend/Sudoku.React/public/staticwebapp.config.json
@@ -1,4 +1,10 @@
 {
+  "routes": [
+    {
+      "route": "/api/*",
+      "allowedRoles": ["anonymous"]
+    }
+  ],
   "navigationFallback": {
     "rewrite": "/index.html",
     "exclude": ["/images/*", "/css/*", "/js/*", "*.{png,jpg,svg,ico,json,woff,woff2,ttf,eot}", "/api/*"]


### PR DESCRIPTION
## Summary

- **Root cause:** When `staticSites/linkedBackends` is created, Azure automatically re-enables Easy Auth on the linked API App Service and reconfigures it to only accept SWA-issued tokens — overriding the `platform.enabled: false` set in `compute.bicep`. Direct callers (the Blazor App Service) have no SWA tokens and are blocked.
- **`infra/modules/staticwebapp.bicep`:** After creating the linked backend, immediately reset `authsettingsV2` to `platform.enabled: false` / `requireAuthentication: false` using `dependsOn` to ensure it runs after the linking that triggers the auth change.
- **`infra/main.bicep`:** Thread the existing `apiAppName` top-level param through to the staticwebapp module.
- **`staticwebapp.config.json`:** Add `allowedRoles: ["anonymous"]` route for `/api/*` so SWA does not enforce its own auth layer when proxying requests from the React frontend to the linked backend.

## Test plan

- [ ] Deploy to prod via merge to `main` and confirm Bicep deployment succeeds
- [ ] Verify the Blazor app can reach the API (e.g. game load works without 401/403)
- [ ] Verify the React frontend can reach the API through SWA (`/api/*` routes respond)
- [ ] Confirm Azure Portal shows Easy Auth as disabled on the API App Service after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)