### PR TITLE
Enable stateless mode on MCP HTTP transport

### DIFF
--- a/src/backend/Sudoku.McpServer/Program.cs
+++ b/src/backend/Sudoku.McpServer/Program.cs
@@ -17,7 +17,7 @@ builder.Services.AddSingleton(_ => new LogsQueryClient(new DefaultAzureCredentia
 // ---------------------------------------------------------------------------
 builder.Services
     .AddMcpServer()
-    .WithHttpTransport()
+    .WithHttpTransport(options => options.Stateless = true)
     .WithTools<ApplicationInsightsTools>();
 
 builder.Services.AddHealthChecks();


### PR DESCRIPTION
## Summary
- Adds `options.Stateless = true` to `WithHttpTransport()` in the MCP server
- Root cause: Claude Code does not maintain the `Mcp-Session-Id` header between tool invocations; the server was rejecting every tool call with a session-not-found error
- The App Insights tools are stateless query functions, so no session state is lost

## Test plan
- [ ] Merge to main and let CI deploy to production
- [ ] Verify MCP tools respond in Claude Code (`get_exception_summary`, `query_logs`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)