### PR TITLE
Surface real Azure errors from MCP tools

### DIFF
--- a/src/backend/Sudoku.McpServer/Tools/ApplicationInsightsTools.cs
+++ b/src/backend/Sudoku.McpServer/Tools/ApplicationInsightsTools.cs
@@ -44,12 +44,7 @@ public sealed class ApplicationInsightsTools
         CancellationToken cancellationToken = default)
     {
         hours = Math.Clamp(hours, 1, 720);
-        var response = await _logsClient.QueryWorkspaceAsync(
-            _workspaceId, kql,
-            new QueryTimeRange(TimeSpan.FromHours(hours)),
-            cancellationToken: cancellationToken);
-
-        return FormatTables(response.Value);
+        return await ExecuteKql(kql, hours, cancellationToken);
     }
 
     // -------------------------------------------------------------------------
@@ -209,12 +204,19 @@ public sealed class ApplicationInsightsTools
 
     private async Task<string> ExecuteKql(string kql, int hours, CancellationToken cancellationToken)
     {
-        var response = await _logsClient.QueryWorkspaceAsync(
-            _workspaceId, kql,
-            new QueryTimeRange(TimeSpan.FromHours(hours)),
-            cancellationToken: cancellationToken);
+        try
+        {
+            var response = await _logsClient.QueryWorkspaceAsync(
+                _workspaceId, kql,
+                new QueryTimeRange(TimeSpan.FromHours(hours)),
+                cancellationToken: cancellationToken);
 
-        return FormatTables(response.Value);
+            return FormatTables(response.Value);
+        }
+        catch (Exception ex)
+        {
+            return $"Error querying Log Analytics: {ex.GetType().Name}: {ex.Message}";
+        }
     }
 
     private static string FormatTables(LogsQueryResult result)


### PR DESCRIPTION
## Summary
- Wraps `ExecuteKql` in a try/catch that returns the actual exception type and message instead of letting it propagate to the MCP SDK (which replaces it with a generic "An error occurred invoking" message)
- Routes `QueryLogs` through `ExecuteKql` to remove the duplicate `QueryWorkspaceAsync` call site

## Why
Auth/permission failures from Azure Monitor are currently invisible — we only see a generic error. With this change, the real error (e.g. `AuthenticationFailedException`, `RequestFailedException`) is returned directly as the tool result so it's diagnosable without needing App Service logs.

## Test plan
- [ ] Merge and deploy
- [ ] Invoke any App Insights MCP tool — on success see real data; on failure see the actual Azure exception message

🤖 Generated with [Claude Code](https://claude.com/claude-code)