### PR TITLE
Style Blazor profile pages to match React UI

### DIFF
--- a/src/frontend/Sudoku.Blazor/Components/Pages/CreateProfile.razor.css
+++ b/src/frontend/Sudoku.Blazor/Components/Pages/CreateProfile.razor.css
@@ -1,0 +1,95 @@
+.create-profile-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    padding: 1rem;
+    background: #f4f4f4;
+}
+
+.create-profile-card {
+    background: white;
+    border-radius: 8px;
+    padding: 2rem;
+    max-width: 440px;
+    width: 100%;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+}
+
+.create-profile-card h1 {
+    margin: 0 0 0.5rem;
+    font-size: 1.75rem;
+    font-weight: 700;
+}
+
+.subtitle {
+    color: #555;
+    margin: 0 0 1.5rem;
+}
+
+.warning-note {
+    margin-top: 1.25rem;
+    font-size: 0.8rem;
+    color: #888;
+}
+
+/* Everything below is inside EditForm → requires ::deep */
+
+::deep .form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+::deep .form-group label {
+    font-weight: 600;
+}
+
+::deep .form-control {
+    padding: 0.6rem 0.8rem;
+    font-size: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    outline: none;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+::deep .form-control:focus {
+    border-color: #555;
+    box-shadow: none;
+}
+
+::deep .form-control.is-invalid {
+    border-color: #d9534f;
+}
+
+::deep .error-message {
+    color: #d9534f;
+    font-size: 0.875rem;
+    margin: 0;
+}
+
+::deep .form-hint {
+    color: #777;
+    font-size: 0.8rem;
+    margin: 0;
+}
+
+::deep .btn-primary {
+    margin-top: 0.75rem;
+    padding: 0.7rem 1.25rem;
+    font-size: 1rem;
+    font-weight: 600;
+    background: #333;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    width: 100%;
+}
+
+::deep .btn-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}

--- a/src/frontend/Sudoku.Blazor/Components/Pages/Profile.razor
+++ b/src/frontend/Sudoku.Blazor/Components/Pages/Profile.razor
@@ -20,10 +20,12 @@
                         <DataAnnotationsValidator />
                         <div class="edit-row">
                             <InputText @bind-Value="_editModel.NewAlias" class="form-control" maxlength="50" />
-                            <button type="submit" class="btn-primary" disabled="@_isSaving">
-                                @(_isSaving ? "Saving…" : "Save")
-                            </button>
-                            <button type="button" class="btn-secondary" @onclick="CancelEdit">Cancel</button>
+                            <div class="edit-actions">
+                                <button type="submit" class="btn-primary" disabled="@_isSaving">
+                                    @(_isSaving ? "Saving…" : "Save")
+                                </button>
+                                <button type="button" class="btn-secondary" @onclick="CancelEdit">Cancel</button>
+                            </div>
                         </div>
                         <ValidationMessage For="@(() => _editModel.NewAlias)" />
                         @if (!string.IsNullOrEmpty(_editError))

--- a/src/frontend/Sudoku.Blazor/Components/Pages/Profile.razor.css
+++ b/src/frontend/Sudoku.Blazor/Components/Pages/Profile.razor.css
@@ -1,0 +1,120 @@
+.profile-container {
+    display: flex;
+    justify-content: center;
+    padding: 2rem 1rem;
+}
+
+.profile-card {
+    background: white;
+    border-radius: 8px;
+    padding: 2rem;
+    max-width: 480px;
+    width: 100%;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+}
+
+.profile-card h1 {
+    margin: 0 0 1.5rem;
+    font-size: 1.75rem;
+    font-weight: 700;
+}
+
+.profile-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-bottom: 1.25rem;
+}
+
+.field-label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.field-value-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-size: 1.1rem;
+}
+
+.btn-link {
+    font-size: 0.85rem;
+    color: #555;
+    background: transparent;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    padding: 0.2rem 0.6rem;
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.warning-note {
+    margin-top: 1.5rem;
+    font-size: 0.8rem;
+    color: #888;
+}
+
+/* Everything below is inside EditForm → requires ::deep */
+
+::deep .edit-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+::deep .form-control {
+    padding: 0.5rem 0.75rem;
+    font-size: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    outline: none;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+::deep .form-control:focus {
+    border-color: #555;
+    box-shadow: none;
+}
+
+::deep .edit-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.25rem;
+}
+
+::deep .btn-primary {
+    padding: 0.45rem 1rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    background: #333;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+::deep .btn-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+::deep .btn-secondary {
+    padding: 0.45rem 1rem;
+    font-size: 0.9rem;
+    background: transparent;
+    color: #555;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+::deep .error-message {
+    color: #d9534f;
+    font-size: 0.875rem;
+    margin: 0;
+}


### PR DESCRIPTION
## Summary
- Add `Profile.razor.css` with scoped styles for the `/profile` page: centered white card, uppercase field labels, inline edit form with dark Save button and outlined Cancel/Edit buttons
- Add `CreateProfile.razor.css` with scoped styles for `/create-profile`: full-viewport-centered card on gray background with dark submit button
- Add `<div class="edit-actions">` wrapper in `Profile.razor` to enable horizontal button layout in the edit form

## Details
All styles mirror the existing React `ProfilePage.module.css` and `CreateProfilePage.module.css`. Rules targeting elements inside `EditForm` use `::deep` since Blazor CSS isolation doesn't cross component boundaries.

## Test plan
- [ ] Run `dotnet run --project src/frontend/Sudoku.Blazor` and navigate to `/create-profile` — centered white card on gray background, dark "Create Profile" button spanning full width
- [ ] Create a profile and navigate to `/profile` — centered card with uppercase gray labels, alias value displayed with small outlined Edit button
- [ ] Click Edit on the alias — input appears above a row of dark Save + outlined Cancel buttons
- [ ] Verify error states render correctly (red border on input, red error text)
- [ ] Confirm no regressions on other Blazor pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)