### PR TITLE
Fix game-not-found returning 400 instead of 404

### DIFF
--- a/src/backend/Sudoku.Api/Controllers/BaseGameController.cs
+++ b/src/backend/Sudoku.Api/Controllers/BaseGameController.cs
@@ -20,7 +20,7 @@ public abstract class BaseGameController(IMediator mediator) : ControllerBase
         var gameResult = await mediator.Send(new GetGameQuery(gameId));
         if (!gameResult.IsSuccess)
         {
-            return (null, BadRequest(gameResult.Error));
+            return (null, NotFound(gameResult.Error));
         }
 
         if (gameResult.Value.PlayerAlias != alias)

--- a/src/backend/Tests/API/GameActionsControllerTests.cs
+++ b/src/backend/Tests/API/GameActionsControllerTests.cs
@@ -64,7 +64,7 @@ public class GameActionsControllerTests : BaseGameControllerTests<GameActionsCon
     }
 
     [Fact]
-    public async Task MakeMoveAsync_WhenGetGameReturnsFailed_ReturnsBadRequest()
+    public async Task MakeMoveAsync_WhenGameNotFound_ReturnsNotFound()
     {
         // Arrange
         var playerAlias = "TestPlayer";
@@ -80,8 +80,8 @@ public class GameActionsControllerTests : BaseGameControllerTests<GameActionsCon
         var result = await Sut.MakeMoveAsync(playerAlias, gameId, move);
 
         // Assert
-        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-        badRequestResult.Value.Should().Be(errorMessage);
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.Value.Should().Be(errorMessage);
     }
 
     [Fact]
@@ -178,7 +178,7 @@ public class GameActionsControllerTests : BaseGameControllerTests<GameActionsCon
     }
 
     [Fact]
-    public async Task ResetGameAsync_WhenGetGameReturnsFailed_ReturnsBadRequest()
+    public async Task ResetGameAsync_WhenGameNotFound_ReturnsNotFound()
     {
         // Arrange
         var playerAlias = "TestPlayer";
@@ -193,8 +193,8 @@ public class GameActionsControllerTests : BaseGameControllerTests<GameActionsCon
         var result = await Sut.ResetGameAsync(playerAlias, gameId);
 
         // Assert
-        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-        badRequestResult.Value.Should().Be(errorMessage);
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.Value.Should().Be(errorMessage);
     }
 
     [Fact]
@@ -289,7 +289,7 @@ public class GameActionsControllerTests : BaseGameControllerTests<GameActionsCon
     }
 
     [Fact]
-    public async Task UndoMoveAsync_WhenGetGameReturnsFailed_ReturnsBadRequest()
+    public async Task UndoMoveAsync_WhenGameNotFound_ReturnsNotFound()
     {
         // Arrange
         var playerAlias = "TestPlayer";
@@ -304,8 +304,8 @@ public class GameActionsControllerTests : BaseGameControllerTests<GameActionsCon
         var result = await Sut.UndoMoveAsync(playerAlias, gameId);
 
         // Assert
-        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-        badRequestResult.Value.Should().Be(errorMessage);
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.Value.Should().Be(errorMessage);
     }
 
     [Fact]

--- a/src/backend/Tests/API/GameStatusControllerTests.cs
+++ b/src/backend/Tests/API/GameStatusControllerTests.cs
@@ -56,7 +56,7 @@ public class GameStatusControllerTests : BaseGameControllerTests<GameStatusContr
     }
 
     [Fact]
-    public async Task PauseGameAsync_WhenGetGameReturnsFailed_ReturnsBadRequest()
+    public async Task PauseGameAsync_WhenGameNotFound_ReturnsNotFound()
     {
         // Arrange
         var errorMessage = "Failed to get game";
@@ -69,8 +69,8 @@ public class GameStatusControllerTests : BaseGameControllerTests<GameStatusContr
         var result = await Sut.PauseGameAsync("TestPlayer", Guid.NewGuid().ToString());
 
         // Assert
-        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-        badRequestResult.Value.Should().Be(errorMessage);
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.Value.Should().Be(errorMessage);
     }
 
     [Fact]
@@ -164,7 +164,7 @@ public class GameStatusControllerTests : BaseGameControllerTests<GameStatusContr
     }
 
     [Fact]
-    public async Task ResumeGameAsync_WhenGetGameReturnsFailed_ReturnsBadRequest()
+    public async Task ResumeGameAsync_WhenGameNotFound_ReturnsNotFound()
     {
         // Arrange
         var errorMessage = "Failed to get game";
@@ -177,8 +177,8 @@ public class GameStatusControllerTests : BaseGameControllerTests<GameStatusContr
         var result = await Sut.ResumeGameAsync("TestPlayer", Guid.NewGuid().ToString());
 
         // Assert
-        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-        badRequestResult.Value.Should().Be(errorMessage);
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.Value.Should().Be(errorMessage);
     }
 
     [Fact]
@@ -272,7 +272,7 @@ public class GameStatusControllerTests : BaseGameControllerTests<GameStatusContr
     }
 
     [Fact]
-    public async Task AbandonGameAsync_WhenGetGameReturnsFailed_ReturnsBadRequest()
+    public async Task AbandonGameAsync_WhenGameNotFound_ReturnsNotFound()
     {
         // Arrange
         var errorMessage = "Failed to get game";
@@ -285,8 +285,8 @@ public class GameStatusControllerTests : BaseGameControllerTests<GameStatusContr
         var result = await Sut.AbandonGameAsync("TestPlayer", Guid.NewGuid().ToString());
 
         // Assert
-        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-        badRequestResult.Value.Should().Be(errorMessage);
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.Value.Should().Be(errorMessage);
     }
 
     [Fact]
@@ -380,7 +380,7 @@ public class GameStatusControllerTests : BaseGameControllerTests<GameStatusContr
     }
 
     [Fact]
-    public async Task CompleteGameAsync_WhenGetGameReturnsFailed_ReturnsBadRequest()
+    public async Task CompleteGameAsync_WhenGameNotFound_ReturnsNotFound()
     {
         // Arrange
         var errorMessage = "Failed to get game";
@@ -393,8 +393,8 @@ public class GameStatusControllerTests : BaseGameControllerTests<GameStatusContr
         var result = await Sut.CompleteGameAsync("TestPlayer", Guid.NewGuid().ToString());
 
         // Assert
-        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-        badRequestResult.Value.Should().Be(errorMessage);
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.Value.Should().Be(errorMessage);
     }
 
     [Fact]
@@ -491,7 +491,7 @@ public class GameStatusControllerTests : BaseGameControllerTests<GameStatusContr
     }
 
     [Fact]
-    public async Task ValidateGameAsync_WhenGetGameReturnsFailed_ReturnsBadRequest()
+    public async Task ValidateGameAsync_WhenGameNotFound_ReturnsNotFound()
     {
         // Arrange
         var errorMessage = "Failed to get game";
@@ -504,8 +504,8 @@ public class GameStatusControllerTests : BaseGameControllerTests<GameStatusContr
         var result = await Sut.ValidateGameAsync("TestPlayer", Guid.NewGuid().ToString());
 
         // Assert
-        var badRequestResult = result.Result.Should().BeOfType<BadRequestObjectResult>().Subject;
-        badRequestResult.Value.Should().Be(errorMessage);
+        var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.Value.Should().Be(errorMessage);
     }
 
     [Fact]

--- a/src/backend/Tests/API/GamesControllerTests.cs
+++ b/src/backend/Tests/API/GamesControllerTests.cs
@@ -110,12 +110,12 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     }
 
     [Fact]
-    public async Task GetGameAsync_WhenServiceReturnsFailed_ReturnsBadRequest()
+    public async Task GetGameAsync_WhenGameNotFound_ReturnsNotFound()
     {
         // Arrange
         var playerAlias = "TestPlayer";
         var gameId = Guid.NewGuid().ToString();
-        var errorMessage = "Failed to get game";
+        var errorMessage = "Game not found with ID: " + gameId;
 
         MockMediator
             .Setup(x => x.Send(It.IsAny<GetGameQuery>(), It.IsAny<CancellationToken>()))
@@ -125,8 +125,8 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
         var result = await Sut.GetGameAsync(playerAlias, gameId);
 
         // Assert
-        var badRequestResult = result.Result.Should().BeOfType<BadRequestObjectResult>().Subject;
-        badRequestResult.Value.Should().Be(errorMessage);
+        var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.Value.Should().Be(errorMessage);
     }
 
     [Fact]
@@ -259,12 +259,12 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     }
 
     [Fact]
-    public async Task DeleteGameAsync_WhenGetGameReturnsFailed_ReturnsBadRequest()
+    public async Task DeleteGameAsync_WhenGameNotFound_ReturnsNotFound()
     {
         // Arrange
         var playerAlias = "TestPlayer";
         var gameId = Guid.NewGuid().ToString();
-        var errorMessage = "Failed to get game";
+        var errorMessage = "Game not found with ID: " + gameId;
 
         MockMediator
             .Setup(x => x.Send(It.IsAny<GetGameQuery>(), It.IsAny<CancellationToken>()))
@@ -274,8 +274,8 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
         var result = await Sut.DeleteGameAsync(playerAlias, gameId);
 
         // Assert
-        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-        badRequestResult.Value.Should().Be(errorMessage);
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.Value.Should().Be(errorMessage);
     }
 
     [Fact]

--- a/src/backend/Tests/API/PossibleValuesControllerTests.cs
+++ b/src/backend/Tests/API/PossibleValuesControllerTests.cs
@@ -64,7 +64,7 @@ public class PossibleValuesControllerTests : BaseGameControllerTests<PossibleVal
     }
 
     [Fact]
-    public async Task AddPossibleValueAsync_WhenGetGameReturnsFailed_ReturnsBadRequest()
+    public async Task AddPossibleValueAsync_WhenGameNotFound_ReturnsNotFound()
     {
         // Arrange
         var request = new PossibleValueRequest(1, 1, 5);
@@ -78,8 +78,8 @@ public class PossibleValuesControllerTests : BaseGameControllerTests<PossibleVal
         var result = await Sut.AddPossibleValueAsync("TestPlayer", Guid.NewGuid().ToString(), request);
 
         // Assert
-        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-        badRequestResult.Value.Should().Be(errorMessage);
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.Value.Should().Be(errorMessage);
     }
 
     [Fact]
@@ -182,7 +182,7 @@ public class PossibleValuesControllerTests : BaseGameControllerTests<PossibleVal
     }
 
     [Fact]
-    public async Task ClearPossibleValuesAsync_WhenGetGameReturnsFailed_ReturnsBadRequest()
+    public async Task ClearPossibleValuesAsync_WhenGameNotFound_ReturnsNotFound()
     {
         // Arrange
         var request = new CellRequest(1, 1);
@@ -196,8 +196,8 @@ public class PossibleValuesControllerTests : BaseGameControllerTests<PossibleVal
         var result = await Sut.ClearPossibleValuesAsync("TestPlayer", Guid.NewGuid().ToString(), request);
 
         // Assert
-        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-        badRequestResult.Value.Should().Be(errorMessage);
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.Value.Should().Be(errorMessage);
     }
 
     [Fact]
@@ -300,7 +300,7 @@ public class PossibleValuesControllerTests : BaseGameControllerTests<PossibleVal
     }
 
     [Fact]
-    public async Task RemovePossibleValueAsync_WhenGetGameReturnsFailed_ReturnsBadRequest()
+    public async Task RemovePossibleValueAsync_WhenGameNotFound_ReturnsNotFound()
     {
         // Arrange
         var request = new PossibleValueRequest(1, 1, 5);
@@ -314,8 +314,8 @@ public class PossibleValuesControllerTests : BaseGameControllerTests<PossibleVal
         var result = await Sut.RemovePossibleValueAsync("TestPlayer", Guid.NewGuid().ToString(), request);
 
         // Assert
-        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
-        badRequestResult.Value.Should().Be(errorMessage);
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        notFoundResult.Value.Should().Be(errorMessage);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Fixes a bug found via Application Insights logs where loading or deleting a game that doesn't exist in CosmosDB returned `400 Bad Request` instead of `404 Not Found`. This caused both the Blazor and React frontends to treat the response as an unrecoverable bad request error rather than a not-found condition.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `BaseGameController.GetAuthorizedGameAsync`: changed `BadRequest(gameResult.Error)` to `NotFound(gameResult.Error)` when `GetGameQuery` returns a failure — all endpoints that flow through this method are now correct
- Updated 12 controller unit tests across `GamesControllerTests`, `GameActionsControllerTests`, `GameStatusControllerTests`, and `PossibleValuesControllerTests` to assert `NotFoundObjectResult` instead of `BadRequestObjectResult` for the game-not-found scenario

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings