### PR TITLE
Associate games with ProfileId instead of PlayerAlias (#270)

### DIFF
--- a/src/backend/Sudoku.Api/Controllers/BaseGameController.cs
+++ b/src/backend/Sudoku.Api/Controllers/BaseGameController.cs
@@ -10,11 +10,11 @@ public abstract class BaseGameController(IMediator mediator) : ControllerBase
 {
     protected IMediator Mediator => mediator;
 
-    protected async Task<(GameDto? game, ActionResult? error)> GetAuthorizedGameAsync(string alias, string gameId)
+    protected async Task<(GameDto? game, ActionResult? error)> GetAuthorizedGameAsync(string profileId, string gameId)
     {
-        if (string.IsNullOrWhiteSpace(alias) || string.IsNullOrWhiteSpace(gameId))
+        if (string.IsNullOrWhiteSpace(profileId) || string.IsNullOrWhiteSpace(gameId))
         {
-            return (null, BadRequest("Player alias and game id cannot be null or empty."));
+            return (null, BadRequest("Profile ID and game id cannot be null or empty."));
         }
 
         var gameResult = await mediator.Send(new GetGameQuery(gameId));
@@ -23,7 +23,7 @@ public abstract class BaseGameController(IMediator mediator) : ControllerBase
             return (null, NotFound(gameResult.Error));
         }
 
-        if (gameResult.Value.PlayerAlias != alias)
+        if (gameResult.Value.ProfileId != profileId)
         {
             return (null, NotFound());
         }

--- a/src/backend/Sudoku.Api/Controllers/GameActionsController.cs
+++ b/src/backend/Sudoku.Api/Controllers/GameActionsController.cs
@@ -5,14 +5,14 @@ using Sudoku.Application.Commands;
 
 namespace Sudoku.Api.Controllers
 {
-    [Route("api/players/{alias}/games/{gameId}/actions")]
+    [Route("api/players/{profileId}/games/{gameId}/actions")]
     [ApiController]
     public class GameActionsController(IMediator mediator) : BaseGameController(mediator)
     {
         /// <summary>
         /// Updates a game (makes a move)
         /// </summary>
-        /// <param name="alias">The player's alias</param>
+        /// <param name="profileId">The player's profile ID</param>
         /// <param name="gameId">The game id</param>
         /// <param name="move">The move to make</param>
         /// <returns>Success or failure result</returns>
@@ -20,9 +20,9 @@ namespace Sudoku.Api.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult> MakeMoveAsync(string alias, string gameId, [FromBody] MoveRequest move)
+        public async Task<ActionResult> MakeMoveAsync(string profileId, string gameId, [FromBody] MoveRequest move)
         {
-            var (_, error) = await GetAuthorizedGameAsync(alias, gameId);
+            var (_, error) = await GetAuthorizedGameAsync(profileId, gameId);
             if (error != null) return error;
 
             var result = await Mediator.Send(new MakeMoveCommand(gameId, move.Row, move.Column, move.Value, move.PlayDuration));
@@ -32,16 +32,16 @@ namespace Sudoku.Api.Controllers
         /// <summary>
         /// Resets a game to its initial state
         /// </summary>
-        /// <param name="alias">The player's alias</param>
+        /// <param name="profileId">The player's profile ID</param>
         /// <param name="gameId">The game id</param>
         /// <returns>No content if successful</returns>
         [HttpPost("reset")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult> ResetGameAsync(string alias, string gameId)
+        public async Task<ActionResult> ResetGameAsync(string profileId, string gameId)
         {
-            var (_, error) = await GetAuthorizedGameAsync(alias, gameId);
+            var (_, error) = await GetAuthorizedGameAsync(profileId, gameId);
             if (error != null) return error;
 
             var result = await Mediator.Send(new ResetGameCommand(gameId));
@@ -51,16 +51,16 @@ namespace Sudoku.Api.Controllers
         /// <summary>
         /// Undoes the last move in a game
         /// </summary>
-        /// <param name="alias">The player's alias</param>
+        /// <param name="profileId">The player's profile ID</param>
         /// <param name="gameId">The game id</param>
         /// <returns>No content if successful</returns>
         [HttpPost("undo")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult> UndoMoveAsync(string alias, string gameId)
+        public async Task<ActionResult> UndoMoveAsync(string profileId, string gameId)
         {
-            var (_, error) = await GetAuthorizedGameAsync(alias, gameId);
+            var (_, error) = await GetAuthorizedGameAsync(profileId, gameId);
             if (error != null) return error;
 
             var result = await Mediator.Send(new UndoLastMoveCommand(gameId));

--- a/src/backend/Sudoku.Api/Controllers/GameStatusController.cs
+++ b/src/backend/Sudoku.Api/Controllers/GameStatusController.cs
@@ -6,7 +6,7 @@ using Sudoku.Application.Queries;
 
 namespace Sudoku.Api.Controllers
 {
-    [Route("api/players/{alias}/games/{gameId}/status")]
+    [Route("api/players/{profileId}/games/{gameId}/status")]
     [ApiController]
     public class GameStatusController(IMediator mediator) : BaseGameController(mediator)
     {
@@ -17,9 +17,9 @@ namespace Sudoku.Api.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult> PauseGameAsync(string alias, string gameId)
+        public async Task<ActionResult> PauseGameAsync(string profileId, string gameId)
         {
-            var (_, error) = await GetAuthorizedGameAsync(alias, gameId);
+            var (_, error) = await GetAuthorizedGameAsync(profileId, gameId);
             if (error != null) return error;
 
             return HandleUnitResult(await Mediator.Send(new PauseGameCommand(gameId)));
@@ -32,9 +32,9 @@ namespace Sudoku.Api.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult> ResumeGameAsync(string alias, string gameId)
+        public async Task<ActionResult> ResumeGameAsync(string profileId, string gameId)
         {
-            var (_, error) = await GetAuthorizedGameAsync(alias, gameId);
+            var (_, error) = await GetAuthorizedGameAsync(profileId, gameId);
             if (error != null) return error;
 
             return HandleUnitResult(await Mediator.Send(new ResumeGameCommand(gameId)));
@@ -47,9 +47,9 @@ namespace Sudoku.Api.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult> AbandonGameAsync(string alias, string gameId)
+        public async Task<ActionResult> AbandonGameAsync(string profileId, string gameId)
         {
-            var (_, error) = await GetAuthorizedGameAsync(alias, gameId);
+            var (_, error) = await GetAuthorizedGameAsync(profileId, gameId);
             if (error != null) return error;
 
             return HandleUnitResult(await Mediator.Send(new AbandonGameCommand(gameId)));
@@ -62,9 +62,9 @@ namespace Sudoku.Api.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult> CompleteGameAsync(string alias, string gameId)
+        public async Task<ActionResult> CompleteGameAsync(string profileId, string gameId)
         {
-            var (_, error) = await GetAuthorizedGameAsync(alias, gameId);
+            var (_, error) = await GetAuthorizedGameAsync(profileId, gameId);
             if (error != null) return error;
 
             return HandleUnitResult(await Mediator.Send(new CompleteGameCommand(gameId)));
@@ -77,9 +77,9 @@ namespace Sudoku.Api.Controllers
         [ProducesResponseType(typeof(ValidationResultDto), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult<ValidationResultDto>> ValidateGameAsync(string alias, string gameId)
+        public async Task<ActionResult<ValidationResultDto>> ValidateGameAsync(string profileId, string gameId)
         {
-            var (_, error) = await GetAuthorizedGameAsync(alias, gameId);
+            var (_, error) = await GetAuthorizedGameAsync(profileId, gameId);
             if (error != null) return error;
 
             var result = await Mediator.Send(new ValidateGameQuery(gameId));

--- a/src/backend/Sudoku.Api/Controllers/GamesController.cs
+++ b/src/backend/Sudoku.Api/Controllers/GamesController.cs
@@ -7,68 +7,75 @@ using Sudoku.Application.Queries;
 
 namespace Sudoku.Api.Controllers;
 
-[Route("api/players/{alias}/games")]
+[Route("api/players/{profileId}/games")]
 [ApiController]
 public class GamesController(IMediator mediator) : BaseGameController(mediator)
 {
     /// <summary>
-    /// Creates a new game for the specified player with the given difficulty.
+    /// Creates a new game for the specified player profile with the given difficulty.
     /// </summary>
-    /// <param name="alias">The alias of the player</param>
+    /// <param name="profileId">The profile ID of the player</param>
     /// <param name="difficulty">The difficulty level of the game</param>
     /// <returns>Location of the created game</returns>
     [HttpPost("{difficulty}")]
     [ProducesResponseType(StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult> CreateGameAsync(string alias, string difficulty)
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> CreateGameAsync(string profileId, string difficulty)
     {
-        if (string.IsNullOrWhiteSpace(alias) || string.IsNullOrWhiteSpace(difficulty))
+        if (string.IsNullOrWhiteSpace(profileId) || string.IsNullOrWhiteSpace(difficulty))
         {
-            return BadRequest("Player alias and difficulty cannot be null or empty.");
+            return BadRequest("Profile ID and difficulty cannot be null or empty.");
         }
 
-        var result = await Mediator.Send(new CreateGameCommand(alias, difficulty));
+        var profileResult = await Mediator.Send(new GetProfileByIdQuery(profileId));
+        if (!profileResult.IsSuccess || profileResult.Value == null)
+        {
+            return NotFound($"Profile '{profileId}' not found.");
+        }
+
+        var result = await Mediator.Send(new CreateGameCommand(profileId, profileResult.Value.Alias, difficulty));
 
         if (!result.IsSuccess)
         {
             return BadRequest(result.Error);
         }
 
-        return Created($"/api/players/{alias}/games/{result.Value}", null);
+        return Created($"/api/players/{profileId}/games/{result.Value}", null);
     }
 
     /// <summary>
     /// Deletes all games for a player
     /// </summary>
-    /// <param name="alias">The player's alias</param>
+    /// <param name="profileId">The player's profile ID</param>
     /// <returns>No content if successful</returns>
     [HttpDelete]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult> DeleteAllGamesAsync(string alias)
+    public async Task<ActionResult> DeleteAllGamesAsync(string profileId)
     {
-        if (string.IsNullOrWhiteSpace(alias))
+        if (string.IsNullOrWhiteSpace(profileId))
         {
-            return BadRequest("Player alias cannot be null or empty.");
+            return BadRequest("Profile ID cannot be null or empty.");
         }
 
-        var result = await Mediator.Send(new DeletePlayerGamesCommand(alias));
+        var result = await Mediator.Send(new DeletePlayerGamesCommand(profileId));
         return HandleUnitResult(result);
     }
 
     /// <summary>
     /// Deletes a specific game for a player
     /// </summary>
-    /// <param name="alias">The player's alias</param>
+    /// <param name="profileId">The player's profile ID</param>
     /// <param name="gameId">The game id to delete</param>
     /// <returns>No content if successful</returns>
     [HttpDelete("{gameId}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult> DeleteGameAsync(string alias, string gameId)
+    public async Task<ActionResult> DeleteGameAsync(string profileId, string gameId)
     {
-        var (_, error) = await GetAuthorizedGameAsync(alias, gameId);
+        var (_, error) = await GetAuthorizedGameAsync(profileId, gameId);
         if (error != null) return error;
 
         var result = await Mediator.Send(new DeleteGameCommand(gameId));
@@ -78,20 +85,20 @@ public class GamesController(IMediator mediator) : BaseGameController(mediator)
     /// <summary>
     /// Gets all games for a specific player
     /// </summary>
-    /// <param name="alias">The player's alias</param>
+    /// <param name="profileId">The player's profile ID</param>
     /// <returns>A list of games for the player</returns>
     [HttpGet]
     [ProducesResponseType(typeof(List<GameDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<List<GameDto>>> GetAllGamesAsync(string alias)
+    public async Task<ActionResult<List<GameDto>>> GetAllGamesAsync(string profileId)
     {
-        if (string.IsNullOrWhiteSpace(alias))
+        if (string.IsNullOrWhiteSpace(profileId))
         {
-            return BadRequest("Player alias cannot be null or empty.");
+            return BadRequest("Profile ID cannot be null or empty.");
         }
 
-        var result = await Mediator.Send(new GetPlayerGamesQuery(alias));
+        var result = await Mediator.Send(new GetPlayerGamesQuery(profileId));
 
         if (!result.IsSuccess)
         {
@@ -104,16 +111,16 @@ public class GamesController(IMediator mediator) : BaseGameController(mediator)
     /// <summary>
     /// Gets a specific game by id for a player
     /// </summary>
-    /// <param name="alias">The player's alias</param>
+    /// <param name="profileId">The player's profile ID</param>
     /// <param name="gameId">The game id</param>
     /// <returns>The game if found</returns>
     [HttpGet("{gameId}")]
     [ProducesResponseType(typeof(GameDto), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<GameDto>> GetGameAsync(string alias, string gameId)
+    public async Task<ActionResult<GameDto>> GetGameAsync(string profileId, string gameId)
     {
-        var (game, error) = await GetAuthorizedGameAsync(alias, gameId);
+        var (game, error) = await GetAuthorizedGameAsync(profileId, gameId);
         if (error != null) return error;
 
         return Ok(game);

--- a/src/backend/Sudoku.Api/Controllers/PossibleValuesController.cs
+++ b/src/backend/Sudoku.Api/Controllers/PossibleValuesController.cs
@@ -5,7 +5,7 @@ using Sudoku.Application.Commands;
 
 namespace Sudoku.Api.Controllers
 {
-    [Route("api/players/{alias}/games/{gameId}/possible-values")]
+    [Route("api/players/{profileId}/games/{gameId}/possible-values")]
     [ApiController]
     public class PossibleValuesController(IMediator mediator) : BaseGameController(mediator)
     {
@@ -16,9 +16,9 @@ namespace Sudoku.Api.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult> AddPossibleValueAsync(string alias, string gameId, [FromBody] PossibleValueRequest request)
+        public async Task<ActionResult> AddPossibleValueAsync(string profileId, string gameId, [FromBody] PossibleValueRequest request)
         {
-            var (_, error) = await GetAuthorizedGameAsync(alias, gameId);
+            var (_, error) = await GetAuthorizedGameAsync(profileId, gameId);
             if (error != null) return error;
 
             var result = await Mediator.Send(new AddPossibleValueCommand(gameId, request.Row, request.Column, request.Value));
@@ -32,9 +32,9 @@ namespace Sudoku.Api.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult> ClearPossibleValuesAsync(string alias, string gameId, [FromBody] CellRequest request)
+        public async Task<ActionResult> ClearPossibleValuesAsync(string profileId, string gameId, [FromBody] CellRequest request)
         {
-            var (_, error) = await GetAuthorizedGameAsync(alias, gameId);
+            var (_, error) = await GetAuthorizedGameAsync(profileId, gameId);
             if (error != null) return error;
 
             var result = await Mediator.Send(new ClearPossibleValuesCommand(gameId, request.Row, request.Column));
@@ -48,9 +48,9 @@ namespace Sudoku.Api.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task<ActionResult> RemovePossibleValueAsync(string alias, string gameId, [FromBody] PossibleValueRequest request)
+        public async Task<ActionResult> RemovePossibleValueAsync(string profileId, string gameId, [FromBody] PossibleValueRequest request)
         {
-            var (_, error) = await GetAuthorizedGameAsync(alias, gameId);
+            var (_, error) = await GetAuthorizedGameAsync(profileId, gameId);
             if (error != null) return error;
 
             var result = await Mediator.Send(new RemovePossibleValueCommand(gameId, request.Row, request.Column, request.Value));

--- a/src/backend/Sudoku.Api/Sudoku.Api.csproj
+++ b/src/backend/Sudoku.Api/Sudoku.Api.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.Security.KeyVault" Version="13.2.4" />
-    <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.2.4" />
+    <PackageReference Include="Aspire.Azure.Security.KeyVault" Version="13.3.0" />
+    <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.3.0" />
     <PackageReference Include="MediatR" Version="14.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />

--- a/src/backend/Sudoku.AppHost/Sudoku.AppHost.csproj
+++ b/src/backend/Sudoku.AppHost/Sudoku.AppHost.csproj
@@ -12,11 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.2.4" />
-    <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" Version="13.2.4" />
-    <PackageReference Include="Aspire.Hosting.Azure.KeyVault" Version="13.2.4" />
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.2.4" />
-    <PackageReference Include="Aspire.Hosting.Azure.AppConfiguration" Version="13.2.4" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.3.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" Version="13.3.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.KeyVault" Version="13.3.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.3.0" />
+    <PackageReference Include="Aspire.Hosting.Azure.AppConfiguration" Version="13.3.0" />
     <PackageReference Include="Aspire.Hosting.NodeJs" Version="9.5.2" />
   </ItemGroup>
 

--- a/src/backend/Sudoku.AppHost/Sudoku.AppHost.csproj
+++ b/src/backend/Sudoku.AppHost/Sudoku.AppHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Sdk Name="Aspire.AppHost.Sdk" Version="13.1.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.2.4" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/backend/Sudoku.Application/Commands/CreateGameCommand.cs
+++ b/src/backend/Sudoku.Application/Commands/CreateGameCommand.cs
@@ -3,5 +3,6 @@ using Sudoku.Application.Common;
 namespace Sudoku.Application.Commands;
 
 public record CreateGameCommand(
-    string PlayerAlias,
+    string ProfileId,
+    string DisplayName,
     string Difficulty) : ICommand<string>;

--- a/src/backend/Sudoku.Application/Commands/DeletePlayerGamesCommand.cs
+++ b/src/backend/Sudoku.Application/Commands/DeletePlayerGamesCommand.cs
@@ -1,6 +1,5 @@
-using MediatR;
 using Sudoku.Application.Common;
 
 namespace Sudoku.Application.Commands;
 
-public record DeletePlayerGamesCommand(string PlayerAlias) : ICommand;
+public record DeletePlayerGamesCommand(string ProfileId) : ICommand;

--- a/src/backend/Sudoku.Application/DTOs/GameDto.cs
+++ b/src/backend/Sudoku.Application/DTOs/GameDto.cs
@@ -5,7 +5,8 @@ namespace Sudoku.Application.DTOs;
 
 public record GameDto(
     string Id,
-    string PlayerAlias,
+    string ProfileId,
+    string DisplayName,
     string Difficulty,
     string Status,
     GameStatisticsDto Statistics,
@@ -20,7 +21,8 @@ public record GameDto(
     {
         return new GameDto(
             game.Id.Value.ToString(),
-            game.PlayerAlias.Value,
+            game.ProfileId.ToString(),
+            game.DisplayName.Value,
             game.Difficulty.Name,
             game.Status.ToString(),
             GameStatisticsDto.FromGameStatistics(game.Statistics),

--- a/src/backend/Sudoku.Application/Handlers/CreateGameCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/CreateGameCommandHandler.cs
@@ -14,7 +14,8 @@ public class CreateGameCommandHandler(IGameRepository gameRepository, IPuzzleGen
     {
         try
         {
-            var playerAlias = PlayerAlias.Create(request.PlayerAlias);
+            var profileId = ProfileId.From(request.ProfileId);
+            var displayName = PlayerAlias.Create(request.DisplayName);
             var difficulty = GameDifficulty.FromName(request.Difficulty);
             var puzzle = await puzzleGenerator.GeneratePuzzleAsync(difficulty);
 
@@ -23,22 +24,22 @@ public class CreateGameCommandHandler(IGameRepository gameRepository, IPuzzleGen
                 return Result<string>.Failure($"No puzzle available for difficulty: {difficulty.Name}");
             }
 
-            var game = SudokuGame.Create(playerAlias, difficulty, puzzle.Cells);
+            var game = SudokuGame.Create(profileId, displayName, difficulty, puzzle.Cells);
 
             await gameRepository.SaveAsync(game);
 
-            logger.LogInformation("Created game {GameId} for player {PlayerAlias} with difficulty {Difficulty}",
-                game.Id.Value, playerAlias.Value, difficulty.Name);
+            logger.LogInformation("Created game {GameId} for profile {ProfileId} with difficulty {Difficulty}",
+                game.Id.Value, profileId.Value, difficulty.Name);
             return Result<string>.Success(game.Id.Value.ToString());
         }
         catch (DomainException ex)
         {
-            logger.LogWarning("Failed to create game for player {PlayerAlias}: {Error}", request.PlayerAlias, ex.Message);
+            logger.LogWarning("Failed to create game for profile {ProfileId}: {Error}", request.ProfileId, ex.Message);
             return Result<string>.Failure(ex.Message);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "An unexpected error occurred creating game for player {PlayerAlias}", request.PlayerAlias);
+            logger.LogError(ex, "An unexpected error occurred creating game for profile {ProfileId}", request.ProfileId);
             return Result<string>.Failure($"An unexpected error occurred: {ex.Message}");
         }
     }

--- a/src/backend/Sudoku.Application/Handlers/CreateProfileCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/CreateProfileCommandHandler.cs
@@ -16,8 +16,7 @@ public class CreateProfileCommandHandler(
     {
         try
         {
-            var normalizedAlias = request.Alias.Trim().ToLowerInvariant();
-            var playerAlias = PlayerAlias.Create(normalizedAlias);
+            var playerAlias = PlayerAlias.Create(request.Alias.Trim());
 
             if (await profileRepository.AliasExistsAsync(playerAlias))
             {

--- a/src/backend/Sudoku.Application/Handlers/DeletePlayerGamesCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/DeletePlayerGamesCommandHandler.cs
@@ -13,16 +13,16 @@ public class DeletePlayerGamesCommandHandler(IGameRepository gameRepository, ILo
     {
         try
         {
-            var playerAlias = PlayerAlias.Create(cmd.PlayerAlias);
-            
-            var games = await gameRepository.GetByPlayerAsync(playerAlias);
-            
+            var profileId = ProfileId.From(cmd.ProfileId);
+
+            var games = await gameRepository.GetByProfileIdAsync(profileId);
+
             foreach (var game in games)
             {
                 await gameRepository.DeleteAsync(game.Id);
             }
-            
-            logger.LogInformation("Deleted {Count} games for player {PlayerAlias}", games.Count(), playerAlias.Value);
+
+            logger.LogInformation("Deleted {Count} games for profile {ProfileId}", games.Count(), profileId.Value);
             return Result.Success();
         }
         catch (DomainException ex)

--- a/src/backend/Sudoku.Application/Handlers/GetPlayerGamesByStatusQueryHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/GetPlayerGamesByStatusQueryHandler.cs
@@ -16,29 +16,29 @@ public class GetPlayerGamesByStatusQueryHandler(IGameRepository gameRepository, 
     {
         try
         {
-            var playerAlias = PlayerAlias.Create(request.PlayerAlias);
+            var profileId = ProfileId.From(request.ProfileId);
 
             if (!Enum.TryParse<GameStatusEnum>(request.Status, true, out var gameStatus))
             {
                 return Result<List<GameDto>>.Failure($"Invalid game statusEnum: {request.Status}");
             }
 
-            var games = await gameRepository.GetByPlayerAndStatusAsync(playerAlias, gameStatus);
+            var games = await gameRepository.GetByProfileIdAndStatusAsync(profileId, gameStatus);
 
             var gameDtos = games.Select(GameDto.FromGame).ToList();
 
-            logger.LogInformation("Retrieved {Count} games with status {Status} for player {PlayerAlias}", 
-                gameDtos.Count, gameStatus, playerAlias.Value);
+            logger.LogInformation("Retrieved {Count} games with status {Status} for profile {ProfileId}",
+                gameDtos.Count, gameStatus, profileId.Value);
             return Result<List<GameDto>>.Success(gameDtos);
         }
         catch (DomainException ex)
         {
-            logger.LogWarning("Failed to get games by status for player {PlayerAlias}: {Error}", request.PlayerAlias, ex.Message);
+            logger.LogWarning("Failed to get games by status for profile {ProfileId}: {Error}", request.ProfileId, ex.Message);
             return Result<List<GameDto>>.Failure(ex.Message);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "An unexpected error occurred getting games by status for player {PlayerAlias}", request.PlayerAlias);
+            logger.LogError(ex, "An unexpected error occurred getting games by status for profile {ProfileId}", request.ProfileId);
             return Result<List<GameDto>>.Failure($"An unexpected error occurred: {ex.Message}");
         }
     }

--- a/src/backend/Sudoku.Application/Handlers/GetPlayerGamesQueryHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/GetPlayerGamesQueryHandler.cs
@@ -14,21 +14,21 @@ public class GetPlayerGamesQueryHandler(IGameRepository gameRepository, ILogger<
     {
         try
         {
-            var playerAlias = PlayerAlias.Create(request.PlayerAlias);
-            var games = await gameRepository.GetByPlayerAsync(playerAlias);
+            var profileId = ProfileId.From(request.ProfileId);
+            var games = await gameRepository.GetByProfileIdAsync(profileId);
             var gameDtos = games.Select(GameDto.FromGame).ToList();
 
-            logger.LogInformation("Retrieved {Count} games for player {PlayerAlias}", gameDtos.Count, playerAlias.Value);
+            logger.LogInformation("Retrieved {Count} games for profile {ProfileId}", gameDtos.Count, profileId.Value);
             return Result<List<GameDto>>.Success(gameDtos);
         }
         catch (DomainException ex)
         {
-            logger.LogWarning("Failed to get games for player {PlayerAlias}: {Error}", request.PlayerAlias, ex.Message);
+            logger.LogWarning("Failed to get games for profile {ProfileId}: {Error}", request.ProfileId, ex.Message);
             return Result<List<GameDto>>.Failure(ex.Message);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "An unexpected error occurred getting games for player {PlayerAlias}", request.PlayerAlias);
+            logger.LogError(ex, "An unexpected error occurred getting games for profile {ProfileId}", request.ProfileId);
             return Result<List<GameDto>>.Failure($"An unexpected error occurred: {ex.Message}");
         }
     }

--- a/src/backend/Sudoku.Application/Handlers/GetProfileByAliasQueryHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/GetProfileByAliasQueryHandler.cs
@@ -16,8 +16,7 @@ public class GetProfileByAliasQueryHandler(
     {
         try
         {
-            var normalizedAlias = request.Alias.Trim().ToLowerInvariant();
-            var playerAlias = PlayerAlias.Create(normalizedAlias);
+            var playerAlias = PlayerAlias.Create(request.Alias.Trim());
             var profile = await profileRepository.GetByAliasAsync(playerAlias);
 
             if (profile == null)

--- a/src/backend/Sudoku.Application/Handlers/GetProfileByIdQueryHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/GetProfileByIdQueryHandler.cs
@@ -1,0 +1,42 @@
+using Microsoft.Extensions.Logging;
+using Sudoku.Application.Common;
+using Sudoku.Application.DTOs;
+using Sudoku.Application.Interfaces;
+using Sudoku.Application.Queries;
+using Sudoku.Domain.ValueObjects;
+
+namespace Sudoku.Application.Handlers;
+
+public class GetProfileByIdQueryHandler(
+    IUserProfileRepository profileRepository,
+    ILogger<GetProfileByIdQueryHandler> logger) : IQueryHandler<GetProfileByIdQuery, ProfileDto?>
+{
+    public async Task<Result<ProfileDto?>> Handle(GetProfileByIdQuery request, CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(request.ProfileId, out var guid))
+        {
+            logger.LogWarning("Invalid ProfileId format: {ProfileId}", request.ProfileId);
+            return Result<ProfileDto?>.Failure($"Invalid ProfileId format: {request.ProfileId}");
+        }
+
+        try
+        {
+            var profileId = ProfileId.From(guid);
+            var profile = await profileRepository.GetByIdAsync(profileId);
+
+            if (profile == null)
+            {
+                logger.LogDebug("Profile not found for id {ProfileId}", request.ProfileId);
+                return Result<ProfileDto?>.Success(null);
+            }
+
+            logger.LogDebug("Retrieved profile {ProfileId}", request.ProfileId);
+            return Result<ProfileDto?>.Success(ProfileDto.FromProfile(profile));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Unexpected error getting profile for id {ProfileId}", request.ProfileId);
+            return Result<ProfileDto?>.Failure($"An unexpected error occurred: {ex.Message}");
+        }
+    }
+}

--- a/src/backend/Sudoku.Application/Handlers/UpdateProfileAliasCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/UpdateProfileAliasCommandHandler.cs
@@ -17,8 +17,7 @@ public class UpdateProfileAliasCommandHandler(
     {
         try
         {
-            var normalizedAlias = request.NewAlias.Trim().ToLowerInvariant();
-            var newAlias = PlayerAlias.Create(normalizedAlias);
+            var newAlias = PlayerAlias.Create(request.NewAlias.Trim());
 
             var profile = await profileRepository.GetByIdAsync(ProfileId.From(request.ProfileId));
             if (profile == null)

--- a/src/backend/Sudoku.Application/Interfaces/IGameRepository.cs
+++ b/src/backend/Sudoku.Application/Interfaces/IGameRepository.cs
@@ -9,8 +9,8 @@ public interface IGameRepository
 {
     // Basic CRUD operations
     Task<SudokuGame?> GetByIdAsync(GameId id);
-    Task<IEnumerable<SudokuGame>> GetByPlayerAsync(PlayerAlias playerAlias);
-    Task<IEnumerable<SudokuGame>> GetByPlayerAndStatusAsync(PlayerAlias playerAlias, GameStatusEnum statusEnum);
+    Task<IEnumerable<SudokuGame>> GetByProfileIdAsync(ProfileId profileId);
+    Task<IEnumerable<SudokuGame>> GetByProfileIdAndStatusAsync(ProfileId profileId, GameStatusEnum statusEnum);
     Task SaveAsync(SudokuGame game);
     Task DeleteAsync(GameId id);
     Task<bool> ExistsAsync(GameId id);
@@ -22,12 +22,12 @@ public interface IGameRepository
 
     // Additional query methods
     Task<IEnumerable<SudokuGame>> GetRecentGamesAsync(int count = 10);
-    Task<IEnumerable<SudokuGame>> GetCompletedGamesAsync(PlayerAlias? playerAlias = null);
+    Task<IEnumerable<SudokuGame>> GetCompletedGamesAsync(ProfileId? profileId = null);
     Task<IEnumerable<SudokuGame>> GetGamesByDifficultyAsync(GameDifficulty difficulty);
     Task<IEnumerable<SudokuGame>> GetGamesByStatusAsync(GameStatusEnum statusEnum);
 
     // Statistics and analytics
-    Task<int> GetTotalGamesCountAsync(PlayerAlias? playerAlias = null);
-    Task<int> GetCompletedGamesCountAsync(PlayerAlias? playerAlias = null);
-    Task<TimeSpan> GetAverageCompletionTimeAsync(PlayerAlias? playerAlias = null);
+    Task<int> GetTotalGamesCountAsync(ProfileId? profileId = null);
+    Task<int> GetCompletedGamesCountAsync(ProfileId? profileId = null);
+    Task<TimeSpan> GetAverageCompletionTimeAsync(ProfileId? profileId = null);
 }

--- a/src/backend/Sudoku.Application/Queries/GetPlayerGamesByStatusQuery.cs
+++ b/src/backend/Sudoku.Application/Queries/GetPlayerGamesByStatusQuery.cs
@@ -4,5 +4,5 @@ using Sudoku.Application.DTOs;
 namespace Sudoku.Application.Queries;
 
 public record GetPlayerGamesByStatusQuery(
-    string PlayerAlias,
+    string ProfileId,
     string Status) : IQuery<List<GameDto>>;

--- a/src/backend/Sudoku.Application/Queries/GetProfileByIdQuery.cs
+++ b/src/backend/Sudoku.Application/Queries/GetProfileByIdQuery.cs
@@ -3,4 +3,4 @@ using Sudoku.Application.DTOs;
 
 namespace Sudoku.Application.Queries;
 
-public record GetPlayerGamesQuery(string ProfileId) : IQuery<List<GameDto>>;
+public record GetProfileByIdQuery(string ProfileId) : IQuery<ProfileDto?>;

--- a/src/backend/Sudoku.Application/Specifications/GameSpecifications.cs
+++ b/src/backend/Sudoku.Application/Specifications/GameSpecifications.cs
@@ -4,20 +4,20 @@ using Sudoku.Domain.ValueObjects;
 
 namespace Sudoku.Application.Specifications;
 
-public class GameByPlayerSpecification : BaseSpecification<SudokuGame>
+public class GameByProfileIdSpecification : BaseSpecification<SudokuGame>
 {
-    public GameByPlayerSpecification(PlayerAlias playerAlias)
+    public GameByProfileIdSpecification(ProfileId profileId)
     {
-        AddCriteria(game => game.PlayerAlias == playerAlias);
+        AddCriteria(game => game.ProfileId == profileId);
         AddOrderByDescending(game => game.CreatedAt);
     }
 }
 
-public class GameByPlayerAndStatusSpecification : BaseSpecification<SudokuGame>
+public class GameByProfileIdAndStatusSpecification : BaseSpecification<SudokuGame>
 {
-    public GameByPlayerAndStatusSpecification(PlayerAlias playerAlias, GameStatusEnum statusEnum)
+    public GameByProfileIdAndStatusSpecification(ProfileId profileId, GameStatusEnum statusEnum)
     {
-        AddCriteria(game => game.PlayerAlias == playerAlias && game.Status == statusEnum);
+        AddCriteria(game => game.ProfileId == profileId && game.Status == statusEnum);
         AddOrderByDescending(game => game.CreatedAt);
     }
 }
@@ -40,11 +40,11 @@ public class GameByDifficultySpecification : BaseSpecification<SudokuGame>
     }
 }
 
-public class GameByPlayerAndDifficultySpecification : BaseSpecification<SudokuGame>
+public class GameByProfileIdAndDifficultySpecification : BaseSpecification<SudokuGame>
 {
-    public GameByPlayerAndDifficultySpecification(PlayerAlias playerAlias, GameDifficulty difficulty)
+    public GameByProfileIdAndDifficultySpecification(ProfileId profileId, GameDifficulty difficulty)
     {
-        AddCriteria(game => game.PlayerAlias == playerAlias && game.Difficulty == difficulty);
+        AddCriteria(game => game.ProfileId == profileId && game.Difficulty == difficulty);
         AddOrderByDescending(game => game.CreatedAt);
     }
 }
@@ -60,11 +60,11 @@ public class RecentGamesSpecification : BaseSpecification<SudokuGame>
 
 public class CompletedGamesSpecification : BaseSpecification<SudokuGame>
 {
-    public CompletedGamesSpecification(PlayerAlias? playerAlias = null)
+    public CompletedGamesSpecification(ProfileId? profileId = null)
     {
-        if (playerAlias != null)
+        if (profileId != null)
         {
-            AddCriteria(game => game.Status == GameStatusEnum.Completed && game.PlayerAlias == playerAlias);
+            AddCriteria(game => game.Status == GameStatusEnum.Completed && game.ProfileId == profileId);
         }
         else
         {

--- a/src/backend/Sudoku.Domain/Entities/SudokuGame.cs
+++ b/src/backend/Sudoku.Domain/Entities/SudokuGame.cs
@@ -6,7 +6,8 @@ public class SudokuGame : AggregateRoot
     private readonly List<MoveHistory> _moveHistory;
 
     public GameId Id { get; private set; }
-    public PlayerAlias PlayerAlias { get; private set; }
+    public ProfileId ProfileId { get; private set; }
+    public PlayerAlias DisplayName { get; private set; }
     public GameDifficulty Difficulty { get; private set; }
     public GameStatusEnum Status { get; private set; }
     public GameStatistics Statistics { get; private set; }
@@ -22,12 +23,13 @@ public class SudokuGame : AggregateRoot
         _moveHistory = [];
     }
 
-    public static SudokuGame Create(PlayerAlias playerAlias, GameDifficulty difficulty, IEnumerable<Cell> initialCells)
+    public static SudokuGame Create(ProfileId profileId, PlayerAlias displayName, GameDifficulty difficulty, IEnumerable<Cell> initialCells)
     {
         var game = new SudokuGame
         {
             Id = GameId.New(),
-            PlayerAlias = playerAlias,
+            ProfileId = profileId,
+            DisplayName = displayName,
             Difficulty = difficulty,
             Status = GameStatusEnum.NotStarted,
             Statistics = GameStatistics.Create(),
@@ -36,13 +38,14 @@ public class SudokuGame : AggregateRoot
 
         game._cells.AddRange(initialCells);
 
-        game.AddDomainEvent(new GameCreatedEvent(game.Id, playerAlias, difficulty));
+        game.AddDomainEvent(new GameCreatedEvent(game.Id, profileId, displayName, difficulty));
         return game;
     }
 
     public static SudokuGame Reconstitute(
         GameId id,
-        PlayerAlias playerAlias,
+        ProfileId profileId,
+        PlayerAlias displayName,
         GameDifficulty difficulty,
         GameStatusEnum statusEnum,
         GameStatistics statistics,
@@ -56,7 +59,8 @@ public class SudokuGame : AggregateRoot
         var game = new SudokuGame
         {
             Id = id,
-            PlayerAlias = playerAlias,
+            ProfileId = profileId,
+            DisplayName = displayName,
             Difficulty = difficulty,
             Status = statusEnum,
             Statistics = statistics,
@@ -237,7 +241,7 @@ public class SudokuGame : AggregateRoot
             var rowValues = _cells.Where(c => c.Row == row && c.HasValue)
                                  .Select(c => c.Value!.Value)
                                  .ToList();
-            
+
             if (rowValues.Count != rowValues.Distinct().Count())
             {
                 errors.Add($"Row {row + 1} contains duplicate values");
@@ -251,7 +255,7 @@ public class SudokuGame : AggregateRoot
             var columnValues = _cells.Where(c => c.Column == column && c.HasValue)
                                     .Select(c => c.Value!.Value)
                                     .ToList();
-            
+
             if (columnValues.Count != columnValues.Distinct().Count())
             {
                 errors.Add($"Column {column + 1} contains duplicate values");
@@ -269,7 +273,7 @@ public class SudokuGame : AggregateRoot
                                                  c.HasValue)
                                      .Select(c => c.Value!.Value)
                                      .ToList();
-                
+
                 if (boxValues.Count != boxValues.Distinct().Count())
                 {
                     errors.Add($"Box at position ({boxRow / 3 + 1}, {boxColumn / 3 + 1}) contains duplicate values");

--- a/src/backend/Sudoku.Domain/Events/GameEvents.cs
+++ b/src/backend/Sudoku.Domain/Events/GameEvents.cs
@@ -1,6 +1,6 @@
 namespace Sudoku.Domain.Events;
 
-public record GameCreatedEvent(GameId GameId, PlayerAlias PlayerAlias, GameDifficulty Difficulty) : DomainEvent;
+public record GameCreatedEvent(GameId GameId, ProfileId ProfileId, PlayerAlias DisplayName, GameDifficulty Difficulty) : DomainEvent;
 
 public record GameStartedEvent(GameId GameId) : DomainEvent;
 

--- a/src/backend/Sudoku.Infrastructure/EventHandling/GameCreatedEventHandler.cs
+++ b/src/backend/Sudoku.Infrastructure/EventHandling/GameCreatedEventHandler.cs
@@ -7,8 +7,8 @@ public class GameCreatedEventHandler(ILogger<GameCreatedEventHandler> logger) : 
 {
     public async Task HandleAsync(GameCreatedEvent domainEvent)
     {
-        logger.LogInformation("Game created: {GameId} for player {PlayerAlias} with difficulty {Difficulty}",
-            domainEvent.GameId.Value, domainEvent.PlayerAlias.Value, domainEvent.Difficulty);
+        logger.LogInformation("Game created: {GameId} for player {DisplayName} with difficulty {Difficulty}",
+            domainEvent.GameId.Value, domainEvent.DisplayName.Value, domainEvent.Difficulty);
 
         // Here you could:
         // - Send notifications

--- a/src/backend/Sudoku.Infrastructure/Mappers/SudokuGameMapper.cs
+++ b/src/backend/Sudoku.Infrastructure/Mappers/SudokuGameMapper.cs
@@ -12,7 +12,8 @@ public static class SudokuGameMapper
         {
             Id = game.Id.Value.ToString(),
             GameId = game.Id.Value.ToString(),
-            PlayerAlias = game.PlayerAlias.Value,
+            ProfileId = game.ProfileId.ToString(),
+            DisplayName = game.DisplayName.Value,
             Difficulty = game.Difficulty,
             Status = game.Status,
             Cells = game.GetCells().Select(ToDocument).ToList(),
@@ -36,9 +37,17 @@ public static class SudokuGameMapper
 
     public static SudokuGame ToDomain(SudokuGameDocument document)
     {
+        var profileIdStr = string.IsNullOrEmpty(document.ProfileId) ? Guid.Empty.ToString() : document.ProfileId;
+        var profileId = Guid.TryParse(profileIdStr, out var guid)
+            ? ProfileId.From(guid)
+            : ProfileId.From(Guid.Empty);
+
+        var displayName = PlayerAlias.Create(string.IsNullOrEmpty(document.DisplayName) ? "Unknown" : document.DisplayName);
+
         var sudokuGame = SudokuGame.Reconstitute(
             GameId.Create(document.GameId),
-            PlayerAlias.Create(document.PlayerAlias),
+            profileId,
+            displayName,
             document.Difficulty,
             document.Status,
             document.Statistics.ToDomain(),
@@ -69,12 +78,12 @@ public static class SudokuGameMapper
     private static Cell ToDomain(this CellDocument document)
     {
         var cell = Cell.Create(document.Row, document.Column, document.Value, document.IsFixed);
-        
+
         // Set possible values using reflection since there's no public setter
         var cellType = typeof(Cell);
         var possibleValuesField = cellType.GetField("<PossibleValues>k__BackingField", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         possibleValuesField?.SetValue(cell, document.PossibleValues);
-        
+
         return cell;
     }
 
@@ -94,25 +103,25 @@ public static class SudokuGameMapper
     private static GameStatistics ToDomain(this GameStatisticsDocument document)
     {
         var statistics = GameStatistics.Create();
-        
+
         // Use reflection to restore the statistics state
         var statsType = typeof(GameStatistics);
-        
+
         var totalMovesField = statsType.GetField("<TotalMoves>k__BackingField", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         totalMovesField?.SetValue(statistics, document.TotalMoves);
-        
+
         var validMovesField = statsType.GetField("<ValidMoves>k__BackingField", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         validMovesField?.SetValue(statistics, document.ValidMoves);
-        
+
         var invalidMovesField = statsType.GetField("<InvalidMoves>k__BackingField", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         invalidMovesField?.SetValue(statistics, document.InvalidMoves);
-        
+
         var playDurationField = statsType.GetField("<PlayDuration>k__BackingField", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         playDurationField?.SetValue(statistics, document.PlayDuration);
-        
+
         var lastMoveAtField = statsType.GetField("<LastMoveAt>k__BackingField", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         lastMoveAtField?.SetValue(statistics, document.LastMoveAt);
-        
+
         return statistics;
     }
 }

--- a/src/backend/Sudoku.Infrastructure/Models/SudokuGameDocument.cs
+++ b/src/backend/Sudoku.Infrastructure/Models/SudokuGameDocument.cs
@@ -12,33 +12,36 @@ public class SudokuGameDocument
     [JsonProperty("gameId")]
     public string GameId { get; set; } = string.Empty;
 
-    [JsonProperty("playerAlias")]
-    public string PlayerAlias { get; set; } = string.Empty;
+    [JsonProperty("profileId")]
+    public string? ProfileId { get; set; }
+
+    [JsonProperty("displayName")]
+    public string? DisplayName { get; set; }
 
     [JsonProperty("difficulty")]
     public GameDifficulty Difficulty { get; set; } = GameDifficulty.Easy;
 
     [JsonProperty("status")]
     public GameStatusEnum Status { get; set; }
-    
+
     [JsonProperty("cells")]
     public List<CellDocument> Cells { get; set; } = [];
-    
+
     [JsonProperty("statistics")]
     public GameStatisticsDocument Statistics { get; set; } = new();
-    
+
     [JsonProperty("moveHistory")]
     public List<MoveHistoryDocument> MoveHistory { get; set; } = [];
-    
+
     [JsonProperty("createdAt")]
     public DateTime CreatedAt { get; set; }
-    
+
     [JsonProperty("startedAt")]
     public DateTime? StartedAt { get; set; }
-    
+
     [JsonProperty("completedAt")]
     public DateTime? CompletedAt { get; set; }
-    
+
     [JsonProperty("pausedAt")]
     public DateTime? PausedAt { get; set; }
 }
@@ -47,16 +50,16 @@ public class CellDocument
 {
     [JsonProperty("row")]
     public int Row { get; set; }
-    
+
     [JsonProperty("column")]
     public int Column { get; set; }
-    
+
     [JsonProperty("value")]
     public int? Value { get; set; }
-    
+
     [JsonProperty("isFixed")]
     public bool IsFixed { get; set; }
-    
+
     [JsonProperty("possibleValues")]
     public HashSet<int> PossibleValues { get; set; } = [];
 }
@@ -65,16 +68,16 @@ public class GameStatisticsDocument
 {
     [JsonProperty("totalMoves")]
     public int TotalMoves { get; set; }
-    
+
     [JsonProperty("validMoves")]
     public int ValidMoves { get; set; }
-    
+
     [JsonProperty("invalidMoves")]
     public int InvalidMoves { get; set; }
-    
+
     [JsonProperty("playDuration")]
     public TimeSpan PlayDuration { get; set; }
-    
+
     [JsonProperty("lastMoveAt")]
     public DateTime? LastMoveAt { get; set; }
 }
@@ -83,13 +86,13 @@ public class MoveHistoryDocument
 {
     [JsonProperty("row")]
     public int Row { get; set; }
-    
+
     [JsonProperty("column")]
     public int Column { get; set; }
-    
+
     [JsonProperty("previousValue")]
     public int? PreviousValue { get; set; }
-    
+
     [JsonProperty("newValue")]
     public int? NewValue { get; set; }
 }

--- a/src/backend/Sudoku.Infrastructure/Repositories/AzureBlobGameRepository.cs
+++ b/src/backend/Sudoku.Infrastructure/Repositories/AzureBlobGameRepository.cs
@@ -17,24 +17,24 @@ public class AzureBlobGameRepository(IAzureStorageService storageService, ILogge
     {
         try
         {
-            // We need to find the game by ID, but we don't know the player alias yet
+            // We need to find the game by ID, but we don't know the profile ID yet
             // so we need to search through all blobs to find it
             var gamePrefix = $"*/{id.Value}/";
             SudokuGame? game = null;
-            
+
             await foreach (var blobName in storageService.GetBlobNamesAsync(ContainerName, gamePrefix))
             {
-                // The blobName will be in the format "{playerAlias}/{gameId}/{revisionId}.json"
+                // The blobName will be in the format "{profileId}/{gameId}/{revisionId}.json"
                 // We need to get the latest revision
                 var parts = blobName.Split('/');
                 if (parts.Length < 3) continue;
-                
-                var playerAlias = parts[0];
+
+                var profileId = parts[0];
                 var gameId = parts[1];
-                
+
                 if (gameId == id.Value.ToString())
                 {
-                    var latestBlobName = await GetLatestRevisionAsync(playerAlias, id);
+                    var latestBlobName = await GetLatestRevisionAsync(profileId, id);
                     if (latestBlobName != null)
                     {
                         game = await storageService.LoadAsync<SudokuGame>(ContainerName, latestBlobName);
@@ -59,12 +59,12 @@ public class AzureBlobGameRepository(IAzureStorageService storageService, ILogge
         }
     }
 
-    public async Task<IEnumerable<SudokuGame>> GetByPlayerAsync(PlayerAlias playerAlias)
+    public async Task<IEnumerable<SudokuGame>> GetByProfileIdAsync(ProfileId profileId)
     {
         try
         {
             var games = new List<SudokuGame>();
-            var prefix = $"{playerAlias.Value}/";
+            var prefix = $"{profileId}/";
             var gameIdSet = new HashSet<string>();
 
             await foreach (var blobName in storageService.GetBlobNamesAsync(ContainerName, prefix))
@@ -74,11 +74,11 @@ public class AzureBlobGameRepository(IAzureStorageService storageService, ILogge
                 if (parts.Length < 3) continue;
 
                 var gameId = parts[1];
-                
+
                 // Only process each game ID once
                 if (gameIdSet.Add(gameId))
                 {
-                    var latestBlobName = await GetLatestRevisionAsync(playerAlias.Value, GameId.Create(gameId));
+                    var latestBlobName = await GetLatestRevisionAsync(profileId.ToString(), GameId.Create(gameId));
                     if (latestBlobName != null)
                     {
                         var game = await storageService.LoadAsync<SudokuGame>(ContainerName, latestBlobName);
@@ -90,19 +90,19 @@ public class AzureBlobGameRepository(IAzureStorageService storageService, ILogge
                 }
             }
 
-            logger.LogDebug("Retrieved {Count} games for player {PlayerAlias}", games.Count, playerAlias.Value);
+            logger.LogDebug("Retrieved {Count} games for profile {ProfileId}", games.Count, profileId);
             return games.OrderByDescending(g => g.CreatedAt);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error retrieving games for player {PlayerAlias}", playerAlias.Value);
+            logger.LogError(ex, "Error retrieving games for profile {ProfileId}", profileId);
             throw;
         }
     }
 
-    public async Task<IEnumerable<SudokuGame>> GetByPlayerAndStatusAsync(PlayerAlias playerAlias, GameStatusEnum statusEnum)
+    public async Task<IEnumerable<SudokuGame>> GetByProfileIdAndStatusAsync(ProfileId profileId, GameStatusEnum statusEnum)
     {
-        var specification = new GameByPlayerAndStatusSpecification(playerAlias, statusEnum);
+        var specification = new GameByProfileIdAndStatusSpecification(profileId, statusEnum);
         return await GetBySpecificationAsync(specification);
     }
 
@@ -114,7 +114,7 @@ public class AzureBlobGameRepository(IAzureStorageService storageService, ILogge
 
             try
             {
-                var nextBlobName = await GetNextRevisionBlobNameAsync(game.PlayerAlias.Value, game.Id);
+                var nextBlobName = await GetNextRevisionBlobNameAsync(game.ProfileId.ToString(), game.Id);
                 await storageService.SaveAsync(ContainerName, nextBlobName, game);
 
                 logger.LogDebug("Saved game {GameId} to Azure Blob Storage at {BlobName}", game.Id.Value, nextBlobName);
@@ -137,13 +137,13 @@ public class AzureBlobGameRepository(IAzureStorageService storageService, ILogge
         {
             // Find all revisions for this game
             var gamePrefix = $"*/{id.Value}/";
-            
+
             await foreach (var blobName in storageService.GetBlobNamesAsync(ContainerName, gamePrefix))
             {
                 await storageService.DeleteAsync(ContainerName, blobName);
                 logger.LogDebug("Deleted game revision {BlobName} from Azure Blob Storage", blobName);
             }
-            
+
             logger.LogDebug("Deleted all revisions of game {GameId} from Azure Blob Storage", id.Value);
         }
         catch (Exception ex)
@@ -159,12 +159,12 @@ public class AzureBlobGameRepository(IAzureStorageService storageService, ILogge
         {
             // Check if any blob exists with this game ID
             var gamePrefix = $"*/{id.Value}/";
-            
+
             await foreach (var blobName in storageService.GetBlobNamesAsync(ContainerName, gamePrefix))
             {
                 return true;
             }
-            
+
             return false;
         }
         catch (Exception ex)
@@ -247,9 +247,9 @@ public class AzureBlobGameRepository(IAzureStorageService storageService, ILogge
         return await GetBySpecificationAsync(specification);
     }
 
-    public async Task<IEnumerable<SudokuGame>> GetCompletedGamesAsync(PlayerAlias? playerAlias = null)
+    public async Task<IEnumerable<SudokuGame>> GetCompletedGamesAsync(ProfileId? profileId = null)
     {
-        var specification = new CompletedGamesSpecification(playerAlias);
+        var specification = new CompletedGamesSpecification(profileId);
         return await GetBySpecificationAsync(specification);
     }
 
@@ -265,38 +265,38 @@ public class AzureBlobGameRepository(IAzureStorageService storageService, ILogge
         return await GetBySpecificationAsync(specification);
     }
 
-    public async Task<int> GetTotalGamesCountAsync(PlayerAlias? playerAlias = null)
+    public async Task<int> GetTotalGamesCountAsync(ProfileId? profileId = null)
     {
         try
         {
             var allGames = await GetAllGamesAsync();
             var query = allGames.AsQueryable();
 
-            if (playerAlias != null)
+            if (profileId != null)
             {
-                query = query.Where(g => g.PlayerAlias == playerAlias);
+                query = query.Where(g => g.ProfileId == profileId);
             }
 
             return query.Count();
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error getting total games count for player {PlayerAlias}", playerAlias?.Value);
+            logger.LogError(ex, "Error getting total games count for profile {ProfileId}", profileId);
             throw;
         }
     }
 
-    public async Task<int> GetCompletedGamesCountAsync(PlayerAlias? playerAlias = null)
+    public async Task<int> GetCompletedGamesCountAsync(ProfileId? profileId = null)
     {
-        var specification = new CompletedGamesSpecification(playerAlias);
+        var specification = new CompletedGamesSpecification(profileId);
         return await CountBySpecificationAsync(specification);
     }
 
-    public async Task<TimeSpan> GetAverageCompletionTimeAsync(PlayerAlias? playerAlias = null)
+    public async Task<TimeSpan> GetAverageCompletionTimeAsync(ProfileId? profileId = null)
     {
         try
         {
-            var completedGames = await GetCompletedGamesAsync(playerAlias);
+            var completedGames = await GetCompletedGamesAsync(profileId);
             var gamesWithCompletionTime = completedGames
                 .Where(g => g.CompletedAt.HasValue && g.StartedAt.HasValue)
                 .ToList();
@@ -313,7 +313,7 @@ public class AzureBlobGameRepository(IAzureStorageService storageService, ILogge
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error calculating average completion time for player {PlayerAlias}", playerAlias?.Value);
+            logger.LogError(ex, "Error calculating average completion time for profile {ProfileId}", profileId);
             throw;
         }
     }
@@ -328,14 +328,14 @@ public class AzureBlobGameRepository(IAzureStorageService storageService, ILogge
             var parts = blobName.Split('/');
             if (parts.Length < 3) continue;
 
-            var playerAlias = parts[0];
+            var profileId = parts[0];
             var gameId = parts[1];
-            
+
             // Only process each game ID once to get the latest revision
             var gameIdString = gameId.ToString();
             if (processedGameIds.Add(gameIdString))
             {
-                var latestBlobName = await GetLatestRevisionAsync(playerAlias, GameId.Create(gameId));
+                var latestBlobName = await GetLatestRevisionAsync(profileId, GameId.Create(gameId));
                 if (latestBlobName != null)
                 {
                     var game = await storageService.LoadAsync<SudokuGame>(ContainerName, latestBlobName);
@@ -350,23 +350,23 @@ public class AzureBlobGameRepository(IAzureStorageService storageService, ILogge
         return games;
     }
 
-    private async Task<string?> GetLatestRevisionAsync(string playerAlias, GameId gameId)
+    private async Task<string?> GetLatestRevisionAsync(string profileId, GameId gameId)
     {
-        var prefix = $"{playerAlias}/{gameId.Value}/";
+        var prefix = $"{profileId}/{gameId.Value}/";
         var revisions = new List<string>();
-        
+
         await foreach (var blobName in storageService.GetBlobNamesAsync(ContainerName, prefix))
         {
             revisions.Add(blobName);
         }
-        
+
         if (revisions.Count == 0)
         {
             return null;
         }
-        
+
         // Sort by revision number (last part of the path, excluding .json)
-        return revisions.OrderByDescending(r => 
+        return revisions.OrderByDescending(r =>
         {
             var parts = r.Split('/');
             var fileName = parts[^1];
@@ -374,12 +374,12 @@ public class AzureBlobGameRepository(IAzureStorageService storageService, ILogge
             return int.Parse(revNumber);
         }).First();
     }
-    
-    private async Task<string> GetNextRevisionBlobNameAsync(string playerAlias, GameId gameId)
+
+    private async Task<string> GetNextRevisionBlobNameAsync(string profileId, GameId gameId)
     {
-        var prefix = $"{playerAlias}/{gameId.Value}/";
+        var prefix = $"{profileId}/{gameId.Value}/";
         var revisions = new List<int>();
-        
+
         await foreach (var blobName in storageService.GetBlobNamesAsync(ContainerName, prefix))
         {
             var parts = blobName.Split('/');
@@ -390,9 +390,9 @@ public class AzureBlobGameRepository(IAzureStorageService storageService, ILogge
                 revisions.Add(revNumber);
             }
         }
-        
+
         var nextRevision = revisions.Count > 0 ? revisions.Max() + 1 : 1;
-        return $"{playerAlias}/{gameId.Value}/{nextRevision:D5}.json";
+        return $"{profileId}/{gameId.Value}/{nextRevision:D5}.json";
     }
 
     public void Dispose()

--- a/src/backend/Sudoku.Infrastructure/Repositories/CosmosDbGameRepository.cs
+++ b/src/backend/Sudoku.Infrastructure/Repositories/CosmosDbGameRepository.cs
@@ -34,51 +34,51 @@ public class CosmosDbGameRepository(ICosmosDbService cosmosDbService, ILogger<Co
         }
     }
 
-    public async Task<IEnumerable<SudokuGame>> GetByPlayerAsync(PlayerAlias playerAlias)
+    public async Task<IEnumerable<SudokuGame>> GetByProfileIdAsync(ProfileId profileId)
     {
         try
         {
-            var sqlQuery = "SELECT * FROM c WHERE c.playerAlias = @playerAlias ORDER BY c.createdAt DESC";
+            var sqlQuery = "SELECT * FROM c WHERE c.profileId = @profileId ORDER BY c.createdAt DESC";
             var queryParams = new Dictionary<string, string>
             {
-                { "@playerAlias", playerAlias.Value }
+                { "@profileId", profileId.Value.ToString() }
             };
 
             var documents = await cosmosDbService.QueryItemsAsync<Models.SudokuGameDocument>(sqlQuery, queryParams);
             var games = documents.Select(SudokuGameMapper.ToDomain).ToList();
 
-            logger.LogDebug("Retrieved {Count} games for player {PlayerAlias} from CosmosDB", games.Count, playerAlias.Value);
+            logger.LogDebug("Retrieved {Count} games for profile {ProfileId} from CosmosDB", games.Count, profileId.Value);
             return games;
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error retrieving games for player {PlayerAlias} from CosmosDB", playerAlias.Value);
+            logger.LogError(ex, "Error retrieving games for profile {ProfileId} from CosmosDB", profileId.Value);
             throw;
         }
     }
 
-    public async Task<IEnumerable<SudokuGame>> GetByPlayerAndStatusAsync(PlayerAlias playerAlias, GameStatusEnum statusEnum)
+    public async Task<IEnumerable<SudokuGame>> GetByProfileIdAndStatusAsync(ProfileId profileId, GameStatusEnum statusEnum)
     {
         try
         {
-            var sqlQuery = "SELECT * FROM c WHERE c.playerAlias = @playerAlias AND c.statusEnum = @statusEnum ORDER BY c.createdAt DESC";
+            var sqlQuery = "SELECT * FROM c WHERE c.profileId = @profileId AND c.status = @status ORDER BY c.createdAt DESC";
             var queryParams = new Dictionary<string, string>
             {
-                { "@playerAlias", playerAlias.Value },
-                { "@statusEnum", statusEnum.ToString() }
+                { "@profileId", profileId.Value.ToString() },
+                { "@status", statusEnum.ToString() }
             };
 
             var documents = await cosmosDbService.QueryItemsAsync<Models.SudokuGameDocument>(sqlQuery, queryParams);
             var games = documents.Select(SudokuGameMapper.ToDomain).ToList();
 
-            logger.LogDebug("Retrieved {Count} games for player {PlayerAlias} with statusEnum {StatusEnum} from CosmosDB", 
-                games.Count, playerAlias.Value, statusEnum);
+            logger.LogDebug("Retrieved {Count} games for profile {ProfileId} with status {Status} from CosmosDB",
+                games.Count, profileId.Value, statusEnum);
             return games;
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error retrieving games for player {PlayerAlias} with statusEnum {StatusEnum} from CosmosDB", 
-                playerAlias.Value, statusEnum);
+            logger.LogError(ex, "Error retrieving games for profile {ProfileId} with status {Status} from CosmosDB",
+                profileId.Value, statusEnum);
             throw;
         }
     }
@@ -88,9 +88,9 @@ public class CosmosDbGameRepository(ICosmosDbService cosmosDbService, ILogger<Co
         try
         {
             var document = SudokuGameMapper.ToDocument(game);
-            
+
             await cosmosDbService.UpsertItemAsync(document, game.Id);
-            
+
             logger.LogDebug("Saved game {GameId} to CosmosDB", game.Id.Value);
         }
         catch (Exception ex)
@@ -105,7 +105,7 @@ public class CosmosDbGameRepository(ICosmosDbService cosmosDbService, ILogger<Co
         try
         {
             await cosmosDbService.DeleteItemAsync<Models.SudokuGameDocument>(id.Value.ToString(), id);
-            
+
             logger.LogDebug("Deleted game {GameId} from CosmosDB", id.Value);
         }
         catch (Exception ex)
@@ -120,7 +120,7 @@ public class CosmosDbGameRepository(ICosmosDbService cosmosDbService, ILogger<Co
         try
         {
             var exists = await cosmosDbService.ExistsAsync<Models.SudokuGameDocument>(id.Value.ToString(), id);
-            
+
             logger.LogDebug("Game {GameId} exists in CosmosDB: {Exists}", id.Value, exists);
             return exists;
         }
@@ -218,28 +218,28 @@ public class CosmosDbGameRepository(ICosmosDbService cosmosDbService, ILogger<Co
         }
     }
 
-    public async Task<IEnumerable<SudokuGame>> GetCompletedGamesAsync(PlayerAlias? playerAlias = null)
+    public async Task<IEnumerable<SudokuGame>> GetCompletedGamesAsync(ProfileId? profileId = null)
     {
         try
         {
             string sqlQuery;
             Dictionary<string, string> queryParams;
 
-            if (playerAlias != null)
+            if (profileId != null)
             {
-                sqlQuery = "SELECT * FROM c WHERE c.statusEnum = @statusEnum AND c.playerAlias = @playerAlias ORDER BY c.completedAt DESC";
+                sqlQuery = "SELECT * FROM c WHERE c.status = @status AND c.profileId = @profileId ORDER BY c.completedAt DESC";
                 queryParams = new Dictionary<string, string>
                 {
-                    { "@statusEnum", GameStatusEnum.Completed.ToString() },
-                    { "@playerAlias", playerAlias.Value }
+                    { "@status", GameStatusEnum.Completed.ToString() },
+                    { "@profileId", profileId.Value.ToString() }
                 };
             }
             else
             {
-                sqlQuery = "SELECT * FROM c WHERE c.statusEnum = @statusEnum ORDER BY c.completedAt DESC";
+                sqlQuery = "SELECT * FROM c WHERE c.status = @status ORDER BY c.completedAt DESC";
                 queryParams = new Dictionary<string, string>
                 {
-                    { "@statusEnum", GameStatusEnum.Completed.ToString() }
+                    { "@status", GameStatusEnum.Completed.ToString() }
                 };
             }
 
@@ -283,38 +283,38 @@ public class CosmosDbGameRepository(ICosmosDbService cosmosDbService, ILogger<Co
     {
         try
         {
-            var sqlQuery = "SELECT * FROM c WHERE c.statusEnum = @statusEnum ORDER BY c.createdAt DESC";
+            var sqlQuery = "SELECT * FROM c WHERE c.status = @status ORDER BY c.createdAt DESC";
             var queryParams = new Dictionary<string, string>
             {
-                { "@statusEnum", statusEnum.ToString() }
+                { "@status", statusEnum.ToString() }
             };
 
             var documents = await cosmosDbService.QueryItemsAsync<Models.SudokuGameDocument>(sqlQuery, queryParams);
             var games = documents.Select(SudokuGameMapper.ToDomain).ToList();
 
-            logger.LogDebug("Retrieved {Count} games with statusEnum {StatusEnum} from CosmosDB", games.Count, statusEnum);
+            logger.LogDebug("Retrieved {Count} games with status {Status} from CosmosDB", games.Count, statusEnum);
             return games;
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error retrieving games by statusEnum {StatusEnum} from CosmosDB", statusEnum);
+            logger.LogError(ex, "Error retrieving games by status {Status} from CosmosDB", statusEnum);
             throw;
         }
     }
 
-    public async Task<int> GetTotalGamesCountAsync(PlayerAlias? playerAlias = null)
+    public async Task<int> GetTotalGamesCountAsync(ProfileId? profileId = null)
     {
         try
         {
             string sqlQuery;
             Dictionary<string, string> queryParams = new();
 
-            if (playerAlias != null)
+            if (profileId != null)
             {
-                sqlQuery = "SELECT VALUE COUNT(1) FROM c WHERE c.playerAlias = @playerAlias";
+                sqlQuery = "SELECT VALUE COUNT(1) FROM c WHERE c.profileId = @profileId";
                 queryParams = new Dictionary<string, string>
                 {
-                    { "@playerAlias", playerAlias.Value }
+                    { "@profileId", profileId.Value.ToString() }
                 };
             }
             else
@@ -335,28 +335,28 @@ public class CosmosDbGameRepository(ICosmosDbService cosmosDbService, ILogger<Co
         }
     }
 
-    public async Task<int> GetCompletedGamesCountAsync(PlayerAlias? playerAlias = null)
+    public async Task<int> GetCompletedGamesCountAsync(ProfileId? profileId = null)
     {
         try
         {
             string sqlQuery;
             Dictionary<string, string> queryParams;
 
-            if (playerAlias != null)
+            if (profileId != null)
             {
-                sqlQuery = "SELECT VALUE COUNT(1) FROM c WHERE c.statusEnum = @statusEnum AND c.playerAlias = @playerAlias";
+                sqlQuery = "SELECT VALUE COUNT(1) FROM c WHERE c.status = @status AND c.profileId = @profileId";
                 queryParams = new Dictionary<string, string>
                 {
-                    { "@statusEnum", GameStatusEnum.Completed.ToString() },
-                    { "@playerAlias", playerAlias.Value }
+                    { "@status", GameStatusEnum.Completed.ToString() },
+                    { "@profileId", profileId.Value.ToString() }
                 };
             }
             else
             {
-                sqlQuery = "SELECT VALUE COUNT(1) FROM c WHERE c.statusEnum = @statusEnum";
+                sqlQuery = "SELECT VALUE COUNT(1) FROM c WHERE c.status = @status";
                 queryParams = new Dictionary<string, string>()
                 {
-                    { "@statusEnum", GameStatusEnum.Completed.ToString() }
+                    { "@status", GameStatusEnum.Completed.ToString() }
                 };
             }
 
@@ -373,11 +373,11 @@ public class CosmosDbGameRepository(ICosmosDbService cosmosDbService, ILogger<Co
         }
     }
 
-    public async Task<TimeSpan> GetAverageCompletionTimeAsync(PlayerAlias? playerAlias = null)
+    public async Task<TimeSpan> GetAverageCompletionTimeAsync(ProfileId? profileId = null)
     {
         try
         {
-            var completedGames = await GetCompletedGamesAsync(playerAlias);
+            var completedGames = await GetCompletedGamesAsync(profileId);
             var gamesWithCompletionTime = completedGames
                 .Where(g => g.CompletedAt.HasValue && g.StartedAt.HasValue)
                 .ToList();
@@ -390,7 +390,7 @@ public class CosmosDbGameRepository(ICosmosDbService cosmosDbService, ILogger<Co
             var totalTime = gamesWithCompletionTime.Sum(g =>
                 (g.CompletedAt!.Value - g.StartedAt!.Value).TotalMilliseconds);
             var averageMilliseconds = totalTime / gamesWithCompletionTime.Count;
-            
+
             var averageTime = TimeSpan.FromMilliseconds(averageMilliseconds);
             logger.LogDebug("Average completion time: {AverageTime}", averageTime);
             return averageTime;

--- a/src/backend/Sudoku.Infrastructure/Sudoku.Infrastructure.csproj
+++ b/src/backend/Sudoku.Infrastructure/Sudoku.Infrastructure.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.2.4" />
+    <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.3.0" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />

--- a/src/backend/Sudoku.McpServer/Sudoku.McpServer.csproj
+++ b/src/backend/Sudoku.McpServer/Sudoku.McpServer.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Monitor.Query" Version="1.7.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/backend/Tests/API/BaseGameControllerTests.cs
+++ b/src/backend/Tests/API/BaseGameControllerTests.cs
@@ -15,11 +15,12 @@ public abstract class BaseGameControllerTests<TControllerType> : MoqBaseTestByTy
         Sut = ResolveSut();
     }
 
-    protected static GameDto CreateTestGameDto(string playerAlias, string difficulty, string? gameId = null)
+    protected static GameDto CreateTestGameDto(string profileId, string difficulty, string? gameId = null)
     {
         return new GameDto(
             gameId ?? Guid.NewGuid().ToString(),
-            playerAlias,
+            profileId,
+            "TestPlayer",
             difficulty,
             "NotStarted",
             new GameStatisticsDto(0, 0, 0, TimeSpan.Zero, 0.0),

--- a/src/backend/Tests/API/GamesControllerTests.cs
+++ b/src/backend/Tests/API/GamesControllerTests.cs
@@ -13,13 +13,13 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     #region GetAllGamesAsync Tests
 
     [Fact]
-    public async Task GetAllGamesAsync_WithValidAlias_ReturnsOkWithGames()
+    public async Task GetAllGamesAsync_WithValidProfileId_ReturnsOkWithGames()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
+        var profileId = Guid.NewGuid().ToString();
         var games = new List<GameDto>
         {
-            CreateTestGameDto(playerAlias, "Medium")
+            CreateTestGameDto(profileId, "Medium")
         };
 
         MockMediator
@@ -27,7 +27,7 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
             .ReturnsAsync(Result<List<GameDto>>.Success(games));
 
         // Act
-        var result = await Sut.GetAllGamesAsync(playerAlias);
+        var result = await Sut.GetAllGamesAsync(profileId);
 
         // Assert
         var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
@@ -36,7 +36,27 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     }
 
     [Fact]
-    public async Task GetAllGamesAsync_WithEmptyAlias_ReturnsBadRequest()
+    public async Task GetAllGamesAsync_WithValidProfileId_CallsGetPlayerGamesQuery()
+    {
+        // Arrange
+        var profileId = Guid.NewGuid().ToString();
+        var games = new List<GameDto>();
+
+        MockMediator
+            .Setup(x => x.Send(It.IsAny<GetPlayerGamesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<List<GameDto>>.Success(games));
+
+        // Act
+        await Sut.GetAllGamesAsync(profileId);
+
+        // Assert
+        MockMediator.Verify(x => x.Send(
+            It.Is<GetPlayerGamesQuery>(q => q.ProfileId == profileId),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAllGamesAsync_WithEmptyProfileId_ReturnsBadRequest()
     {
         // Act
         var result = await Sut.GetAllGamesAsync(string.Empty);
@@ -49,7 +69,7 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     public async Task GetAllGamesAsync_WhenServiceReturnsFailed_ReturnsBadRequest()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
+        var profileId = Guid.NewGuid().ToString();
         var errorMessage = "Failed to get games";
 
         MockMediator
@@ -57,7 +77,7 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
             .ReturnsAsync(Result<List<GameDto>>.Failure(errorMessage));
 
         // Act
-        var result = await Sut.GetAllGamesAsync(playerAlias);
+        var result = await Sut.GetAllGamesAsync(profileId);
 
         // Assert
         var badRequestResult = result.Result.Should().BeOfType<BadRequestObjectResult>().Subject;
@@ -72,16 +92,16 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     public async Task GetGameAsync_WithValidParameters_ReturnsOkWithGame()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
+        var profileId = Guid.NewGuid().ToString();
         var gameId = Guid.NewGuid().ToString();
-        var game = CreateTestGameDto(playerAlias, "Medium", gameId);
+        var game = CreateTestGameDto(profileId, "Medium", gameId);
 
         MockMediator
             .Setup(x => x.Send(It.IsAny<GetGameQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<GameDto>.Success(game));
 
         // Act
-        var result = await Sut.GetGameAsync(playerAlias, gameId);
+        var result = await Sut.GetGameAsync(profileId, gameId);
 
         // Assert
         var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
@@ -90,7 +110,7 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     }
 
     [Fact]
-    public async Task GetGameAsync_WithEmptyAlias_ReturnsBadRequest()
+    public async Task GetGameAsync_WithEmptyProfileId_ReturnsBadRequest()
     {
         // Act
         var result = await Sut.GetGameAsync(string.Empty, Guid.NewGuid().ToString());
@@ -103,7 +123,7 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     public async Task GetGameAsync_WithEmptyGameId_ReturnsBadRequest()
     {
         // Act
-        var result = await Sut.GetGameAsync("TestPlayer", string.Empty);
+        var result = await Sut.GetGameAsync(Guid.NewGuid().ToString(), string.Empty);
 
         // Assert
         result.Result.Should().BeOfType<BadRequestObjectResult>();
@@ -113,7 +133,7 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     public async Task GetGameAsync_WhenGameNotFound_ReturnsNotFound()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
+        var profileId = Guid.NewGuid().ToString();
         var gameId = Guid.NewGuid().ToString();
         var errorMessage = "Game not found with ID: " + gameId;
 
@@ -122,7 +142,7 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
             .ReturnsAsync(Result<GameDto>.Failure(errorMessage));
 
         // Act
-        var result = await Sut.GetGameAsync(playerAlias, gameId);
+        var result = await Sut.GetGameAsync(profileId, gameId);
 
         // Assert
         var notFoundResult = result.Result.Should().BeOfType<NotFoundObjectResult>().Subject;
@@ -130,19 +150,19 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     }
 
     [Fact]
-    public async Task GetGameAsync_WhenGameBelongsToAnotherPlayer_ReturnsNotFound()
+    public async Task GetGameAsync_WhenGameBelongsToAnotherProfile_ReturnsNotFound()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
+        var profileId = Guid.NewGuid().ToString();
         var gameId = Guid.NewGuid().ToString();
-        var game = CreateTestGameDto("OtherPlayer", "Medium", gameId);
+        var game = CreateTestGameDto(Guid.NewGuid().ToString(), "Medium", gameId);
 
         MockMediator
             .Setup(x => x.Send(It.IsAny<GetGameQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<GameDto>.Success(game));
 
         // Act
-        var result = await Sut.GetGameAsync(playerAlias, gameId);
+        var result = await Sut.GetGameAsync(profileId, gameId);
 
         // Assert
         result.Result.Should().BeOfType<NotFoundResult>();
@@ -156,25 +176,47 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     public async Task CreateGameAsync_WithValidParameters_ReturnsCreated()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
+        var profileId = Guid.NewGuid().ToString();
         var difficulty = "Medium";
         var gameId = Guid.NewGuid().ToString();
+        var profileDto = new ProfileDto(profileId, "TestPlayer", DateTime.UtcNow, DateTime.UtcNow);
+
+        MockMediator
+            .Setup(x => x.Send(It.IsAny<GetProfileByIdQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ProfileDto?>.Success(profileDto));
 
         MockMediator
             .Setup(x => x.Send(It.IsAny<CreateGameCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<string>.Success(gameId));
 
         // Act
-        var result = await Sut.CreateGameAsync(playerAlias, difficulty);
+        var result = await Sut.CreateGameAsync(profileId, difficulty);
 
         // Assert
         var createdResult = result.Should().BeOfType<CreatedResult>().Subject;
-        createdResult.Location.Should().Be($"/api/players/{playerAlias}/games/{gameId}");
+        createdResult.Location.Should().Be($"/api/players/{profileId}/games/{gameId}");
         createdResult.Value.Should().BeNull();
     }
 
     [Fact]
-    public async Task CreateGameAsync_WithEmptyAlias_ReturnsBadRequest()
+    public async Task CreateGameAsync_WithUnknownProfileId_Returns404()
+    {
+        // Arrange
+        var profileId = Guid.NewGuid().ToString();
+
+        MockMediator
+            .Setup(x => x.Send(It.IsAny<GetProfileByIdQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ProfileDto?>.Success(null));
+
+        // Act
+        var result = await Sut.CreateGameAsync(profileId, "Medium");
+
+        // Assert
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task CreateGameAsync_WithEmptyProfileId_ReturnsBadRequest()
     {
         // Act
         var result = await Sut.CreateGameAsync(string.Empty, "Medium");
@@ -187,7 +229,7 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     public async Task CreateGameAsync_WithEmptyDifficulty_ReturnsBadRequest()
     {
         // Act
-        var result = await Sut.CreateGameAsync("TestPlayer", string.Empty);
+        var result = await Sut.CreateGameAsync(Guid.NewGuid().ToString(), string.Empty);
 
         // Assert
         result.Should().BeOfType<BadRequestObjectResult>();
@@ -197,14 +239,20 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     public async Task CreateGameAsync_WhenCommandFails_ReturnsBadRequest()
     {
         // Arrange
+        var profileId = Guid.NewGuid().ToString();
         var errorMessage = "Failed to create game";
+        var profileDto = new ProfileDto(profileId, "TestPlayer", DateTime.UtcNow, DateTime.UtcNow);
+
+        MockMediator
+            .Setup(x => x.Send(It.IsAny<GetProfileByIdQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ProfileDto?>.Success(profileDto));
 
         MockMediator
             .Setup(x => x.Send(It.IsAny<CreateGameCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<string>.Failure(errorMessage));
 
         // Act
-        var result = await Sut.CreateGameAsync("TestPlayer", "Medium");
+        var result = await Sut.CreateGameAsync(profileId, "Medium");
 
         // Assert
         var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
@@ -219,9 +267,9 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     public async Task DeleteGameAsync_WithValidParameters_ReturnsNoContent()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
+        var profileId = Guid.NewGuid().ToString();
         var gameId = Guid.NewGuid().ToString();
-        var game = CreateTestGameDto(playerAlias, "Medium", gameId);
+        var game = CreateTestGameDto(profileId, "Medium", gameId);
 
         MockMediator
             .Setup(x => x.Send(It.IsAny<GetGameQuery>(), It.IsAny<CancellationToken>()))
@@ -232,14 +280,14 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
             .ReturnsAsync(Result.Success());
 
         // Act
-        var result = await Sut.DeleteGameAsync(playerAlias, gameId);
+        var result = await Sut.DeleteGameAsync(profileId, gameId);
 
         // Assert
         result.Should().BeOfType<NoContentResult>();
     }
 
     [Fact]
-    public async Task DeleteGameAsync_WithEmptyAlias_ReturnsBadRequest()
+    public async Task DeleteGameAsync_WithEmptyProfileId_ReturnsBadRequest()
     {
         // Act
         var result = await Sut.DeleteGameAsync(string.Empty, Guid.NewGuid().ToString());
@@ -252,7 +300,7 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     public async Task DeleteGameAsync_WithEmptyGameId_ReturnsBadRequest()
     {
         // Act
-        var result = await Sut.DeleteGameAsync("TestPlayer", string.Empty);
+        var result = await Sut.DeleteGameAsync(Guid.NewGuid().ToString(), string.Empty);
 
         // Assert
         result.Should().BeOfType<BadRequestObjectResult>();
@@ -262,7 +310,7 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     public async Task DeleteGameAsync_WhenGameNotFound_ReturnsNotFound()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
+        var profileId = Guid.NewGuid().ToString();
         var gameId = Guid.NewGuid().ToString();
         var errorMessage = "Game not found with ID: " + gameId;
 
@@ -271,7 +319,7 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
             .ReturnsAsync(Result<GameDto>.Failure(errorMessage));
 
         // Act
-        var result = await Sut.DeleteGameAsync(playerAlias, gameId);
+        var result = await Sut.DeleteGameAsync(profileId, gameId);
 
         // Assert
         var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
@@ -279,19 +327,19 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     }
 
     [Fact]
-    public async Task DeleteGameAsync_WhenGameBelongsToAnotherPlayer_ReturnsNotFound()
+    public async Task DeleteGameAsync_WhenGameBelongsToAnotherProfile_ReturnsNotFound()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
+        var profileId = Guid.NewGuid().ToString();
         var gameId = Guid.NewGuid().ToString();
-        var game = CreateTestGameDto("OtherPlayer", "Medium", gameId);
+        var game = CreateTestGameDto(Guid.NewGuid().ToString(), "Medium", gameId);
 
         MockMediator
             .Setup(x => x.Send(It.IsAny<GetGameQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<GameDto>.Success(game));
 
         // Act
-        var result = await Sut.DeleteGameAsync(playerAlias, gameId);
+        var result = await Sut.DeleteGameAsync(profileId, gameId);
 
         // Assert
         result.Should().BeOfType<NotFoundResult>();
@@ -301,9 +349,9 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     public async Task DeleteGameAsync_WhenDeleteGameReturnsFailed_ReturnsBadRequest()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
+        var profileId = Guid.NewGuid().ToString();
         var gameId = Guid.NewGuid().ToString();
-        var game = CreateTestGameDto(playerAlias, "Medium", gameId);
+        var game = CreateTestGameDto(profileId, "Medium", gameId);
         var errorMessage = "Failed to delete game";
 
         MockMediator
@@ -315,7 +363,7 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
             .ReturnsAsync(Result.Failure(errorMessage));
 
         // Act
-        var result = await Sut.DeleteGameAsync(playerAlias, gameId);
+        var result = await Sut.DeleteGameAsync(profileId, gameId);
 
         // Assert
         var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
@@ -327,24 +375,24 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
     #region DeleteAllGamesAsync Tests
 
     [Fact]
-    public async Task DeleteAllGamesAsync_WithValidAlias_ReturnsNoContent()
+    public async Task DeleteAllGamesAsync_WithValidProfileId_ReturnsNoContent()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
+        var profileId = Guid.NewGuid().ToString();
 
         MockMediator
             .Setup(x => x.Send(It.IsAny<DeletePlayerGamesCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
 
         // Act
-        var result = await Sut.DeleteAllGamesAsync(playerAlias);
+        var result = await Sut.DeleteAllGamesAsync(profileId);
 
         // Assert
         result.Should().BeOfType<NoContentResult>();
     }
 
     [Fact]
-    public async Task DeleteAllGamesAsync_WithEmptyAlias_ReturnsBadRequest()
+    public async Task DeleteAllGamesAsync_WithEmptyProfileId_ReturnsBadRequest()
     {
         // Act
         var result = await Sut.DeleteAllGamesAsync(string.Empty);
@@ -364,7 +412,7 @@ public class GamesControllerTests : BaseGameControllerTests<GamesController>
             .ReturnsAsync(Result.Failure(errorMessage));
 
         // Act
-        var result = await Sut.DeleteAllGamesAsync("TestPlayer");
+        var result = await Sut.DeleteAllGamesAsync(Guid.NewGuid().ToString());
 
         // Assert
         var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;

--- a/src/backend/Tests/Application/DTOs/GameDtoTests.cs
+++ b/src/backend/Tests/Application/DTOs/GameDtoTests.cs
@@ -17,7 +17,8 @@ public class GameDtoTests : MoqBaseTestByType<GameDto>
 
         // Assert
         dto.Id.Should().Be(game.Id.Value.ToString());
-        dto.PlayerAlias.Should().Be(game.PlayerAlias.Value);
+        dto.ProfileId.Should().Be(game.ProfileId.ToString());
+        dto.DisplayName.Should().Be(game.DisplayName.Value);
         dto.Difficulty.Should().Be(game.Difficulty.Name);
         dto.Status.Should().Be(game.Status.ToString());
         dto.CreatedAt.Should().Be(game.CreatedAt);
@@ -28,6 +29,20 @@ public class GameDtoTests : MoqBaseTestByType<GameDto>
         dto.Cells.Should().NotBeNull();
         dto.Cells.Count.Should().Be(game.GetCells().Count);
         dto.MoveHistory.Should().BeEquivalentTo(game.MoveHistory);
+    }
+
+    [Fact]
+    public void FromGame_MapsProfileId_Correctly()
+    {
+        // Arrange
+        var profileId = ProfileId.New();
+        var game = CreateTestGame(profileId: profileId);
+
+        // Act
+        var dto = GameDto.FromGame(game);
+
+        // Assert
+        dto.ProfileId.Should().Be(profileId.ToString());
     }
 
     [Fact]
@@ -74,12 +89,12 @@ public class GameDtoTests : MoqBaseTestByType<GameDto>
         // Assert
         dto.Cells.Should().NotBeNull();
         dto.Cells.Count.Should().Be(expectedCellCount);
-        
+
         for (int i = 0; i < expectedCellCount; i++)
         {
             var originalCell = game.GetCells()[i];
             var dtoCell = dto.Cells[i];
-            
+
             dtoCell.Row.Should().Be(originalCell.Row);
             dtoCell.Column.Should().Be(originalCell.Column);
             dtoCell.Value.Should().Be(originalCell.Value);
@@ -128,7 +143,8 @@ public class GameDtoTests : MoqBaseTestByType<GameDto>
     {
         // Arrange
         var id = Guid.NewGuid().ToString();
-        var playerAlias = "TestPlayer";
+        var profileId = Guid.NewGuid().ToString();
+        var displayName = "TestPlayer";
         var difficulty = "Medium";
         var status = "InProgress";
         var statistics = new GameStatisticsDto(10, 8, 2, TimeSpan.FromMinutes(5), 80.0);
@@ -140,11 +156,12 @@ public class GameDtoTests : MoqBaseTestByType<GameDto>
         var moveHistory = new List<MoveHistoryDto>();
 
         // Act
-        var dto = new GameDto(id, playerAlias, difficulty, status, statistics, createdAt, startedAt, completedAt, pausedAt, cells, moveHistory);
+        var dto = new GameDto(id, profileId, displayName, difficulty, status, statistics, createdAt, startedAt, completedAt, pausedAt, cells, moveHistory);
 
         // Assert
         dto.Id.Should().Be(id);
-        dto.PlayerAlias.Should().Be(playerAlias);
+        dto.ProfileId.Should().Be(profileId);
+        dto.DisplayName.Should().Be(displayName);
         dto.Difficulty.Should().Be(difficulty);
         dto.Status.Should().Be(status);
         dto.Statistics.Should().Be(statistics);
@@ -156,12 +173,13 @@ public class GameDtoTests : MoqBaseTestByType<GameDto>
         dto.MoveHistory.Should().BeEquivalentTo(moveHistory);
     }
 
-    private static SudokuGame CreateTestGame()
+    private static SudokuGame CreateTestGame(ProfileId? profileId = null)
     {
-        var playerAlias = PlayerAlias.Create("TestPlayer");
+        var withProfileId = profileId ?? ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Medium;
         var cells = new List<Cell>();
-        
+
         for (int i = 0; i < 9; i++)
         {
             for (int j = 0; j < 9; j++)
@@ -170,6 +188,6 @@ public class GameDtoTests : MoqBaseTestByType<GameDto>
             }
         }
 
-        return SudokuGame.Create(playerAlias, difficulty, cells);
+        return SudokuGame.Create(withProfileId, displayName, difficulty, cells);
     }
 }

--- a/src/backend/Tests/Application/Handlers/CreateGameCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/CreateGameCommandHandlerTests.cs
@@ -28,10 +28,11 @@ public class CreateGameCommandHandlerTests : MoqBaseTestByAbstraction<CreateGame
     public async Task Handle_WithValidCommand_ReturnsSuccessResult()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
+        var profileId = Guid.NewGuid().ToString();
+        var displayName = "TestPlayer";
         var difficulty = "Medium";
         var puzzle = CreateTestPuzzle();
-        var command = new CreateGameCommand(playerAlias, difficulty);
+        var command = new CreateGameCommand(profileId, displayName, difficulty);
 
         _mockPuzzleRepository.Setup(x => x.GeneratePuzzleAsync(It.IsAny<GameDifficulty>()))
             .ReturnsAsync(puzzle);
@@ -55,9 +56,9 @@ public class CreateGameCommandHandlerTests : MoqBaseTestByAbstraction<CreateGame
     public async Task Handle_WhenNoPuzzleAvailable_ReturnsFailureResult()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
+        var profileId = Guid.NewGuid().ToString();
         var difficulty = "Medium";
-        var command = new CreateGameCommand(playerAlias, difficulty);
+        var command = new CreateGameCommand(profileId, "TestPlayer", difficulty);
 
         _mockPuzzleRepository.Setup(x => x.GeneratePuzzleAsync(It.IsAny<GameDifficulty>()))
             .ReturnsAsync((SudokuPuzzle?)null);
@@ -74,12 +75,13 @@ public class CreateGameCommandHandlerTests : MoqBaseTestByAbstraction<CreateGame
     }
 
     [Fact]
-    public async Task Handle_WithInvalidPlayerAlias_ReturnsFailureResult()
+    public async Task Handle_WithInvalidDisplayName_ReturnsFailureResult()
     {
         // Arrange
-        var playerAlias = ""; // Invalid player alias
+        var profileId = Guid.NewGuid().ToString();
+        var displayName = ""; // Invalid display name
         var difficulty = "Medium";
-        var command = new CreateGameCommand(playerAlias, difficulty);
+        var command = new CreateGameCommand(profileId, displayName, difficulty);
 
         var sut = ResolveSut();
 
@@ -97,9 +99,9 @@ public class CreateGameCommandHandlerTests : MoqBaseTestByAbstraction<CreateGame
     public async Task Handle_WithInvalidDifficulty_ReturnsFailureResult()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
+        var profileId = Guid.NewGuid().ToString();
         var difficulty = "InvalidDifficulty";
-        var command = new CreateGameCommand(playerAlias, difficulty);
+        var command = new CreateGameCommand(profileId, "TestPlayer", difficulty);
 
         var sut = ResolveSut();
 
@@ -117,10 +119,9 @@ public class CreateGameCommandHandlerTests : MoqBaseTestByAbstraction<CreateGame
     public async Task Handle_WhenRepositoryThrowsException_ReturnsFailureResult()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
-        var difficulty = "Medium";
+        var profileId = Guid.NewGuid().ToString();
         var puzzle = CreateTestPuzzle();
-        var command = new CreateGameCommand(playerAlias, difficulty);
+        var command = new CreateGameCommand(profileId, "TestPlayer", "Medium");
         var exceptionMessage = "Database error";
 
         _mockPuzzleRepository.Setup(x => x.GeneratePuzzleAsync(It.IsAny<GameDifficulty>()))
@@ -143,9 +144,8 @@ public class CreateGameCommandHandlerTests : MoqBaseTestByAbstraction<CreateGame
     public async Task Handle_WhenDomainExceptionThrown_ReturnsFailureWithDomainMessage()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
-        var difficulty = "Medium";
-        var command = new CreateGameCommand(playerAlias, difficulty);
+        var profileId = Guid.NewGuid().ToString();
+        var command = new CreateGameCommand(profileId, "TestPlayer", "Medium");
         var domainException = new InvalidPlayerAliasException("Invalid player alias");
 
         _mockPuzzleRepository.Setup(x => x.GeneratePuzzleAsync(It.IsAny<GameDifficulty>()))
@@ -165,10 +165,10 @@ public class CreateGameCommandHandlerTests : MoqBaseTestByAbstraction<CreateGame
     public async Task Handle_CallsRepositoryWithCorrectParameters()
     {
         // Arrange
-        var playerAlias = "TestPlayer";
+        var profileId = Guid.NewGuid().ToString();
         var difficulty = "Medium";
         var puzzle = CreateTestPuzzle();
-        var command = new CreateGameCommand(playerAlias, difficulty);
+        var command = new CreateGameCommand(profileId, "TestPlayer", difficulty);
         var expectedDifficulty = GameDifficulty.FromName(difficulty);
 
         _mockPuzzleRepository.Setup(x => x.GeneratePuzzleAsync(It.IsAny<GameDifficulty>()))

--- a/src/backend/Tests/Application/Handlers/CreateProfileCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/CreateProfileCommandHandlerTests.cs
@@ -36,7 +36,7 @@ public class CreateProfileCommandHandlerTests : MoqBaseTestByAbstraction<CreateP
     }
 
     [Fact]
-    public async Task Handle_NormalizesAliasToLowercase()
+    public async Task Handle_PreservesOriginalAliasCase()
     {
         _mockProfileRepository.Setup(x => x.AliasExistsAsync(It.IsAny<PlayerAlias>())).ReturnsAsync(false);
         _mockProfileRepository.Setup(x => x.SaveAsync(It.IsAny<Sudoku.Domain.Entities.UserProfile>())).Returns(Task.CompletedTask);
@@ -45,7 +45,7 @@ public class CreateProfileCommandHandlerTests : MoqBaseTestByAbstraction<CreateP
         var result = await sut.Handle(new CreateProfileCommand("MixedCase"), CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value!.Alias.Should().Be("mixedcase");
+        result.Value!.Alias.Should().Be("MixedCase");
     }
 
     [Fact]

--- a/src/backend/Tests/Application/Handlers/DeleteGameCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/DeleteGameCommandHandlerTests.cs
@@ -49,10 +49,11 @@ public class DeleteGameCommandHandlerTests : MoqBaseTestByAbstraction<Handler, I
 
     private static SudokuGame CreateTestGame()
     {
-        var playerAlias = PlayerAlias.Create("TestPlayer");
+        var profileId = ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Medium;
         var cells = new List<Cell>();
-        
+
         for (int i = 0; i < 9; i++)
         {
             for (int j = 0; j < 9; j++)
@@ -61,6 +62,6 @@ public class DeleteGameCommandHandlerTests : MoqBaseTestByAbstraction<Handler, I
             }
         }
 
-        return SudokuGame.Create(playerAlias, difficulty, cells);
+        return SudokuGame.Create(profileId, displayName, difficulty, cells);
     }
 }

--- a/src/backend/Tests/Application/Handlers/DeletePlayerGamesCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/DeletePlayerGamesCommandHandlerTests.cs
@@ -33,12 +33,12 @@ public class DeletePlayerGamesCommandHandlerTests : MoqBaseTestByAbstraction<Del
     public async Task Handle_CallsDeleteAsyncForEachGame()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var command = new DeletePlayerGamesCommand(playerAlias);
+        var profileId = Guid.NewGuid().ToString();
+        var command = new DeletePlayerGamesCommand(profileId);
         var games = Container.CreateMany<SudokuGame>(2);
 
         _mockGameRepository
-            .Setup(x => x.GetByPlayerAsync(It.IsAny<PlayerAlias>()))
+            .Setup(x => x.GetByProfileIdAsync(It.IsAny<ProfileId>()))
             .ReturnsAsync(games);
 
         var sut = ResolveSut();
@@ -54,12 +54,12 @@ public class DeletePlayerGamesCommandHandlerTests : MoqBaseTestByAbstraction<Del
     public async Task Handle_LogsInformationWithGameCount()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var command = new DeletePlayerGamesCommand(playerAlias);
+        var profileId = Guid.NewGuid().ToString();
+        var command = new DeletePlayerGamesCommand(profileId);
         var games = Container.CreateMany<SudokuGame>(2);
 
         _mockGameRepository
-            .Setup(x => x.GetByPlayerAsync(It.IsAny<PlayerAlias>()))
+            .Setup(x => x.GetByProfileIdAsync(It.IsAny<ProfileId>()))
             .ReturnsAsync(games);
 
         var sut = ResolveSut();
@@ -68,19 +68,19 @@ public class DeletePlayerGamesCommandHandlerTests : MoqBaseTestByAbstraction<Del
         await sut.Handle(command, CancellationToken.None);
 
         // Assert
-        Logger.InformationLogs().ContainsMessage($"Deleted 2 games for player {playerAlias}");
+        Logger.InformationLogs().ContainsMessage("Deleted 2 games for profile");
     }
 
     [Fact]
-    public async Task Handle_WhenDomainExceptionThrown_ReturnsFailureResult()
+    public async Task Handle_WhenRepositoryThrowsException_ReturnsFailureResult()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var command = new DeletePlayerGamesCommand(playerAlias);
-        var exceptionMessage = "Invalid player alias format";
+        var profileId = Guid.NewGuid().ToString();
+        var command = new DeletePlayerGamesCommand(profileId);
+        var exceptionMessage = "Database error";
 
         _mockGameRepository
-            .Setup(x => x.GetByPlayerAsync(It.IsAny<PlayerAlias>()))
+            .Setup(x => x.GetByProfileIdAsync(It.IsAny<ProfileId>()))
             .ThrowsAsync(new Exception(exceptionMessage));
 
         var sut = ResolveSut();
@@ -94,16 +94,16 @@ public class DeletePlayerGamesCommandHandlerTests : MoqBaseTestByAbstraction<Del
     }
 
     [Fact]
-    public async Task Handle_WhenRepositoryThrowsException_ReturnsFailureResult()
+    public async Task Handle_WhenDeleteThrowsException_ReturnsFailureResult()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var command = new DeletePlayerGamesCommand(playerAlias);
+        var profileId = Guid.NewGuid().ToString();
+        var command = new DeletePlayerGamesCommand(profileId);
         var games = Container.CreateMany<SudokuGame>(1);
         var exceptionMessage = "Database error";
 
         _mockGameRepository
-            .Setup(x => x.GetByPlayerAsync(It.IsAny<PlayerAlias>()))
+            .Setup(x => x.GetByProfileIdAsync(It.IsAny<ProfileId>()))
             .ReturnsAsync(games);
 
         _mockGameRepository
@@ -124,12 +124,12 @@ public class DeletePlayerGamesCommandHandlerTests : MoqBaseTestByAbstraction<Del
     public async Task Handle_WithNoGames_ReturnsSuccessResult()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var command = new DeletePlayerGamesCommand(playerAlias);
+        var profileId = Guid.NewGuid().ToString();
+        var command = new DeletePlayerGamesCommand(profileId);
         var games = new List<SudokuGame>();
 
         _mockGameRepository
-            .Setup(x => x.GetByPlayerAsync(It.IsAny<PlayerAlias>()))
+            .Setup(x => x.GetByProfileIdAsync(It.IsAny<ProfileId>()))
             .ReturnsAsync(games);
 
         var sut = ResolveSut();
@@ -142,15 +142,15 @@ public class DeletePlayerGamesCommandHandlerTests : MoqBaseTestByAbstraction<Del
     }
 
     [Fact]
-    public async Task Handle_WithValidPlayerAlias_ReturnsSuccessResult()
+    public async Task Handle_WithValidProfileId_ReturnsSuccessResult()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var command = new DeletePlayerGamesCommand(playerAlias);
+        var profileId = Guid.NewGuid().ToString();
+        var command = new DeletePlayerGamesCommand(profileId);
         var games = Container.CreateMany<SudokuGame>(2);
 
         _mockGameRepository
-            .Setup(x => x.GetByPlayerAsync(It.IsAny<PlayerAlias>()))
+            .Setup(x => x.GetByProfileIdAsync(It.IsAny<ProfileId>()))
             .ReturnsAsync(games);
 
         var sut = ResolveSut();

--- a/src/backend/Tests/Application/Handlers/GetGameQueryHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/GetGameQueryHandlerTests.cs
@@ -43,7 +43,7 @@ public class GetGameQueryHandlerTests : MoqBaseTestByAbstraction<GetGameQueryHan
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().NotBeNull();
         result.Value!.Id.Should().Be(game.Id.Value.ToString());
-        result.Value.PlayerAlias.Should().Be(game.PlayerAlias.Value);
+        result.Value.DisplayName.Should().Be(game.DisplayName.Value);
         result.Value.Difficulty.Should().Be(game.Difficulty.Name);
         result.Value.Status.Should().Be(game.Status.ToString());
     }
@@ -170,7 +170,7 @@ public class GetGameQueryHandlerTests : MoqBaseTestByAbstraction<GetGameQueryHan
         
         var gameDto = result.Value!;
         gameDto.Id.Should().Be(game.Id.Value.ToString());
-        gameDto.PlayerAlias.Should().Be(game.PlayerAlias.Value);
+        gameDto.DisplayName.Should().Be(game.DisplayName.Value);
         gameDto.Difficulty.Should().Be(game.Difficulty.Name);
         gameDto.Status.Should().Be(game.Status.ToString());
         gameDto.CreatedAt.Should().Be(game.CreatedAt);
@@ -184,10 +184,11 @@ public class GetGameQueryHandlerTests : MoqBaseTestByAbstraction<GetGameQueryHan
 
     private static SudokuGame CreateTestGame()
     {
-        var playerAlias = PlayerAlias.Create("TestPlayer");
+        var profileId = ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Medium;
         var cells = new List<Cell>();
-        
+
         for (int i = 0; i < 9; i++)
         {
             for (int j = 0; j < 9; j++)
@@ -196,6 +197,6 @@ public class GetGameQueryHandlerTests : MoqBaseTestByAbstraction<GetGameQueryHan
             }
         }
 
-        return SudokuGame.Create(playerAlias, difficulty, cells);
+        return SudokuGame.Create(profileId, displayName, difficulty, cells);
     }
 }

--- a/src/backend/Tests/Application/Handlers/MakeMoveCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/MakeMoveCommandHandlerTests.cs
@@ -236,21 +236,23 @@ public class MakeMoveCommandHandlerTests : MoqBaseTestByAbstraction<MakeMoveComm
 
     private static SudokuGame CreateTestGameInProgress()
     {
-        var playerAlias = PlayerAlias.Create("TestPlayer");
+        var profileId = ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Medium;
         var cells = InitializeCells((i, j) => Cell.CreateEmpty(i, j));
 
-        var game = SudokuGame.Create(playerAlias, difficulty, cells);
+        var game = SudokuGame.Create(profileId, displayName, difficulty, cells);
         game.StartGame();
         return game;
     }
 
     private static SudokuGame CreateTestGameWithDuplicateValue()
     {
-        var playerAlias = PlayerAlias.Create("TestPlayer");
+        var profileId = ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Medium;
         var cells = new List<Cell>();
-        
+
         for (int i = 0; i < 9; i++)
         {
             for (int j = 0; j < 9; j++)
@@ -261,7 +263,7 @@ public class MakeMoveCommandHandlerTests : MoqBaseTestByAbstraction<MakeMoveComm
             }
         }
 
-        var game = SudokuGame.Create(playerAlias, difficulty, cells);
+        var game = SudokuGame.Create(profileId, displayName, difficulty, cells);
         game.StartGame();
         return game;
     }

--- a/src/backend/Tests/Application/Handlers/UpdateProfileAliasCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/UpdateProfileAliasCommandHandlerTests.cs
@@ -33,7 +33,6 @@ public class UpdateProfileAliasCommandHandlerTests : MoqBaseTestByAbstraction<Up
         _mockProfileRepository.Setup(x => x.GetByIdAsync(It.IsAny<ProfileId>())).ReturnsAsync(profile);
         _mockProfileRepository.Setup(x => x.AliasExistsAsync(It.IsAny<PlayerAlias>())).ReturnsAsync(false);
         _mockProfileRepository.Setup(x => x.SaveAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
-        _mockGameRepository.Setup(x => x.GetByPlayerAsync(It.IsAny<PlayerAlias>())).ReturnsAsync([]);
 
         var sut = ResolveSut();
 
@@ -86,7 +85,7 @@ public class UpdateProfileAliasCommandHandlerTests : MoqBaseTestByAbstraction<Up
     }
 
     [Fact]
-    public async Task Handle_NormalizesNewAliasToLowercase()
+    public async Task Handle_PreservesOriginalAliasCase()
     {
         var existingAlias = PlayerAlias.Create("oldalias");
         var profile = UserProfile.Create(existingAlias);
@@ -94,14 +93,13 @@ public class UpdateProfileAliasCommandHandlerTests : MoqBaseTestByAbstraction<Up
         _mockProfileRepository.Setup(x => x.GetByIdAsync(It.IsAny<ProfileId>())).ReturnsAsync(profile);
         _mockProfileRepository.Setup(x => x.AliasExistsAsync(It.IsAny<PlayerAlias>())).ReturnsAsync(false);
         _mockProfileRepository.Setup(x => x.SaveAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
-        _mockGameRepository.Setup(x => x.GetByPlayerAsync(It.IsAny<PlayerAlias>())).ReturnsAsync([]);
 
         var sut = ResolveSut();
 
         var result = await sut.Handle(new UpdateProfileAliasCommand(profile.Id.ToString(), "NewAlias"), CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        result.Value!.Alias.Should().Be("newalias");
+        result.Value!.Alias.Should().Be("NewAlias");
     }
 
     [Fact]
@@ -114,7 +112,6 @@ public class UpdateProfileAliasCommandHandlerTests : MoqBaseTestByAbstraction<Up
         _mockProfileRepository.Setup(x => x.AliasExistsAsync(It.IsAny<PlayerAlias>())).ReturnsAsync(false);
         _mockProfileRepository.Setup(x => x.SaveAsync(It.IsAny<UserProfile>()))
             .ThrowsAsync(new Exception("Storage failure"));
-        _mockGameRepository.Setup(x => x.GetByPlayerAsync(It.IsAny<PlayerAlias>())).ReturnsAsync([]);
 
         var sut = ResolveSut();
 
@@ -133,7 +130,6 @@ public class UpdateProfileAliasCommandHandlerTests : MoqBaseTestByAbstraction<Up
         _mockProfileRepository.Setup(x => x.GetByIdAsync(It.IsAny<ProfileId>())).ReturnsAsync(profile);
         _mockProfileRepository.Setup(x => x.AliasExistsAsync(It.IsAny<PlayerAlias>())).ReturnsAsync(false);
         _mockProfileRepository.Setup(x => x.SaveAsync(It.IsAny<UserProfile>())).Returns(Task.CompletedTask);
-        _mockGameRepository.Setup(x => x.GetByPlayerAsync(It.IsAny<PlayerAlias>())).ReturnsAsync([]);
 
         var sut = ResolveSut();
 

--- a/src/backend/Tests/Blazor/Pages/GameListPageTests.cs
+++ b/src/backend/Tests/Blazor/Pages/GameListPageTests.cs
@@ -37,8 +37,8 @@ public class GameListPageTests : BunitContext
         SetupReturningPlayer();
         var games = new List<GameModel>
         {
-            new() { Id = Guid.NewGuid().ToString(), PlayerAlias = Alias },
-            new() { Id = Guid.NewGuid().ToString(), PlayerAlias = Alias },
+            new() { Id = Guid.NewGuid().ToString(), ProfileId = Alias },
+            new() { Id = Guid.NewGuid().ToString(), ProfileId = Alias },
         };
         _mockGameManager.SetupLoadGamesAsync(games);
 
@@ -64,8 +64,8 @@ public class GameListPageTests : BunitContext
         SetupReturningPlayer();
         var games = new List<GameModel>
         {
-            new() { Id = Guid.NewGuid().ToString(), PlayerAlias = Alias },
-            new() { Id = Guid.NewGuid().ToString(), PlayerAlias = Alias },
+            new() { Id = Guid.NewGuid().ToString(), ProfileId = Alias },
+            new() { Id = Guid.NewGuid().ToString(), ProfileId = Alias },
         };
         _mockGameManager.SetupLoadGamesAsync(games);
 
@@ -81,7 +81,7 @@ public class GameListPageTests : BunitContext
         SetupReturningPlayer();
         var games = new List<GameModel>
         {
-            new() { Id = Guid.NewGuid().ToString(), PlayerAlias = Alias },
+            new() { Id = Guid.NewGuid().ToString(), ProfileId = Alias },
         };
         _mockGameManager.SetupLoadGamesAsync(games);
 

--- a/src/backend/Tests/Blazor/Pages/GamePageTests.cs
+++ b/src/backend/Tests/Blazor/Pages/GamePageTests.cs
@@ -27,14 +27,14 @@ public class GamePageTests : BunitContext
         var loadedGameState = GameModelFactory
             .Build()
             .WithDifficulty(GameDifficulty.Easy)
-            .WithPlayerAlias(Alias)
+            .WithProfileId(Alias)
             .WithId(PuzzleId)
             .Create();
         var mockGameTimer = new Mock<IGameTimer>();
         _mockGameManager.Setup(x => x.CurrentStatistics).Returns(gameStatistics);
         _mockGameManager.Setup(x => x.Game).Returns(loadedGameState);
         _mockGameManager.Setup(x => x.Timer).Returns(mockGameTimer.Object);
-        _mockPlayerManager.SetupGetCurrentPlayerAsync(Alias);
+        _mockPlayerManager.SetupGetCurrentProfileIdAsync(Alias);
         Services.AddSingleton(_mockNotificationService.Object);
         Services.AddSingleton(_mockGameManager.Object);
         Services.AddSingleton(_mockPlayerManager.Object);
@@ -83,7 +83,7 @@ public class GamePageTests : BunitContext
         // Arrange
         var gameState = new GameModel
         {
-            PlayerAlias = Alias,
+            ProfileId = Alias,
             Cells = GameModelFactory.GetSolvedPuzzle().Cells,
             Id = PuzzleId
         };
@@ -163,7 +163,7 @@ public class GamePageTests : BunitContext
         // Arrange
         var gameState = new GameModel
         {
-            PlayerAlias = Alias,
+            ProfileId = Alias,
             Cells = GameModelFactory.GetSolvedPuzzle().Cells,
             Id = PuzzleId
         };
@@ -177,7 +177,7 @@ public class GamePageTests : BunitContext
         await sut.InvokeAsync(() => buttonGroup.OnValueChanged.InvokeAsync(new CellValueChangedEventArgs(1)));
 
         // Assert
-        _mockGameManager.VerifyDeleteGameAsyncCalled(gameState.PlayerAlias, gameState.Id, Times.Once);
+        _mockGameManager.VerifyDeleteGameAsyncCalled(gameState.ProfileId, gameState.Id, Times.Once);
     }
 
     [Fact]
@@ -186,7 +186,7 @@ public class GamePageTests : BunitContext
         // Arrange
         var gameState = new GameModel
         {
-            PlayerAlias = Alias,
+            ProfileId = Alias,
             Cells = GameModelFactory.GetSolvedPuzzle().Cells,
             Id = PuzzleId
         };
@@ -210,7 +210,7 @@ public class GamePageTests : BunitContext
         // Arrange
         var gameState = new GameModel
         {
-            PlayerAlias = Alias,
+            ProfileId = Alias,
             Cells = GameModelFactory.GetSolvedPuzzle().Cells,
             Id = PuzzleId
         };

--- a/src/backend/Tests/Blazor/Pages/NewPageTests.cs
+++ b/src/backend/Tests/Blazor/Pages/NewPageTests.cs
@@ -16,7 +16,7 @@ public class NewPageTests : BunitContext
         var alias = "game-alias";
         _mockGameManager = new Mock<IGameManager>();
         var playerManager = new Mock<IPlayerManager>();
-        playerManager.SetupGetCurrentPlayerAsync(alias);
+        playerManager.SetupGetCurrentProfileIdAsync(alias);
 
         _mockGameManager.SetupCreateGameAsync(alias, "Medium");
 

--- a/src/backend/Tests/Blazor/Services/GameStateManagerTests.cs
+++ b/src/backend/Tests/Blazor/Services/GameStateManagerTests.cs
@@ -70,7 +70,7 @@ public class GameStateManagerTests : MoqBaseTestByAbstraction<GameManager, IGame
         var exception = await Assert.ThrowsAsync<ArgumentException>(() => sut.CreateGameAsync(alias, TestDifficulty));
 
         // Assert
-        exception.Message.Should().Be("Alias not set.");
+        exception.Message.Should().Be("Profile ID not set.");
     }
 
     [Theory]
@@ -129,7 +129,7 @@ public class GameStateManagerTests : MoqBaseTestByAbstraction<GameManager, IGame
         var game = CreateTestGameModel();
         var successResult = ApiResult<bool>.Success(true);
         _mockGameApiClient
-            .Setup(x => x.DeleteGameAsync(game.PlayerAlias, game.Id))
+            .Setup(x => x.DeleteGameAsync(game.ProfileId, game.Id))
             .ReturnsAsync(successResult);
         var sut = ResolveSut();
         SetGameProperty(sut, game);
@@ -148,7 +148,7 @@ public class GameStateManagerTests : MoqBaseTestByAbstraction<GameManager, IGame
         var game = CreateTestGameModel();
         var successResult = ApiResult<bool>.Success(true);
         _mockGameApiClient
-            .Setup(x => x.DeleteGameAsync(game.PlayerAlias, game.Id))
+            .Setup(x => x.DeleteGameAsync(game.ProfileId, game.Id))
             .ReturnsAsync(successResult);
         var sut = ResolveSut();
         SetGameProperty(sut, game);
@@ -157,7 +157,7 @@ public class GameStateManagerTests : MoqBaseTestByAbstraction<GameManager, IGame
         await sut.DeleteGameAsync();
 
         // Assert
-        _mockGameApiClient.Verify(x => x.DeleteGameAsync(game.PlayerAlias, game.Id), Times.Once);
+        _mockGameApiClient.Verify(x => x.DeleteGameAsync(game.ProfileId, game.Id), Times.Once);
     }
 
     [Fact]
@@ -167,7 +167,7 @@ public class GameStateManagerTests : MoqBaseTestByAbstraction<GameManager, IGame
         var game = CreateTestGameModel();
         var successResult = ApiResult<bool>.Success(true);
         _mockGameApiClient
-            .Setup(x => x.DeleteGameAsync(game.PlayerAlias, game.Id))
+            .Setup(x => x.DeleteGameAsync(game.ProfileId, game.Id))
             .ReturnsAsync(successResult);
         var sut = ResolveSut();
         SetGameProperty(sut, game);
@@ -238,7 +238,7 @@ public class GameStateManagerTests : MoqBaseTestByAbstraction<GameManager, IGame
         var exception = await Assert.ThrowsAsync<ArgumentException>(() => sut.DeleteGameAsync(alias, TestGameId));
 
         // Assert
-        exception.Message.Should().Be("Alias not set.");
+        exception.Message.Should().Be("Profile ID not set.");
     }
 
     [Theory]
@@ -328,7 +328,7 @@ public class GameStateManagerTests : MoqBaseTestByAbstraction<GameManager, IGame
         var exception = await Assert.ThrowsAsync<ArgumentException>(() => sut.LoadGameAsync(alias, TestGameId));
 
         // Assert
-        exception.Message.Should().Be("Alias not set.");
+        exception.Message.Should().Be("Profile ID not set.");
     }
 
     [Theory]
@@ -457,7 +457,7 @@ public class GameStateManagerTests : MoqBaseTestByAbstraction<GameManager, IGame
         var exception = await Assert.ThrowsAsync<ArgumentException>(() => sut.LoadGamesAsync(alias));
 
         // Assert
-        exception.Message.Should().Be("Alias not set.");
+        exception.Message.Should().Be("Profile ID not set.");
     }
 
     [Fact]
@@ -509,10 +509,10 @@ public class GameStateManagerTests : MoqBaseTestByAbstraction<GameManager, IGame
         var successResult = ApiResult<bool>.Success(true);
         var gameResult = ApiResult<GameModel>.Success(resetGame);
         _mockGameApiClient
-            .Setup(x => x.ResetGameAsync(game.PlayerAlias, game.Id))
+            .Setup(x => x.ResetGameAsync(game.ProfileId, game.Id))
             .ReturnsAsync(successResult);
         _mockGameApiClient
-            .Setup(x => x.GetGameAsync(game.PlayerAlias, game.Id))
+            .Setup(x => x.GetGameAsync(game.ProfileId, game.Id))
             .ReturnsAsync(gameResult);
         var sut = ResolveSut();
         SetGameProperty(sut, game);
@@ -534,10 +534,10 @@ public class GameStateManagerTests : MoqBaseTestByAbstraction<GameManager, IGame
         var successResult = ApiResult<bool>.Success(true);
         var gameResult = ApiResult<GameModel>.Success(resetGame);
         _mockGameApiClient
-            .Setup(x => x.ResetGameAsync(game.PlayerAlias, game.Id))
+            .Setup(x => x.ResetGameAsync(game.ProfileId, game.Id))
             .ReturnsAsync(successResult);
         _mockGameApiClient
-            .Setup(x => x.GetGameAsync(game.PlayerAlias, game.Id))
+            .Setup(x => x.GetGameAsync(game.ProfileId, game.Id))
             .ReturnsAsync(gameResult);
         var sut = ResolveSut();
         SetGameProperty(sut, game);
@@ -556,7 +556,7 @@ public class GameStateManagerTests : MoqBaseTestByAbstraction<GameManager, IGame
         var game = CreateTestGameModel();
         var failureResult = ApiResult<bool>.Failure("API Error");
         _mockGameApiClient
-            .Setup(x => x.ResetGameAsync(game.PlayerAlias, game.Id))
+            .Setup(x => x.ResetGameAsync(game.ProfileId, game.Id))
             .ReturnsAsync(failureResult);
         var sut = ResolveSut();
         SetGameProperty(sut, game);
@@ -622,10 +622,10 @@ public class GameStateManagerTests : MoqBaseTestByAbstraction<GameManager, IGame
         var successResult = ApiResult<bool>.Success(true);
         var gameResult = ApiResult<GameModel>.Success(undoGame);
         _mockGameApiClient
-            .Setup(x => x.UndoMoveAsync(game.PlayerAlias, game.Id))
+            .Setup(x => x.UndoMoveAsync(game.ProfileId, game.Id))
             .ReturnsAsync(successResult);
         _mockGameApiClient
-            .Setup(x => x.GetGameAsync(game.PlayerAlias, game.Id))
+            .Setup(x => x.GetGameAsync(game.ProfileId, game.Id))
             .ReturnsAsync(gameResult);
         var sut = ResolveSut();
         SetGameProperty(sut, game);
@@ -661,7 +661,7 @@ public class GameStateManagerTests : MoqBaseTestByAbstraction<GameManager, IGame
         var game = CreateTestGameModelWithMoves();
         var failureResult = ApiResult<bool>.Failure("API Error");
         _mockGameApiClient
-            .Setup(x => x.UndoMoveAsync(game.PlayerAlias, game.Id))
+            .Setup(x => x.UndoMoveAsync(game.ProfileId, game.Id))
             .ReturnsAsync(failureResult);
         var sut = ResolveSut();
         SetGameProperty(sut, game);
@@ -687,7 +687,8 @@ public class GameStateManagerTests : MoqBaseTestByAbstraction<GameManager, IGame
         return new GameModel
         {
             Id = TestGameId,
-            PlayerAlias = TestAlias,
+            ProfileId = TestAlias,
+            DisplayName = TestAlias,
             Difficulty = TestDifficulty,
             Status = "InProgress",
             Statistics = new GameStatisticsModel(),
@@ -701,7 +702,8 @@ public class GameStateManagerTests : MoqBaseTestByAbstraction<GameManager, IGame
         var game = new GameModel
         {
             Id = TestGameId,
-            PlayerAlias = TestAlias,
+            ProfileId = TestAlias,
+            DisplayName = TestAlias,
             Difficulty = TestDifficulty,
             Status = "InProgress",
             Statistics = new GameStatisticsModel(),

--- a/src/backend/Tests/Blazor/Services/GameStatisticsManagerTests.cs
+++ b/src/backend/Tests/Blazor/Services/GameStatisticsManagerTests.cs
@@ -26,7 +26,7 @@ public class GameStatisticsManagerTests : MoqBaseTestByAbstraction<GameManager, 
         _testGame = GameModelFactory
             .Build()
             .WithStatus(GameStatus.NotStarted)
-            .WithPlayerAlias(_testAlias)
+            .WithProfileId(_testAlias)
             .WithId(_testGameId)
             .Create();
 
@@ -90,7 +90,7 @@ public class GameStatisticsManagerTests : MoqBaseTestByAbstraction<GameManager, 
         await sut.EndSession();
 
         // Assert
-        _mockGameApiClient.VerifySavesGameStatus(game.PlayerAlias, game.Id, GameStatus.Completed, Times.Once);
+        _mockGameApiClient.VerifySavesGameStatus(game.ProfileId, game.Id, GameStatus.Completed, Times.Once);
     }
 
     [Fact]

--- a/src/backend/Tests/Domain/SudokuGameMoveHistoryTests.cs
+++ b/src/backend/Tests/Domain/SudokuGameMoveHistoryTests.cs
@@ -86,6 +86,7 @@ public class SudokuGameMoveHistoryTests : MoqBaseTestByType<SudokuGame>
         // Act
         var sut = SudokuGame.Reconstitute(
             GameId.New(),
+            ProfileId.New(),
             PlayerAlias.Create("TestPlayer"),
             GameDifficulty.Easy,
             GameStatusEnum.InProgress,
@@ -108,6 +109,7 @@ public class SudokuGameMoveHistoryTests : MoqBaseTestByType<SudokuGame>
     {
         var cells = CellsFactory.CreateEmptyCells();
         return SudokuGame.Create(
+            ProfileId.New(),
             PlayerAlias.Create("TestPlayer"),
             GameDifficulty.Easy,
             cells

--- a/src/backend/Tests/Domain/SudokuGamePossibleValuesTests.cs
+++ b/src/backend/Tests/Domain/SudokuGamePossibleValuesTests.cs
@@ -8,6 +8,7 @@ namespace UnitTests.Domain;
 
 public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
 {
+    private readonly ProfileId _profileId = ProfileId.New();
     private readonly PlayerAlias _playerAlias = PlayerAlias.Create("TestPlayer");
     private readonly GameDifficulty _difficulty = GameDifficulty.Easy;
     private readonly List<Cell> _initialCells;
@@ -21,7 +22,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void AddPossibleValue_ToEmptyCell_AddsPossibleValue()
     {
         // Arrange
-        var game = SudokuGame.Create(_playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
         game.StartGame();
         int row = 2, col = 2, value = 3;
 
@@ -45,7 +46,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void AddPossibleValue_ToFixedCell_ThrowsCellIsFixedException()
     {
         // Arrange
-        var game = SudokuGame.Create(_playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
         game.StartGame();
         int row = 0, col = 0, value = 3; // Cell at (0,0) is fixed
 
@@ -61,7 +62,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void AddPossibleValue_ToCellWithValue_ThrowsCellAlreadyHasValueException()
     {
         // Arrange
-        var game = SudokuGame.Create(_playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
         game.StartGame();
         int row = 1, col = 1, value = 3; // Cell at (1,1) has a value
 
@@ -77,7 +78,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void AddPossibleValue_WhenGameNotInProgress_ThrowsGameNotInProgressException()
     {
         // Arrange
-        var game = SudokuGame.Create(_playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
         // Don't start the game
         int row = 2, col = 2, value = 3;
 
@@ -93,7 +94,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void ClearPossibleValues_FromCellWithPossibleValues_ClearsPossibleValues()
     {
         // Arrange
-        var game = SudokuGame.Create(_playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
         game.StartGame();
         int row = 2, col = 2;
         game.AddPossibleValue(row, col, 3);
@@ -120,7 +121,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void ClearPossibleValues_FromFixedCell_ThrowsCellIsFixedException()
     {
         // Arrange
-        var game = SudokuGame.Create(_playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
         game.StartGame();
         int row = 0, col = 0; // Cell at (0,0) is fixed
 
@@ -136,7 +137,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void ClearPossibleValues_WhenGameNotInProgress_ThrowsGameNotInProgressException()
     {
         // Arrange
-        var game = SudokuGame.Create(_playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
         // Don't start the game
         int row = 2, col = 2;
 
@@ -152,7 +153,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void MakeMove_ClearsPossibleValues()
     {
         // Arrange
-        var game = SudokuGame.Create(_playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
         game.StartGame();
         int row = 2, col = 2;
         game.AddPossibleValue(row, col, 3);
@@ -171,7 +172,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void RemovePossibleValue_FromCellWithPossibleValue_RemovesPossibleValue()
     {
         // Arrange
-        var game = SudokuGame.Create(_playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
         game.StartGame();
         int row = 2, col = 2, value = 3;
         game.AddPossibleValue(row, col, value);
@@ -197,7 +198,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void RemovePossibleValue_FromFixedCell_ThrowsCellIsFixedException()
     {
         // Arrange
-        var game = SudokuGame.Create(_playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
         game.StartGame();
         int row = 0, col = 0, value = 3; // Cell at (0,0) is fixed
 
@@ -213,7 +214,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void RemovePossibleValue_WhenGameNotInProgress_ThrowsGameNotInProgressException()
     {
         // Arrange
-        var game = SudokuGame.Create(_playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
         // Don't start the game
         int row = 2, col = 2, value = 3;
 
@@ -229,7 +230,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void ResetGame_ClearsPossibleValuesForAllNonFixedCells()
     {
         // Arrange
-        var game = SudokuGame.Create(_playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
         game.StartGame();
         game.AddPossibleValue(2, 2, 3);
         game.AddPossibleValue(2, 2, 5);

--- a/src/backend/Tests/Domain/SudokuGameTests.cs
+++ b/src/backend/Tests/Domain/SudokuGameTests.cs
@@ -41,21 +41,70 @@ public class SudokuGameTests : MoqBaseTestByType<SudokuGame>
     public void Create_WithValidParameters_CreatesGameWithCorrectProperties()
     {
         // Arrange
-        var playerAlias = PlayerAlias.Create("TestPlayer");
+        var profileId = ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Medium;
         var cells = GenerateEmptyCells();
 
         // Act
-        var sut = SudokuGame.Create(playerAlias, difficulty, cells);
+        var sut = SudokuGame.Create(profileId, displayName, difficulty, cells);
 
         // Assert
         sut.Id.Should().NotBeNull();
-        sut.PlayerAlias.Should().Be(playerAlias);
+        sut.ProfileId.Should().Be(profileId);
+        sut.DisplayName.Should().Be(displayName);
         sut.Difficulty.Should().Be(difficulty);
         sut.Status.Should().Be(GameStatusEnum.NotStarted);
         sut.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(1));
         sut.GetCells().Count.Should().Be(81);
         sut.DomainEvents.Should().ContainSingle(e => e is GameCreatedEvent);
+    }
+
+    [Fact]
+    public void Create_SetsProfileIdProperty()
+    {
+        // Arrange
+        var profileId = ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
+        var cells = GenerateEmptyCells();
+
+        // Act
+        var sut = SudokuGame.Create(profileId, displayName, GameDifficulty.Easy, cells);
+
+        // Assert
+        sut.ProfileId.Should().Be(profileId);
+    }
+
+    [Fact]
+    public void Create_SetsDisplayNameProperty()
+    {
+        // Arrange
+        var profileId = ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
+        var cells = GenerateEmptyCells();
+
+        // Act
+        var sut = SudokuGame.Create(profileId, displayName, GameDifficulty.Easy, cells);
+
+        // Assert
+        sut.DisplayName.Should().Be(displayName);
+    }
+
+    [Fact]
+    public void Create_RaisesGameCreatedEvent_WithProfileId()
+    {
+        // Arrange
+        var profileId = ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
+        var cells = GenerateEmptyCells();
+
+        // Act
+        var sut = SudokuGame.Create(profileId, displayName, GameDifficulty.Easy, cells);
+
+        // Assert
+        var evt = sut.DomainEvents.OfType<GameCreatedEvent>().Single();
+        evt.ProfileId.Should().Be(profileId);
+        evt.DisplayName.Should().Be(displayName);
     }
 
     [Fact]
@@ -334,11 +383,12 @@ public class SudokuGameTests : MoqBaseTestByType<SudokuGame>
 
     private SudokuGame CreateGameWithCells(IEnumerable<Cell> specificCells)
     {
-        var playerAlias = PlayerAlias.Create("TestPlayer");
+        var profileId = ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Medium;
-        
+
         var cells = GenerateEmptyCells().ToList();
-        
+
         foreach (var cell in specificCells)
         {
             var index = cells.FindIndex(c => c.Row == cell.Row && c.Column == cell.Column);
@@ -347,8 +397,8 @@ public class SudokuGameTests : MoqBaseTestByType<SudokuGame>
                 cells[index] = cell;
             }
         }
-        
-        return SudokuGame.Create(playerAlias, difficulty, cells);
+
+        return SudokuGame.Create(profileId, displayName, difficulty, cells);
     }
 
     private IEnumerable<Cell> GenerateEmptyCells()

--- a/src/backend/Tests/Helpers/Builders/SudokuGameGenerator.cs
+++ b/src/backend/Tests/Helpers/Builders/SudokuGameGenerator.cs
@@ -1,4 +1,4 @@
-﻿using AutoFixture.Kernel;
+using AutoFixture.Kernel;
 using Sudoku.Domain.Entities;
 using Sudoku.Domain.ValueObjects;
 using UnitTests.Helpers.Factories;
@@ -13,6 +13,7 @@ public class SudokuGameGenerator : ISpecimenBuilder
         {
             var cells = CellsFactory.CreateEmptyCells();
             return SudokuGame.Create(
+                ProfileId.New(),
                 context.Create<PlayerAlias>(),
                 context.Create<GameDifficulty>(),
                 cells

--- a/src/backend/Tests/Helpers/Factories/GameFactory.cs
+++ b/src/backend/Tests/Helpers/Factories/GameFactory.cs
@@ -1,4 +1,4 @@
-﻿using Sudoku.Domain.Entities;
+using Sudoku.Domain.Entities;
 using Sudoku.Domain.ValueObjects;
 
 namespace UnitTests.Helpers.Factories;
@@ -16,11 +16,9 @@ public static class GameFactory
         return game;
     }
 
-    public static SudokuGame CreateGameForPlayer(PlayerAlias playerAlias)
+    public static SudokuGame CreateGameForPlayer(ProfileId profileId, PlayerAlias displayName)
     {
-        var game = CreateGame(CellsFactory.CreateIncompleteCells(), playerAlias: playerAlias);
-
-        return game;
+        return CreateGame(CellsFactory.CreateIncompleteCells(), profileId: profileId, displayName: displayName);
     }
 
     public static SudokuGame CreateEmptyGame()
@@ -72,12 +70,14 @@ public static class GameFactory
         return game;
     }
 
-    private static SudokuGame CreateGame(IEnumerable<Cell> cells, PlayerAlias? playerAlias = null, GameDifficulty? difficulty = null)
+    private static SudokuGame CreateGame(IEnumerable<Cell> cells, ProfileId? profileId = null, PlayerAlias? displayName = null, GameDifficulty? difficulty = null)
     {
         var withDifficulty = difficulty ?? GameDifficulty.Easy;
-        var withPlayerAlias = playerAlias ?? PlayerAlias.Create("DefaultPlayer");
+        var withProfileId = profileId ?? ProfileId.New();
+        var withDisplayName = displayName ?? PlayerAlias.Create("DefaultPlayer");
         var game = SudokuGame.Create(
-            withPlayerAlias,
+            withProfileId,
+            withDisplayName,
             withDifficulty,
             cells);
 

--- a/src/backend/Tests/Helpers/Factories/GameModelFactory.cs
+++ b/src/backend/Tests/Helpers/Factories/GameModelFactory.cs
@@ -9,7 +9,8 @@ public class GameModelFactory
     private static readonly GameModelFactory Instance = null!;
 
     private string _id = Guid.NewGuid().ToString();
-    private string _playerAlias = string.Empty;
+    private string _profileId = string.Empty;
+    private string _displayName = string.Empty;
     private GameDifficulty _difficulty = GameDifficulty.Easy;
     private string _gameStatus = GameStatus.NotStarted;
     private List<CellModel> _cells = GenerateCellModels(GameDifficulty.Easy, true);
@@ -66,9 +67,15 @@ public class GameModelFactory
         return this;
     }
 
-    public GameModelFactory WithPlayerAlias(string playerAlias)
+    public GameModelFactory WithProfileId(string profileId)
     {
-        _playerAlias = playerAlias;
+        _profileId = profileId;
+        return this;
+    }
+
+    public GameModelFactory WithDisplayName(string displayName)
+    {
+        _displayName = displayName;
         return this;
     }
 
@@ -98,7 +105,8 @@ public class GameModelFactory
         CreatedAt = _createdAt,
         Difficulty = _difficulty,
         PausedAt = _pausedAt,
-        PlayerAlias = _playerAlias,
+        ProfileId = _profileId,
+        DisplayName = _displayName,
         StartedAt = _startedAt,
         Statistics = _statistics,
         Status = _gameStatus,

--- a/src/backend/Tests/Infrastructure/EventHandling/GameCreatedEventHandlersTests.cs
+++ b/src/backend/Tests/Infrastructure/EventHandling/GameCreatedEventHandlersTests.cs
@@ -11,9 +11,10 @@ public class GameCreatedEventHandlerTests : MoqBaseTestByAbstraction<GameCreated
     {
         // Arrange
         var gameId = GameId.New();
-        var playerAlias = PlayerAlias.Create("TestPlayer");
+        var profileId = ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Medium;
-        var domainEvent = new GameCreatedEvent(gameId, playerAlias, difficulty);
+        var domainEvent = new GameCreatedEvent(gameId, profileId, displayName, difficulty);
 
         var sut = ResolveSut();
 
@@ -29,9 +30,10 @@ public class GameCreatedEventHandlerTests : MoqBaseTestByAbstraction<GameCreated
     {
         // Arrange
         var gameId = GameId.New();
-        var playerAlias = PlayerAlias.Create("TestPlayer");
+        var profileId = ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Hard;
-        var domainEvent = new GameCreatedEvent(gameId, playerAlias, difficulty);
+        var domainEvent = new GameCreatedEvent(gameId, profileId, displayName, difficulty);
 
         var sut = ResolveSut();
 
@@ -47,9 +49,10 @@ public class GameCreatedEventHandlerTests : MoqBaseTestByAbstraction<GameCreated
     {
         // Arrange
         var gameId = GameId.New();
-        var playerAlias = PlayerAlias.Create("TestPlayer");
+        var profileId = ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Expert;
-        var domainEvent = new GameCreatedEvent(gameId, playerAlias, difficulty);
+        var domainEvent = new GameCreatedEvent(gameId, profileId, displayName, difficulty);
 
         var sut = ResolveSut();
 
@@ -61,13 +64,14 @@ public class GameCreatedEventHandlerTests : MoqBaseTestByAbstraction<GameCreated
     }
 
     [Fact]
-    public async Task HandleAsync_WithDifferentPlayerAlias_LogsCorrectPlayerAlias()
+    public async Task HandleAsync_WithDifferentDisplayName_LogsCorrectDisplayName()
     {
         // Arrange
         var gameId = GameId.New();
-        var playerAlias = PlayerAlias.Create("DifferentPlayer");
+        var profileId = ProfileId.New();
+        var displayName = PlayerAlias.Create("DifferentPlayer");
         var difficulty = GameDifficulty.Easy;
-        var domainEvent = new GameCreatedEvent(gameId, playerAlias, difficulty);
+        var domainEvent = new GameCreatedEvent(gameId, profileId, displayName, difficulty);
 
         var sut = ResolveSut();
 

--- a/src/backend/Tests/Infrastructure/Repositories/AzureBlobGameRepositoryTests.cs
+++ b/src/backend/Tests/Infrastructure/Repositories/AzureBlobGameRepositoryTests.cs
@@ -32,15 +32,15 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
     public async Task CountBySpecificationAsync_WithMatchingGames_ReturnsCorrectCount()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var game1 = CreateTestGame(playerAlias);
-        var game2 = CreateTestGame(playerAlias);
-        var game3 = CreateTestGame(Container.Create<PlayerAlias>());
+        var profileId = ProfileId.New();
+        var game1 = CreateTestGame(profileId);
+        var game2 = CreateTestGame(profileId);
+        var game3 = CreateTestGame(ProfileId.New());
         var allGames = new[] { game1, game2, game3 };
-        
+
         SetupGetAllGamesAsync(allGames);
 
-        var specification = new GameByPlayerSpecification(playerAlias);
+        var specification = new GameByProfileIdSpecification(profileId);
         var sut = ResolveSut();
 
         // Act
@@ -54,14 +54,14 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
     public async Task DeleteAsync_WithExistingGame_DeletesGame()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
+        var profileId = ProfileId.New();
         var gameId = GameId.New();
-        var blobName1 = GetBlobPath(playerAlias.Value, gameId, "00001");
-        var blobName2 = GetBlobPath(playerAlias.Value, gameId, "00002");
+        var blobName1 = GetBlobPath(profileId.ToString(), gameId, "00001");
+        var blobName2 = GetBlobPath(profileId.ToString(), gameId, "00002");
         var matchingPrefix = $"*/{gameId.Value}/";
-        
+
         var blobNames = new[] { blobName1, blobName2 };
-        
+
         _mockStorageService
             .Setup(x => x.GetBlobNamesAsync(ContainerName, matchingPrefix))
             .Returns(blobNames.ToAsyncEnumerable());
@@ -80,18 +80,18 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
     public async Task DeleteAsync_WhenStorageServiceThrows_RethrowsException()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
+        var profileId = ProfileId.New();
         var gameId = GameId.New();
-        var blobName = GetBlobPath(playerAlias.Value, gameId, "00001");
+        var blobName = GetBlobPath(profileId.ToString(), gameId, "00001");
         var matchingPrefix = $"*/{gameId.Value}/";
         var expectedException = new InvalidOperationException("Storage error");
-        
+
         var blobNames = new[] { blobName };
-        
+
         _mockStorageService
             .Setup(x => x.GetBlobNamesAsync(ContainerName, matchingPrefix))
             .Returns(blobNames.ToAsyncEnumerable());
-        
+
         _mockStorageService
             .Setup(x => x.DeleteAsync(ContainerName, blobName))
             .ThrowsAsync(expectedException);
@@ -123,13 +123,13 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
     public async Task ExistsAsync_WithExistingGame_ReturnsTrue()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
+        var profileId = ProfileId.New();
         var gameId = GameId.New();
-        var blobName = GetBlobPath(playerAlias.Value, gameId, "00001");
+        var blobName = GetBlobPath(profileId.ToString(), gameId, "00001");
         var matchingPrefix = $"*/{gameId.Value}/";
-        
+
         var blobNames = new[] { blobName };
-        
+
         _mockStorageService
             .Setup(x => x.GetBlobNamesAsync(ContainerName, matchingPrefix))
             .Returns(blobNames.ToAsyncEnumerable());
@@ -150,7 +150,7 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
         var gameId = GameId.New();
         var matchingPrefix = $"*/{gameId.Value}/";
         var emptyBlobNames = Array.Empty<string>();
-        
+
         _mockStorageService
             .Setup(x => x.GetBlobNamesAsync(ContainerName, matchingPrefix))
             .Returns(emptyBlobNames.ToAsyncEnumerable());
@@ -171,7 +171,7 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
         var gameId = GameId.New();
         var matchingPrefix = $"*/{gameId.Value}/";
         var expectedException = new InvalidOperationException("Storage error");
-        
+
         _mockStorageService
             .Setup(x => x.GetBlobNamesAsync(ContainerName, matchingPrefix))
             .Throws(expectedException);
@@ -190,15 +190,15 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
     public async Task GetAverageCompletionTimeAsync_WithNoCompletedGames_ReturnsZero()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
+        var profileId = ProfileId.New();
         var allGames = Array.Empty<SudokuGame>();
-        
+
         SetupGetAllGamesAsync(allGames);
 
         var sut = ResolveSut();
 
         // Act
-        var result = await sut.GetAverageCompletionTimeAsync(playerAlias);
+        var result = await sut.GetAverageCompletionTimeAsync(profileId);
 
         // Assert
         result.Should().Be(TimeSpan.Zero);
@@ -208,22 +208,22 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
     public async Task GetByIdAsync_WithExistingGame_ReturnsGame()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var game = CreateTestGame(playerAlias);
+        var profileId = ProfileId.New();
+        var game = CreateTestGame(profileId);
         var gameId = game.Id;
         var matchingPrefix = $"*/{gameId.Value}/";
-        var blobName = GetBlobPath(playerAlias.Value, gameId, "00001");
-        
+        var blobName = GetBlobPath(profileId.ToString(), gameId, "00001");
+
         var blobNames = new[] { blobName };
-        
+
         _mockStorageService
             .Setup(x => x.GetBlobNamesAsync(ContainerName, matchingPrefix))
             .Returns(blobNames.ToAsyncEnumerable());
-            
+
         _mockStorageService
-            .Setup(x => x.GetBlobNamesAsync(ContainerName, $"{playerAlias.Value}/{gameId.Value}/"))
+            .Setup(x => x.GetBlobNamesAsync(ContainerName, $"{profileId}/{gameId.Value}/"))
             .Returns(blobNames.ToAsyncEnumerable());
-            
+
         _mockStorageService
             .Setup(x => x.LoadAsync<SudokuGame>(ContainerName, blobName))
             .ReturnsAsync(game);
@@ -236,7 +236,7 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
         // Assert
         result.Should().NotBeNull();
         result!.Id.Should().Be(game.Id);
-        result.PlayerAlias.Should().Be(game.PlayerAlias);
+        result.DisplayName.Should().Be(game.DisplayName);
     }
 
     [Fact]
@@ -246,7 +246,7 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
         var gameId = GameId.New();
         var matchingPrefix = $"*/{gameId.Value}/";
         var emptyBlobNames = Array.Empty<string>();
-        
+
         _mockStorageService
             .Setup(x => x.GetBlobNamesAsync(ContainerName, matchingPrefix))
             .Returns(emptyBlobNames.ToAsyncEnumerable());
@@ -267,7 +267,7 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
         var gameId = GameId.New();
         var matchingPrefix = $"*/{gameId.Value}/";
         var expectedException = new InvalidOperationException("Storage error");
-        
+
         _mockStorageService
             .Setup(x => x.GetBlobNamesAsync(ContainerName, matchingPrefix))
             .Throws(expectedException);
@@ -283,35 +283,35 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
     }
 
     [Fact]
-    public async Task GetByPlayerAsync_WithExistingPlayer_ReturnsGamesOrderedByCreatedAt()
+    public async Task GetByProfileIdAsync_WithExistingProfile_ReturnsGamesOrderedByCreatedAt()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var game1 = CreateTestGame(playerAlias);
-        var game2 = CreateTestGame(playerAlias);
-        var prefixPath = $"{playerAlias.Value}/";
-        
-        var blobName1 = GetBlobPath(playerAlias.Value, game1.Id, "00001");
-        var blobName2 = GetBlobPath(playerAlias.Value, game2.Id, "00001");
+        var profileId = ProfileId.New();
+        var game1 = CreateTestGame(profileId);
+        var game2 = CreateTestGame(profileId);
+        var prefixPath = $"{profileId}/";
+
+        var blobName1 = GetBlobPath(profileId.ToString(), game1.Id, "00001");
+        var blobName2 = GetBlobPath(profileId.ToString(), game2.Id, "00001");
         var blobNames = new[] { blobName1, blobName2 };
-        
+
         _mockStorageService
             .Setup(x => x.GetBlobNamesAsync(ContainerName, prefixPath))
             .Returns(blobNames.ToAsyncEnumerable());
-            
+
         // Setup for GetLatestRevisionAsync
         _mockStorageService
-            .Setup(x => x.GetBlobNamesAsync(ContainerName, $"{playerAlias.Value}/{game1.Id.Value}/"))
+            .Setup(x => x.GetBlobNamesAsync(ContainerName, $"{profileId}/{game1.Id.Value}/"))
             .Returns(new[] { blobName1 }.ToAsyncEnumerable());
-            
+
         _mockStorageService
-            .Setup(x => x.GetBlobNamesAsync(ContainerName, $"{playerAlias.Value}/{game2.Id.Value}/"))
+            .Setup(x => x.GetBlobNamesAsync(ContainerName, $"{profileId}/{game2.Id.Value}/"))
             .Returns(new[] { blobName2 }.ToAsyncEnumerable());
-        
+
         _mockStorageService
             .Setup(x => x.LoadAsync<SudokuGame>(ContainerName, blobName1))
             .ReturnsAsync(game1);
-            
+
         _mockStorageService
             .Setup(x => x.LoadAsync<SudokuGame>(ContainerName, blobName2))
             .ReturnsAsync(game2);
@@ -319,22 +319,22 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
         var sut = ResolveSut();
 
         // Act
-        var result = await sut.GetByPlayerAsync(playerAlias);
+        var result = await sut.GetByProfileIdAsync(profileId);
 
         // Assert
         result.Should().HaveCount(2);
-        result.Should().AllSatisfy(g => g.PlayerAlias.Should().Be(playerAlias));
+        result.Should().AllSatisfy(g => g.ProfileId.Should().Be(profileId));
         result.Should().BeInDescendingOrder(g => g.CreatedAt);
     }
 
     [Fact]
-    public async Task GetByPlayerAsync_WithNonExistingPlayer_ReturnsEmptyCollection()
+    public async Task GetByProfileIdAsync_WithNonExistingProfile_ReturnsEmptyCollection()
     {
         // Arrange
-        var playerAlias = PlayerAlias.Create("NonExistingPlayer");
-        var expectedPrefix = $"{playerAlias.Value}/";
+        var profileId = ProfileId.New();
+        var expectedPrefix = $"{profileId}/";
         var emptyBlobNames = Array.Empty<string>();
-        
+
         _mockStorageService
             .Setup(x => x.GetBlobNamesAsync(ContainerName, expectedPrefix))
             .Returns(emptyBlobNames.ToAsyncEnumerable());
@@ -342,20 +342,20 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
         var sut = ResolveSut();
 
         // Act
-        var result = await sut.GetByPlayerAsync(playerAlias);
+        var result = await sut.GetByProfileIdAsync(profileId);
 
         // Assert
         result.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task GetByPlayerAsync_WhenStorageServiceThrows_RethrowsException()
+    public async Task GetByProfileIdAsync_WhenStorageServiceThrows_RethrowsException()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var expectedPrefix = $"{playerAlias.Value}/";
+        var profileId = ProfileId.New();
+        var expectedPrefix = $"{profileId}/";
         var expectedException = new InvalidOperationException("Storage error");
-        
+
         _mockStorageService
             .Setup(x => x.GetBlobNamesAsync(ContainerName, expectedPrefix))
             .Throws(expectedException);
@@ -363,7 +363,7 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
         var sut = ResolveSut();
 
         // Act
-        Func<Task> act = async () => await sut.GetByPlayerAsync(playerAlias);
+        Func<Task> act = async () => await sut.GetByProfileIdAsync(profileId);
 
         // Assert
         await act.Should().ThrowAsync<InvalidOperationException>()
@@ -371,41 +371,41 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
     }
 
     [Fact]
-    public async Task GetByPlayerAndStatusAsync_WithMatchingGames_ReturnsFilteredGames()
+    public async Task GetByProfileIdAndStatusAsync_WithMatchingGames_ReturnsFilteredGames()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
+        var profileId = ProfileId.New();
         var status = GameStatusEnum.InProgress;
-        var game1 = CreateTestGame(playerAlias);
-        var game2 = CreateTestGame(playerAlias);
+        var game1 = CreateTestGame(profileId);
+        var game2 = CreateTestGame(profileId);
         game2.StartGame(); // Set to InProgress
         var allGames = new[] { game1, game2 };
-        
+
         SetupGetAllGamesAsync(allGames);
 
         var sut = ResolveSut();
 
         // Act
-        var result = await sut.GetByPlayerAndStatusAsync(playerAlias, status);
+        var result = await sut.GetByProfileIdAndStatusAsync(profileId, status);
 
         // Assert
         result.Should().HaveCount(1);
         result.First().Status.Should().Be(status);
-        result.First().PlayerAlias.Should().Be(playerAlias);
+        result.First().ProfileId.Should().Be(profileId);
     }
 
     [Fact]
     public async Task GetBySpecificationAsync_WithValidSpecification_ReturnsFilteredGames()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var game1 = CreateTestGame(playerAlias);
-        var game2 = CreateTestGame(PlayerAlias.Create("AnotherPlayer"));
+        var profileId = ProfileId.New();
+        var game1 = CreateTestGame(profileId);
+        var game2 = CreateTestGame(ProfileId.New());
         var allGames = new[] { game1, game2 };
-        
+
         SetupGetAllGamesAsync(allGames);
 
-        var specification = new GameByPlayerSpecification(playerAlias);
+        var specification = new GameByProfileIdSpecification(profileId);
         var sut = ResolveSut();
 
         // Act
@@ -413,20 +413,20 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
 
         // Assert
         result.Should().HaveCount(1);
-        result.First().PlayerAlias.Should().Be(playerAlias);
+        result.First().ProfileId.Should().Be(profileId);
     }
 
     [Fact]
     public async Task GetSingleBySpecificationAsync_WithMatchingGame_ReturnsFirstGame()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var game = CreateTestGame(playerAlias);
+        var profileId = ProfileId.New();
+        var game = CreateTestGame(profileId);
         var allGames = new[] { game };
-        
+
         SetupGetAllGamesAsync(allGames);
 
-        var specification = new GameByPlayerSpecification(playerAlias);
+        var specification = new GameByProfileIdSpecification(profileId);
         var sut = ResolveSut();
 
         // Act
@@ -434,19 +434,19 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
 
         // Assert
         result.Should().NotBeNull();
-        result!.PlayerAlias.Should().Be(playerAlias);
+        result!.ProfileId.Should().Be(profileId);
     }
 
     [Fact]
     public async Task GetSingleBySpecificationAsync_WithNoMatchingGame_ReturnsNull()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
+        var profileId = ProfileId.New();
         var allGames = Array.Empty<SudokuGame>();
-        
+
         SetupGetAllGamesAsync(allGames);
 
-        var specification = new GameByPlayerSpecification(playerAlias);
+        var specification = new GameByProfileIdSpecification(profileId);
         var sut = ResolveSut();
 
         // Act
@@ -465,7 +465,7 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
         {
             games[i] = CreateTestGame();
         }
-        
+
         SetupGetAllGamesAsync(games);
 
         var sut = ResolveSut();
@@ -482,17 +482,17 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
     public async Task GetCompletedGamesAsync_WithCompletedGames_ReturnsOnlyCompletedGames()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var game1 = CreateTestGame(playerAlias);
-        var game2 = CreateTestGame(playerAlias);
+        var profileId = ProfileId.New();
+        var game1 = CreateTestGame(profileId);
+        var game2 = CreateTestGame(profileId);
         var allGames = new[] { game1, game2 };
-        
+
         SetupGetAllGamesAsync(allGames);
 
         var sut = ResolveSut();
 
         // Act
-        var result = await sut.GetCompletedGamesAsync(playerAlias);
+        var result = await sut.GetCompletedGamesAsync(profileId);
 
         // Assert
         result.Should().AllSatisfy(g => g.Status.Should().Be(GameStatusEnum.Completed));
@@ -506,7 +506,7 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
         var game2 = CreateTestGame(difficulty: GameDifficulty.Medium);
         var game3 = CreateTestGame(difficulty: GameDifficulty.Easy);
         var allGames = new[] { game1, game2, game3 };
-        
+
         SetupGetAllGamesAsync(allGames);
 
         var sut = ResolveSut();
@@ -527,7 +527,7 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
         var game2 = CreateTestGame();
         game2.StartGame();
         var allGames = new[] { game1, game2 };
-        
+
         SetupGetAllGamesAsync(allGames);
 
         var sut = ResolveSut();
@@ -548,7 +548,7 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
         var game2 = CreateTestGame();
         var game3 = CreateTestGame();
         var allGames = new[] { game1, game2, game3 };
-        
+
         SetupGetAllGamesAsync(allGames);
 
         var sut = ResolveSut();
@@ -564,18 +564,18 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
     public async Task GetTotalGamesCountAsync_WithPlayerFilter_ReturnsPlayerGamesCount()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var game1 = CreateTestGame(playerAlias);
-        var game2 = CreateTestGame(playerAlias);
-        var game3 = CreateTestGame(PlayerAlias.Create("AnotherPlayer"));
+        var profileId = ProfileId.New();
+        var game1 = CreateTestGame(profileId);
+        var game2 = CreateTestGame(profileId);
+        var game3 = CreateTestGame(ProfileId.New());
         var allGames = new[] { game1, game2, game3 };
-        
+
         SetupGetAllGamesAsync(allGames);
 
         var sut = ResolveSut();
 
         // Act
-        var result = await sut.GetTotalGamesCountAsync(playerAlias);
+        var result = await sut.GetTotalGamesCountAsync(profileId);
 
         // Assert
         result.Should().Be(2);
@@ -585,17 +585,17 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
     public async Task GetCompletedGamesCountAsync_WithCompletedGames_ReturnsCorrectCount()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var game1 = CreateTestGame(playerAlias);
-        var game2 = CreateTestGame(playerAlias);
+        var profileId = ProfileId.New();
+        var game1 = CreateTestGame(profileId);
+        var game2 = CreateTestGame(profileId);
         var allGames = new[] { game1, game2 };
-        
+
         SetupGetAllGamesAsync(allGames);
 
         var sut = ResolveSut();
 
         // Act
-        var result = await sut.GetCompletedGamesCountAsync(playerAlias);
+        var result = await sut.GetCompletedGamesCountAsync(profileId);
 
         // Assert
         result.Should().Be(0); // No games are actually completed in this test
@@ -605,16 +605,16 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
     public async Task SaveAsync_WhenStorageServiceThrows_RethrowsException()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var game = CreateTestGame(playerAlias);
-        var expectedBlobName = GetBlobPath(playerAlias.Value, game.Id, "00001");
+        var profileId = ProfileId.New();
+        var game = CreateTestGame(profileId);
+        var expectedBlobName = GetBlobPath(profileId.ToString(), game.Id, "00001");
         var expectedException = new InvalidOperationException("Storage error");
-        
+
         // Setup for GetNextRevisionBlobNameAsync
         _mockStorageService
-            .Setup(x => x.GetBlobNamesAsync(ContainerName, $"{playerAlias.Value}/{game.Id.Value}/"))
+            .Setup(x => x.GetBlobNamesAsync(ContainerName, $"{profileId}/{game.Id.Value}/"))
             .Returns(Array.Empty<string>().ToAsyncEnumerable());
-        
+
         _mockStorageService
             .Setup(x => x.SaveAsync(ContainerName, expectedBlobName, game))
             .ThrowsAsync(expectedException);
@@ -633,13 +633,13 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
     public async Task SaveAsync_WithValidGame_SavesGameSuccessfully()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var game = CreateTestGame(playerAlias);
-        var expectedBlobName = GetBlobPath(playerAlias.Value, game.Id, "00001");
-        
+        var profileId = ProfileId.New();
+        var game = CreateTestGame(profileId);
+        var expectedBlobName = GetBlobPath(profileId.ToString(), game.Id, "00001");
+
         // Setup for GetNextRevisionBlobNameAsync
         _mockStorageService
-            .Setup(x => x.GetBlobNamesAsync(ContainerName, $"{playerAlias.Value}/{game.Id.Value}/"))
+            .Setup(x => x.GetBlobNamesAsync(ContainerName, $"{profileId}/{game.Id.Value}/"))
             .Returns(Array.Empty<string>().ToAsyncEnumerable());
 
         var sut = ResolveSut();
@@ -655,14 +655,14 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
     public async Task SaveAsync_WithExistingGame_CreatesNewRevision()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
-        var game = CreateTestGame(playerAlias);
-        var existingBlobName = GetBlobPath(playerAlias.Value, game.Id, "00001");
-        var expectedBlobName = GetBlobPath(playerAlias.Value, game.Id, "00002");
-        
+        var profileId = ProfileId.New();
+        var game = CreateTestGame(profileId);
+        var existingBlobName = GetBlobPath(profileId.ToString(), game.Id, "00001");
+        var expectedBlobName = GetBlobPath(profileId.ToString(), game.Id, "00002");
+
         // Setup for GetNextRevisionBlobNameAsync
         _mockStorageService
-            .Setup(x => x.GetBlobNamesAsync(ContainerName, $"{playerAlias.Value}/{game.Id.Value}/"))
+            .Setup(x => x.GetBlobNamesAsync(ContainerName, $"{profileId}/{game.Id.Value}/"))
             .Returns(new[] { existingBlobName }.ToAsyncEnumerable());
 
         var sut = ResolveSut();
@@ -674,44 +674,45 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
         _mockStorageService.Verify(x => x.SaveAsync(ContainerName, expectedBlobName, game), Times.Once);
     }
 
-    private SudokuGame CreateTestGame(PlayerAlias? playerAlias = null, GameDifficulty? difficulty = null)
+    private SudokuGame CreateTestGame(ProfileId? profileId = null, GameDifficulty? difficulty = null)
     {
-        var alias = playerAlias ?? Container.Create<PlayerAlias>();
+        var pid = profileId ?? ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
         var diff = difficulty ?? GameDifficulty.Medium;
         var cells = CellsFactory.CreateEmptyCells();
-        return SudokuGame.Create(alias, diff, cells);
+        return SudokuGame.Create(pid, displayName, diff, cells);
     }
 
-    private static string GetBlobPath(string playerAlias, GameId gameId, string revision)
+    private static string GetBlobPath(string profileId, GameId gameId, string revision)
     {
-        return $"{playerAlias}/{gameId.Value}/{revision}.json";
+        return $"{profileId}/{gameId.Value}/{revision}.json";
     }
 
     private void SetupGetAllGamesAsync(SudokuGame[] games)
     {
         var allBlobNames = new List<string>();
-        var gameInfos = new Dictionary<string, (string PlayerAlias, GameId GameId, string BlobName)>();
-        
+        var gameInfos = new Dictionary<string, (string ProfileId, GameId GameId, string BlobName)>();
+
         for (var i = 0; i < games.Length; i++)
         {
             var game = games[i];
-            var playerAlias = game.PlayerAlias.Value;
+            var profileId = game.ProfileId.ToString();
             var gameId = game.Id;
-            var blobName = GetBlobPath(playerAlias, gameId, "00001");
-            
+            var blobName = GetBlobPath(profileId, gameId, "00001");
+
             allBlobNames.Add(blobName);
-            gameInfos[blobName] = (playerAlias, gameId, blobName);
-            
+            gameInfos[blobName] = (profileId, gameId, blobName);
+
             // Setup for GetLatestRevisionAsync
             _mockStorageService
-                .Setup(x => x.GetBlobNamesAsync(ContainerName, $"{playerAlias}/{gameId.Value}/"))
+                .Setup(x => x.GetBlobNamesAsync(ContainerName, $"{profileId}/{gameId.Value}/"))
                 .Returns(new[] { blobName }.ToAsyncEnumerable());
-                
+
             _mockStorageService
                 .Setup(x => x.LoadAsync<SudokuGame>(ContainerName, blobName))
                 .ReturnsAsync(game);
         }
-        
+
         _mockStorageService
             .Setup(x => x.GetBlobNamesAsync(ContainerName, null))
             .Returns(allBlobNames.ToAsyncEnumerable());

--- a/src/backend/Tests/Infrastructure/Repositories/CosmosDbGameRepositoryTests.cs
+++ b/src/backend/Tests/Infrastructure/Repositories/CosmosDbGameRepositoryTests.cs
@@ -75,13 +75,15 @@ public class CosmosDbGameRepositoryTests : MoqBaseTestByAbstraction<CosmosDbGame
     {
         // Arrange
         var gameId = GameId.New();
-        var playerAlias = PlayerAlias.Create("TestPlayer");
+        var profileId = ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Easy;
         var gameDocument = new SudokuGameDocument
         {
             Id = gameId.Value.ToString(),
             GameId = gameId.Value.ToString(),
-            PlayerAlias = playerAlias.Value,
+            ProfileId = profileId.ToString(),
+            DisplayName = displayName.Value,
             Difficulty = difficulty,
             Status = GameStatusEnum.NotStarted,
             Cells = [],
@@ -97,22 +99,24 @@ public class CosmosDbGameRepositoryTests : MoqBaseTestByAbstraction<CosmosDbGame
         // Assert
         result.Should().NotBeNull();
         result!.Id.Value.ToString().Should().Be(gameId.Value.ToString());
-        result.PlayerAlias.Should().Be(playerAlias);
+        result.DisplayName.Should().Be(displayName);
         result.Difficulty.Should().Be(difficulty);
     }
 
     [Fact]
-    public async Task GetByPlayerAsync_WithMatchingGames_ShouldReturnPlayerGames()
+    public async Task GetByProfileIdAsync_WithMatchingGames_ShouldReturnProfileGames()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
+        var profileId = ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
         var documents = new List<SudokuGameDocument>
         {
             new()
             {
                 Id = Guid.NewGuid().ToString(),
                 GameId = Guid.NewGuid().ToString(),
-                PlayerAlias = playerAlias.Value,
+                ProfileId = profileId.ToString(),
+                DisplayName = displayName.Value,
                 Difficulty = GameDifficulty.Easy,
                 Status = GameStatusEnum.NotStarted,
                 Cells = [],
@@ -120,40 +124,42 @@ public class CosmosDbGameRepositoryTests : MoqBaseTestByAbstraction<CosmosDbGame
             },
             new()
             {
-                Id = Guid.NewGuid().ToString(), 
+                Id = Guid.NewGuid().ToString(),
                 GameId = Guid.NewGuid().ToString(),
-                PlayerAlias = playerAlias.Value,
+                ProfileId = profileId.ToString(),
+                DisplayName = displayName.Value,
                 Difficulty = GameDifficulty.Medium,
                 Status = GameStatusEnum.InProgress,
                 Cells = [],
                 CreatedAt = DateTime.UtcNow
             }
         };
-        _mockCosmosDbService.GetByPlayerAsyncReturnsDocuments(playerAlias, documents);
+        _mockCosmosDbService.GetByProfileIdAsyncReturnsDocuments(profileId.ToString(), documents);
         var sut = ResolveSut();
 
         // Act
-        var result = await sut.GetByPlayerAsync(playerAlias);
+        var result = await sut.GetByProfileIdAsync(profileId);
 
         // Assert
         result.Should().HaveCount(2);
-        result.Should().AllSatisfy(g => g.PlayerAlias.Should().Be(playerAlias));
+        result.Should().AllSatisfy(g => g.ProfileId.Should().Be(profileId));
     }
 
     [Fact]
     public async Task SaveAsync_ShouldCallUpsertItemAsync()
     {
         // Arrange
-        var playerAlias = Container.Create<PlayerAlias>();
+        var profileId = ProfileId.New();
+        var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Easy;
         var cells = CellsFactory.CreateEmptyCells();
-        var game = SudokuGame.Create(playerAlias, difficulty, cells);
+        var game = SudokuGame.Create(profileId, displayName, difficulty, cells);
         var sut = ResolveSut();
 
         // Act
         await sut.SaveAsync(game);
 
         // Assert
-        _mockCosmosDbService.VerifyUpsertItemAsync(game.Id, playerAlias, difficulty, Times.Once);
+        _mockCosmosDbService.VerifyUpsertItemAsync(game.Id, displayName.Value, difficulty, Times.Once);
     }
 }

--- a/src/backend/Tests/Mocks/MockCosmosDbServiceExtensions.cs
+++ b/src/backend/Tests/Mocks/MockCosmosDbServiceExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Sudoku.Infrastructure.Models;
+using Sudoku.Infrastructure.Models;
 using Sudoku.Infrastructure.Services;
 
 namespace UnitTests.Mocks;
@@ -28,7 +28,7 @@ public static class MockCosmosDbServiceExtensions
                 .ReturnsAsync((SudokuGameDocument?)null);
         }
 
-        public void GetByPlayerAsyncReturnsDocuments(string gameId, IEnumerable<SudokuGameDocument> documents)
+        public void GetByProfileIdAsyncReturnsDocuments(string profileId, IEnumerable<SudokuGameDocument> documents)
         {
             mock
                 .Setup(x => x.QueryItemsAsync<SudokuGameDocument>(It.IsAny<string>(), It.IsAny<IDictionary<string, string>>()))
@@ -42,12 +42,12 @@ public static class MockCosmosDbServiceExtensions
                 It.IsAny<string>()), times);
         }
 
-        public void VerifyUpsertItemAsync(string gameId, string playerAlias, string difficulty, Func<Times> times)
+        public void VerifyUpsertItemAsync(string gameId, string displayName, string difficulty, Func<Times> times)
         {
             mock.Verify(x => x.UpsertItemAsync(
-                    It.Is<SudokuGameDocument>(doc => 
-                        doc.GameId == gameId && 
-                        doc.PlayerAlias == playerAlias && 
+                    It.Is<SudokuGameDocument>(doc =>
+                        doc.GameId == gameId &&
+                        doc.DisplayName == displayName &&
                         doc.Difficulty == difficulty),
                     It.IsAny<string?>()),
                 times);

--- a/src/backend/Tests/Mocks/MockGameManagerExtensions.cs
+++ b/src/backend/Tests/Mocks/MockGameManagerExtensions.cs
@@ -7,12 +7,13 @@ public static class MockGameManagerExtensions
 {
     extension(Mock<IGameManager> mock)
     {
-        public void SetupCreateGameAsync(string alias, string difficulty)
+        public void SetupCreateGameAsync(string profileId, string difficulty)
         {
             var game = new GameModel
             {
                 Id = Guid.NewGuid().ToString(),
-                PlayerAlias = alias,
+                ProfileId = profileId,
+                DisplayName = profileId,
                 Difficulty = difficulty,
                 Status = "New",
                 Statistics = new(),
@@ -23,14 +24,14 @@ public static class MockGameManagerExtensions
                 Cells = []
             };
             mock
-                .Setup(x => x.CreateGameAsync(alias, difficulty))
+                .Setup(x => x.CreateGameAsync(profileId, difficulty))
                 .ReturnsAsync(game);
         }
 
         public void SetupLoadGameAsync(GameModel game)
         {
             mock
-                .Setup(x => x.LoadGameAsync(game.PlayerAlias, It.IsAny<string>()))
+                .Setup(x => x.LoadGameAsync(game.ProfileId, It.IsAny<string>()))
                 .ReturnsAsync(game);
         }
 

--- a/src/backend/Tests/Mocks/MockPlayerManagerExtensions.cs
+++ b/src/backend/Tests/Mocks/MockPlayerManagerExtensions.cs
@@ -15,5 +15,13 @@ public static class MockPlayerManagerExtensions
             mock.Setup(x => x.TryGetPlayerAlias())
                 .ReturnsAsync(alias);
         }
+
+        public void SetupGetCurrentProfileIdAsync(string profileId)
+        {
+            mock.Setup(x => x.GetCurrentProfileIdAsync())
+                .ReturnsAsync(profileId);
+            mock.Setup(x => x.EnsureProfileInitializedAsync())
+                .ReturnsAsync(true);
+        }
     }
 }

--- a/src/frontend/Sudoku.Blazor/Components/Pages/CreateProfile.razor.cs
+++ b/src/frontend/Sudoku.Blazor/Components/Pages/CreateProfile.razor.cs
@@ -23,12 +23,12 @@ public partial class CreateProfile
         _errorMessage = null;
         _hasError = false;
 
-        var normalizedAlias = _model.Alias.Trim().ToLowerInvariant();
+        var trimmedAlias = _model.Alias.Trim();
         _isSubmitting = true;
 
         try
         {
-            var result = await PlayerApiClient.CreateProfileAsync(normalizedAlias);
+            var result = await PlayerApiClient.CreateProfileAsync(trimmedAlias);
 
             if (result.IsSuccess && result.Value != null)
             {

--- a/src/frontend/Sudoku.Blazor/Components/Pages/Game.razor.cs
+++ b/src/frontend/Sudoku.Blazor/Components/Pages/Game.razor.cs
@@ -20,7 +20,7 @@ public partial class Game
     private GameModel CurrentGame => GameManager.Game;
     public CellModel SelectedCell { get; private set; } = new();
     private bool IsPencilMode { get; set; }
-    private string Alias { get; set; } = string.Empty;
+    private string ProfileId { get; set; } = string.Empty;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -55,10 +55,10 @@ public partial class Game
 
     private async Task LoadGameStateAsync()
     {
-        Alias = await PlayerManager.GetCurrentPlayerAsync();
-        Logger.LogInformation("Loading game {PuzzleId} for player {Alias}", PuzzleId, Alias);
-        
-        await GameManager.LoadGameAsync(Alias!, PuzzleId!);
+        ProfileId = await PlayerManager.GetCurrentProfileIdAsync() ?? string.Empty;
+        Logger.LogInformation("Loading game {PuzzleId} for profile {ProfileId}", PuzzleId, ProfileId);
+
+        await GameManager.LoadGameAsync(ProfileId, PuzzleId!);
         await GameManager.StartGameAsync();
         
         Logger.LogInformation("Game state loaded and started for puzzle {PuzzleId}", PuzzleId);
@@ -145,7 +145,7 @@ public partial class Game
 
         if (CurrentGame.IsSolved())
         {
-            Logger.LogInformation("Game {PuzzleId} has been solved by player {Alias}", PuzzleId, Alias);
+            Logger.LogInformation("Game {PuzzleId} has been solved by profile {ProfileId}", PuzzleId, ProfileId);
             await HandleGameCompletion();
         }
 
@@ -154,9 +154,9 @@ public partial class Game
 
     private async Task HandleGameCompletion()
     {
-        Logger.LogInformation("Handling game completion for puzzle {PuzzleId}, player {Alias}", PuzzleId, Alias);
+        Logger.LogInformation("Handling game completion for puzzle {PuzzleId}, profile {ProfileId}", PuzzleId, ProfileId);
         await GameManager.EndSession();
-        await GameManager.DeleteGameAsync(Alias, PuzzleId!);
+        await GameManager.DeleteGameAsync(ProfileId, PuzzleId!);
         NotificationService.NotifyGameEnded();
         Logger.LogInformation("Game completion handled successfully for puzzle {PuzzleId}", PuzzleId);
     }

--- a/src/frontend/Sudoku.Blazor/Components/Pages/GameList.razor.cs
+++ b/src/frontend/Sudoku.Blazor/Components/Pages/GameList.razor.cs
@@ -11,7 +11,7 @@ public partial class GameList
     [Inject] public required IGameManager GameManager { get; set; }
     [Inject] public required ILogger<GameList> Logger { get; set; }
 
-    private string _alias = string.Empty;
+    private string _profileId = string.Empty;
     private List<GameModel>? _games;
     private bool _isLoading;
     private bool _hasError;
@@ -28,7 +28,7 @@ public partial class GameList
             return;
         }
 
-        _alias = profile.Alias;
+        _profileId = profile.ProfileId;
         await LoadGamesAsync();
         StateHasChanged();
     }
@@ -40,12 +40,12 @@ public partial class GameList
 
         try
         {
-            _games = await GameManager.LoadGamesAsync(_alias) ?? [];
-            Logger.LogInformation("Loaded {Count} saved games for player {Alias}", _games.Count, _alias);
+            _games = await GameManager.LoadGamesAsync(_profileId) ?? [];
+            Logger.LogInformation("Loaded {Count} saved games for profile {ProfileId}", _games.Count, _profileId);
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Error loading games for player {Alias}", _alias);
+            Logger.LogError(ex, "Error loading games for profile {ProfileId}", _profileId);
             _hasError = true;
         }
         finally
@@ -62,8 +62,8 @@ public partial class GameList
 
     private async Task DeleteGameAsync(string gameId)
     {
-        Logger.LogInformation("Deleting game {GameId} for player {Alias}", gameId, _alias);
-        await GameManager.DeleteGameAsync(_alias, gameId);
+        Logger.LogInformation("Deleting game {GameId} for profile {ProfileId}", gameId, _profileId);
+        await GameManager.DeleteGameAsync(_profileId, gameId);
         _games = _games?.Where(g => g.Id != gameId).ToList();
         Logger.LogInformation("Successfully deleted game {GameId}", gameId);
         StateHasChanged();

--- a/src/frontend/Sudoku.Blazor/Components/Pages/New.razor.cs
+++ b/src/frontend/Sudoku.Blazor/Components/Pages/New.razor.cs
@@ -20,13 +20,13 @@ public partial class New
 
     private async Task GenerateNewGameAsync()
     {
-        var alias = await PlayerManager.GetCurrentPlayerAsync();
+        var profileId = await PlayerManager.GetCurrentProfileIdAsync();
 
-        Logger.LogInformation("Generating new game with difficulty {Difficulty} for player {PlayerAlias}", Difficulty, alias);
+        Logger.LogInformation("Generating new game with difficulty {Difficulty} for profile {ProfileId}", Difficulty, profileId);
 
-        var gameState = await GameManager.CreateGameAsync(alias, Difficulty);
+        var gameState = await GameManager.CreateGameAsync(profileId, Difficulty);
 
-        Logger.LogInformation("Successfully created game {GameId} for player {PlayerAlias}", gameState.Id, alias);
+        Logger.LogInformation("Successfully created game {GameId} for profile {ProfileId}", gameState.Id, profileId);
 
         Navigation.NavigateTo($"/game/{gameState.Id}");
     }

--- a/src/frontend/Sudoku.Blazor/Components/Pages/Profile.razor.cs
+++ b/src/frontend/Sudoku.Blazor/Components/Pages/Profile.razor.cs
@@ -72,12 +72,12 @@ public partial class Profile
         _editError = null;
         if (_alias == null) return;
 
-        var normalizedAlias = _editModel.NewAlias.Trim().ToLowerInvariant();
+        var aliasName = _editModel.NewAlias.Trim();
         _isSaving = true;
 
         try
         {
-            var result = await PlayerApiClient.UpdateProfileAliasAsync(_alias, normalizedAlias);
+            var result = await PlayerApiClient.UpdateProfileAliasAsync(_alias, aliasName);
 
             if (result.IsSuccess && result.Value != null)
             {

--- a/src/frontend/Sudoku.Blazor/Models/GameModel.cs
+++ b/src/frontend/Sudoku.Blazor/Models/GameModel.cs
@@ -6,7 +6,8 @@ namespace Sudoku.Blazor.Models;
 public class GameModel
 {
     public string Id { get; set; } = string.Empty;
-    public string PlayerAlias { get; set; } = string.Empty;
+    public string ProfileId { get; set; } = string.Empty;
+    public string DisplayName { get; set; } = string.Empty;
     public string Difficulty { get; set; } = string.Empty;
     public string Status { get; set; } = string.Empty;
     public GameStatisticsModel Statistics { get; set; } = new();

--- a/src/frontend/Sudoku.Blazor/Services/Abstractions/IGameStateManager.cs
+++ b/src/frontend/Sudoku.Blazor/Services/Abstractions/IGameStateManager.cs
@@ -9,11 +9,11 @@ public interface IGameStateManager : IGameProvider
 {
     Task AddPossibleValueAsync(int row, int column, int value);
     Task ClearPossibleValuesAsync(int row, int column);
-    Task<GameModel> CreateGameAsync(string alias, string difficulty);
+    Task<GameModel> CreateGameAsync(string profileId, string difficulty);
     Task DeleteGameAsync();
-    Task DeleteGameAsync(string alias, string gameId);
-    Task<GameModel> LoadGameAsync(string alias, string gameId);
-    Task<List<GameModel>> LoadGamesAsync(string alias);
+    Task DeleteGameAsync(string profileId, string gameId);
+    Task<GameModel> LoadGameAsync(string profileId, string gameId);
+    Task<List<GameModel>> LoadGamesAsync(string profileId);
     Task RemovePossibleValueAsync(int row, int column, int value);
     Task<GameModel> ResetGameAsync();
     Task SaveGameAsync();

--- a/src/frontend/Sudoku.Blazor/Services/Abstractions/IPlayerManager.cs
+++ b/src/frontend/Sudoku.Blazor/Services/Abstractions/IPlayerManager.cs
@@ -5,6 +5,7 @@ namespace Sudoku.Blazor.Services.Abstractions;
 public interface IPlayerManager
 {
     Task<string?> GetCurrentPlayerAsync();
+    Task<string?> GetCurrentProfileIdAsync();
     Task SetCurrentPlayerAsync(string alias);
     Task<string> TryGetPlayerAlias();
     Task<ProfileInfo?> GetCurrentProfileAsync();

--- a/src/frontend/Sudoku.Blazor/Services/GameStateManager.cs
+++ b/src/frontend/Sudoku.Blazor/Services/GameStateManager.cs
@@ -1,4 +1,4 @@
-﻿using Sudoku.Blazor.Models;
+using Sudoku.Blazor.Models;
 using Sudoku.Blazor.Services.Abstractions;
 
 namespace Sudoku.Blazor.Services;
@@ -7,26 +7,19 @@ namespace Sudoku.Blazor.Services;
 /// Manages the lifecycle and state of a game, including creation, loading, saving, deletion, and other game-related
 /// operations.
 /// </summary>
-/// <remarks>This class provides methods to interact with both local storage and a remote game API to manage game
-/// data.  It ensures that game state is synchronized between the client and server, and offers functionality for
-/// creating,  loading, saving, deleting, resetting, and undoing game actions. The class maintains the current game
-/// state  through the <see cref="Game"/> property.</remarks>
-/// <param name="localStorageService"></param>
-/// <param name="gameApiClient"></param>
-/// <param name="gameTimer"></param>
 public partial class GameManager : IGameStateManager
 {
-    public async Task<GameModel> CreateGameAsync(string alias, string difficulty)
+    public async Task<GameModel> CreateGameAsync(string profileId, string difficulty)
     {
-        if (string.IsNullOrEmpty(alias))
+        if (string.IsNullOrEmpty(profileId))
         {
-            throw new ArgumentException("Alias not set.");
+            throw new ArgumentException("Profile ID not set.");
         }
         if (string.IsNullOrEmpty(difficulty))
         {
             throw new ArgumentException("Difficulty not set.");
         }
-        var response = await gameApiClient.CreateGameAsync(alias, difficulty);
+        var response = await gameApiClient.CreateGameAsync(profileId, difficulty);
         if (!response.IsSuccess || response.Value == null)
         {
             throw new Exception("Failed to create game.");
@@ -43,21 +36,21 @@ public partial class GameManager : IGameStateManager
             throw new Exception("No game loaded.");
         }
 
-        await DeleteGameAsync(Game.PlayerAlias, Game.Id);
+        await DeleteGameAsync(Game.ProfileId, Game.Id);
         Game = null;
     }
 
-    public async Task DeleteGameAsync(string alias, string gameId)
+    public async Task DeleteGameAsync(string profileId, string gameId)
     {
-        if (string.IsNullOrEmpty(alias))
+        if (string.IsNullOrEmpty(profileId))
         {
-            throw new ArgumentException("Alias not set.");
+            throw new ArgumentException("Profile ID not set.");
         }
         if (string.IsNullOrEmpty(gameId))
         {
             throw new ArgumentException("Game ID not set.");
         }
-        var result = await gameApiClient.DeleteGameAsync(alias, gameId);
+        var result = await gameApiClient.DeleteGameAsync(profileId, gameId);
         if (!result.IsSuccess && result.StatusCode != 404)
         {
             throw new Exception("Failed to delete game from server.");
@@ -65,18 +58,18 @@ public partial class GameManager : IGameStateManager
         await localStorageService.DeleteGameAsync(gameId);
     }
 
-    public async Task<GameModel> LoadGameAsync(string alias, string gameId)
+    public async Task<GameModel> LoadGameAsync(string profileId, string gameId)
     {
-        if (string.IsNullOrEmpty(alias))
+        if (string.IsNullOrEmpty(profileId))
         {
-            throw new ArgumentException("Alias not set.");
+            throw new ArgumentException("Profile ID not set.");
         }
         if (string.IsNullOrEmpty(gameId))
         {
             throw new ArgumentException("Game ID not set.");
         }
 
-        var response = await gameApiClient.GetGameAsync(alias, gameId);
+        var response = await gameApiClient.GetGameAsync(profileId, gameId);
         if (!response.IsSuccess || response.Value == null)
         {
             throw new Exception("Failed to load game.");
@@ -88,11 +81,11 @@ public partial class GameManager : IGameStateManager
         return Game;
     }
 
-    public async Task<List<GameModel>> LoadGamesAsync(string alias)
+    public async Task<List<GameModel>> LoadGamesAsync(string profileId)
     {
-        if (string.IsNullOrEmpty(alias))
+        if (string.IsNullOrEmpty(profileId))
         {
-            throw new ArgumentException("Alias not set.");
+            throw new ArgumentException("Profile ID not set.");
         }
 
         var games = await localStorageService.LoadGameStatesAsync();
@@ -100,7 +93,7 @@ public partial class GameManager : IGameStateManager
         {
             return games;
         }
-        var response = await gameApiClient.GetAllGamesAsync(alias);
+        var response = await gameApiClient.GetAllGamesAsync(profileId);
         if (!response.IsSuccess || response.Value == null)
         {
             throw new Exception("Failed to load games.");
@@ -114,13 +107,13 @@ public partial class GameManager : IGameStateManager
 
     public async Task<GameModel> ResetGameAsync()
     {
-        var resetResponse = await gameApiClient.ResetGameAsync(Game.PlayerAlias, Game.Id);
+        var resetResponse = await gameApiClient.ResetGameAsync(Game.ProfileId, Game.Id);
         if (!resetResponse.IsSuccess)
         {
             throw new Exception("Failed to reset game.");
         }
 
-        Game = await LoadGameAsync(Game.PlayerAlias, Game.Id);
+        Game = await LoadGameAsync(Game.ProfileId, Game.Id);
 
         return Game;
     }
@@ -133,20 +126,20 @@ public partial class GameManager : IGameStateManager
 
     public async Task SaveGameAsync(int row, int column, int? value)
     {
-        var response = await gameApiClient.MakeMoveAsync(Game.PlayerAlias, Game.Id, row, column, value, CurrentStatistics.PlayDuration);
+        var response = await gameApiClient.MakeMoveAsync(Game.ProfileId, Game.Id, row, column, value, CurrentStatistics.PlayDuration);
         if (!response.IsSuccess)
         {
             throw new Exception("Failed to save move.");
         }
-        Game = await LoadGameAsync(Game.PlayerAlias, Game.Id);
+        Game = await LoadGameAsync(Game.ProfileId, Game.Id);
     }
 
     public Task SaveGameStatusAsync()
     {
-        if (Game.Status == GameStatus.InProgress) return gameApiClient.ResumeGameAsync(Game.PlayerAlias, Game.Id);
-        if (Game.Status == GameStatus.Paused)     return gameApiClient.PauseGameAsync(Game.PlayerAlias, Game.Id);
-        if (Game.Status == GameStatus.Completed)  return gameApiClient.CompleteGameAsync(Game.PlayerAlias, Game.Id);
-        if (Game.Status == GameStatus.Abandoned)  return gameApiClient.AbandonGameAsync(Game.PlayerAlias, Game.Id);
+        if (Game.Status == GameStatus.InProgress) return gameApiClient.ResumeGameAsync(Game.ProfileId, Game.Id);
+        if (Game.Status == GameStatus.Paused)     return gameApiClient.PauseGameAsync(Game.ProfileId, Game.Id);
+        if (Game.Status == GameStatus.Completed)  return gameApiClient.CompleteGameAsync(Game.ProfileId, Game.Id);
+        if (Game.Status == GameStatus.Abandoned)  return gameApiClient.AbandonGameAsync(Game.ProfileId, Game.Id);
         return Task.CompletedTask;
     }
 
@@ -157,20 +150,20 @@ public partial class GameManager : IGameStateManager
             return Game;
         }
 
-        var response = await gameApiClient.UndoMoveAsync(Game.PlayerAlias, Game.Id);
+        var response = await gameApiClient.UndoMoveAsync(Game.ProfileId, Game.Id);
         if (!response.IsSuccess)
         {
             throw new Exception("Failed to undo move.");
         }
 
-        Game = await LoadGameAsync(Game.PlayerAlias, Game.Id);
+        Game = await LoadGameAsync(Game.ProfileId, Game.Id);
 
         return Game;
     }
 
     public async Task AddPossibleValueAsync(int row, int column, int value)
     {
-        var response = await gameApiClient.AddPossibleValueAsync(Game.PlayerAlias, Game.Id, row, column, value);
+        var response = await gameApiClient.AddPossibleValueAsync(Game.ProfileId, Game.Id, row, column, value);
         if (!response.IsSuccess)
         {
             throw new Exception("Failed to add possible value.");
@@ -187,7 +180,7 @@ public partial class GameManager : IGameStateManager
 
     public async Task RemovePossibleValueAsync(int row, int column, int value)
     {
-        var response = await gameApiClient.RemovePossibleValueAsync(Game.PlayerAlias, Game.Id, row, column, value);
+        var response = await gameApiClient.RemovePossibleValueAsync(Game.ProfileId, Game.Id, row, column, value);
         if (!response.IsSuccess)
         {
             throw new Exception("Failed to remove possible value.");
@@ -204,7 +197,7 @@ public partial class GameManager : IGameStateManager
 
     public async Task ClearPossibleValuesAsync(int row, int column)
     {
-        var response = await gameApiClient.ClearPossibleValuesAsync(Game.PlayerAlias, Game.Id, row, column);
+        var response = await gameApiClient.ClearPossibleValuesAsync(Game.ProfileId, Game.Id, row, column);
         if (!response.IsSuccess)
         {
             throw new Exception("Failed to clear possible values.");

--- a/src/frontend/Sudoku.Blazor/Services/HttpClients/GameApiClient.cs
+++ b/src/frontend/Sudoku.Blazor/Services/HttpClients/GameApiClient.cs
@@ -8,13 +8,6 @@ namespace Sudoku.Blazor.Services.HttpClients;
 /// Provides methods for interacting with a game API, including retrieving, creating, updating, and deleting games, as
 /// well as performing game-specific actions such as making moves, validating, and resetting games.
 /// </summary>
-/// <remarks>This client is designed to communicate with a game API using HTTP requests. It supports operations
-/// for managing games associated with a specific player, identified by their alias. The client handles serialization
-/// and deserialization of JSON payloads and logs relevant information and errors during API interactions.  Typical
-/// usage involves creating an instance of <see cref="GameApiClient"/> with an <see cref="HttpClient"/> and <see
-/// cref="ILogger{TCategoryName}"/> dependency, and then calling the provided asynchronous methods to interact with the
-/// API.  All methods return an <see cref="ApiResult{T}"/> object, which encapsulates the result of the operation,
-/// including success status, data (if applicable), and error messages.</remarks>
 public class GameApiClient(HttpClient httpClient, ILogger<GameApiClient> logger) : IGameApiClient
 {
     private readonly HttpClient _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
@@ -24,27 +17,14 @@ public class GameApiClient(HttpClient httpClient, ILogger<GameApiClient> logger)
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
 
-    /// <summary>
-    /// Adds a possible value to the specified game at the given position.
-    /// </summary>
-    /// <remarks>This method sends a request to the server to add a possible value for the specified game and
-    /// position. If the operation fails, the returned <see cref="ApiResult{T}"/> will contain an error message
-    /// describing the issue.</remarks>
-    /// <param name="alias">The alias of the player associated with the game.</param>
-    /// <param name="gameId">The unique identifier of the game.</param>
-    /// <param name="row">The row index of the position where the value is to be added.</param>
-    /// <param name="column">The column index of the position where the value is to be added.</param>
-    /// <param name="value">The possible value to add at the specified position.</param>
-    /// <returns>An <see cref="ApiResult{T}"/> containing an empty object if the operation succeeds,  or an error message if the
-    /// operation fails.</returns>
-    public async Task<ApiResult<bool>> AddPossibleValueAsync(string alias, string gameId, int row, int column, int value)
+    public async Task<ApiResult<bool>> AddPossibleValueAsync(string profileId, string gameId, int row, int column, int value)
     {
         try
         {
             _logger.LogInformation("Adding possible value {Value} for game {GameId}, position: ({Row}, {Column})", value, gameId, row, column);
-            
+
             var request = new PossibleValueRequest(row, column, value);
-            var response = await _httpClient.PostAsJsonAsync($"api/players/{Uri.EscapeDataString(alias)}/games/{Uri.EscapeDataString(gameId)}/possible-values", request, _jsonOptions);
+            var response = await _httpClient.PostAsJsonAsync($"api/players/{Uri.EscapeDataString(profileId)}/games/{Uri.EscapeDataString(gameId)}/possible-values", request, _jsonOptions);
 
             if (response.IsSuccessStatusCode)
             {
@@ -65,30 +45,18 @@ public class GameApiClient(HttpClient httpClient, ILogger<GameApiClient> logger)
         }
     }
 
-    /// <summary>
-    /// Clears all possible values for a specific cell in a game.
-    /// </summary>
-    /// <remarks>This method sends a request to the server to clear all possible values for the specified
-    /// cell.  If the operation is successful, an empty object is returned. If the operation fails,  the result will
-    /// contain an error message describing the failure.</remarks>
-    /// <param name="alias">The alias of the player associated with the game.</param>
-    /// <param name="gameId">The unique identifier of the game.</param>
-    /// <param name="row">The row index of the cell to clear, starting from 0.</param>
-    /// <param name="column">The column index of the cell to clear, starting from 0.</param>
-    /// <returns>An <see cref="ApiResult{T}"/> containing an empty object if the operation succeeds,  or an error message if the
-    /// operation fails.</returns>
-    public async Task<ApiResult<bool>> ClearPossibleValuesAsync(string alias, string gameId, int row, int column)
+    public async Task<ApiResult<bool>> ClearPossibleValuesAsync(string profileId, string gameId, int row, int column)
     {
         try
         {
             _logger.LogInformation("Clearing possible values for game {GameId}, position: ({Row}, {Column})", gameId, row, column);
-            
+
             var request = new CellRequest(row, column);
-            var requestMessage = new HttpRequestMessage(HttpMethod.Delete, $"api/players/{Uri.EscapeDataString(alias)}/games/{Uri.EscapeDataString(gameId)}/possible-values/clear")
+            var requestMessage = new HttpRequestMessage(HttpMethod.Delete, $"api/players/{Uri.EscapeDataString(profileId)}/games/{Uri.EscapeDataString(gameId)}/possible-values/clear")
             {
                 Content = JsonContent.Create(request, options: _jsonOptions)
             };
-            
+
             var response = await _httpClient.SendAsync(requestMessage);
 
             if (response.IsSuccessStatusCode)
@@ -110,23 +78,13 @@ public class GameApiClient(HttpClient httpClient, ILogger<GameApiClient> logger)
         }
     }
 
-    /// <summary>
-    /// Asynchronously creates a new game for the specified player with the given difficulty level.
-    /// </summary>
-    /// <remarks>This method sends a request to the server to create a new game for the specified player. If
-    /// the operation is successful, the created game is returned. If the operation fails, an error message is included
-    /// in the result. Common failure scenarios include invalid input, server errors, or network issues.</remarks>
-    /// <param name="alias">The alias of the player for whom the game is being created. Cannot be null or empty.</param>
-    /// <param name="difficulty">The difficulty level of the game to be created. Cannot be null or empty.</param>
-    /// <returns>An <see cref="ApiResult{T}"/> containing the created <see cref="GameModel"/> if the operation succeeds, or an
-    /// error message if the operation fails.</returns>
-    public async Task<ApiResult<GameModel>> CreateGameAsync(string alias, string difficulty)
+    public async Task<ApiResult<GameModel>> CreateGameAsync(string profileId, string difficulty)
     {
         try
         {
-            _logger.LogInformation("Creating game for player: {Alias}, difficulty: {Difficulty}", alias, difficulty);
+            _logger.LogInformation("Creating game for profile: {ProfileId}, difficulty: {Difficulty}", profileId, difficulty);
 
-            var response = await _httpClient.PostAsync($"api/players/{Uri.EscapeDataString(alias)}/games/{Uri.EscapeDataString(difficulty)}", null);
+            var response = await _httpClient.PostAsync($"api/players/{Uri.EscapeDataString(profileId)}/games/{Uri.EscapeDataString(difficulty)}", null);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -139,12 +97,12 @@ public class GameApiClient(HttpClient httpClient, ILogger<GameApiClient> logger)
             var gameId = location?.Split('/').LastOrDefault();
             if (string.IsNullOrEmpty(gameId))
             {
-                _logger.LogWarning("Created game but Location header was missing or unparseable for player: {Alias}", alias);
+                _logger.LogWarning("Created game but Location header was missing or unparseable for profile: {ProfileId}", profileId);
                 return ApiResult<GameModel>.Failure("Game created but could not determine game ID from Location header");
             }
 
-            _logger.LogInformation("Created game {GameId} for player: {Alias}, fetching full game", gameId, alias);
-            return await GetGameAsync(alias, gameId);
+            _logger.LogInformation("Created game {GameId} for profile: {ProfileId}, fetching full game", gameId, profileId);
+            return await GetGameAsync(profileId, gameId);
         }
         catch (Exception ex)
         {
@@ -153,26 +111,17 @@ public class GameApiClient(HttpClient httpClient, ILogger<GameApiClient> logger)
         }
     }
 
-    /// <summary>
-    /// Deletes all games associated with the specified player alias.
-    /// </summary>
-    /// <remarks>This method sends an HTTP DELETE request to the server to remove all games for the specified
-    /// player. If the operation is successful, a success result is returned. If the operation fails, the method logs
-    /// the error and returns a failure result with the error details.</remarks>
-    /// <param name="alias">The alias of the player whose games are to be deleted. Cannot be null or empty.</param>
-    /// <returns>An <see cref="ApiResult{T}"/> containing the result of the operation.  If successful, the result contains an
-    /// empty object.  If the operation fails, the result contains an error message.</returns>
-    public async Task<ApiResult<bool>> DeleteAllGamesAsync(string alias)
+    public async Task<ApiResult<bool>> DeleteAllGamesAsync(string profileId)
     {
         try
         {
-            _logger.LogInformation("Deleting all games for player: {Alias}", alias);
-            
-            var response = await _httpClient.DeleteAsync($"api/players/{Uri.EscapeDataString(alias)}/games");
+            _logger.LogInformation("Deleting all games for profile: {ProfileId}", profileId);
+
+            var response = await _httpClient.DeleteAsync($"api/players/{Uri.EscapeDataString(profileId)}/games");
 
             if (response.IsSuccessStatusCode)
             {
-                _logger.LogInformation("All games deleted successfully for player: {Alias}", alias);
+                _logger.LogInformation("All games deleted successfully for profile: {ProfileId}", profileId);
                 return ApiResult<bool>.Success(true);
             }
             else
@@ -189,27 +138,17 @@ public class GameApiClient(HttpClient httpClient, ILogger<GameApiClient> logger)
         }
     }
 
-    /// <summary>
-    /// Deletes a game associated with a specific player.
-    /// </summary>
-    /// <remarks>This method sends an HTTP DELETE request to the server to remove the specified game for the
-    /// given player.  If the operation is successful, an informational log is recorded.  If the operation fails, a
-    /// warning or error log is recorded, and the failure details are included in the result.</remarks>
-    /// <param name="alias">The alias of the player whose game is to be deleted. This value cannot be null or empty.</param>
-    /// <param name="gameId">The unique identifier of the game to delete. This value cannot be null or empty.</param>
-    /// <returns>An <see cref="ApiResult{T}"/> containing the result of the operation.  If successful, the result contains an
-    /// empty object.  If the operation fails, the result contains an error message.</returns>
-    public async Task<ApiResult<bool>> DeleteGameAsync(string alias, string gameId)
+    public async Task<ApiResult<bool>> DeleteGameAsync(string profileId, string gameId)
     {
         try
         {
-            _logger.LogInformation("Deleting game {GameId} for player: {Alias}", gameId, alias);
-            
-            var response = await _httpClient.DeleteAsync($"api/players/{Uri.EscapeDataString(alias)}/games/{Uri.EscapeDataString(gameId)}");
+            _logger.LogInformation("Deleting game {GameId} for profile: {ProfileId}", gameId, profileId);
+
+            var response = await _httpClient.DeleteAsync($"api/players/{Uri.EscapeDataString(profileId)}/games/{Uri.EscapeDataString(gameId)}");
 
             if (response.IsSuccessStatusCode)
             {
-                _logger.LogInformation("Game {GameId} deleted successfully for player: {Alias}", gameId, alias);
+                _logger.LogInformation("Game {GameId} deleted successfully for profile: {ProfileId}", gameId, profileId);
                 return ApiResult<bool>.Success(true);
             }
             else
@@ -226,27 +165,18 @@ public class GameApiClient(HttpClient httpClient, ILogger<GameApiClient> logger)
         }
     }
 
-    /// <summary>
-    /// Retrieves a list of games associated with the specified player's alias.
-    /// </summary>
-    /// <remarks>This method sends an HTTP GET request to retrieve the games for the specified player.  If the
-    /// request is successful, the returned list contains the games associated with the player.  If the request fails or
-    /// an exception occurs, the result will indicate failure with an appropriate error message.</remarks>
-    /// <param name="alias">The alias of the player whose games are to be retrieved. Cannot be null or empty.</param>
-    /// <returns>An <see cref="ApiResult{T}"/> containing a list of <see cref="GameModel"/> objects if the operation is
-    /// successful. If the operation fails, the result contains an error message describing the failure.</returns>
-    public async Task<ApiResult<List<GameModel>>> GetAllGamesAsync(string alias)
+    public async Task<ApiResult<List<GameModel>>> GetAllGamesAsync(string profileId)
     {
         try
         {
-            _logger.LogInformation("Getting all games for player: {Alias}", alias);
-            
-            var response = await _httpClient.GetAsync($"api/players/{Uri.EscapeDataString(alias)}/games");
+            _logger.LogInformation("Getting all games for profile: {ProfileId}", profileId);
+
+            var response = await _httpClient.GetAsync($"api/players/{Uri.EscapeDataString(profileId)}/games");
 
             if (response.IsSuccessStatusCode)
             {
                 var games = await response.Content.ReadFromJsonAsync<List<GameModel>>(_jsonOptions) ?? new List<GameModel>();
-                _logger.LogInformation("Retrieved {Count} games for player: {Alias}", games.Count, alias);
+                _logger.LogInformation("Retrieved {Count} games for profile: {ProfileId}", games.Count, profileId);
                 return ApiResult<List<GameModel>>.Success(games);
             }
             else
@@ -263,36 +193,25 @@ public class GameApiClient(HttpClient httpClient, ILogger<GameApiClient> logger)
         }
     }
 
-    /// <summary>
-    /// Asynchronously retrieves a game for a specified player based on the provided alias and game ID.
-    /// </summary>
-    /// <remarks>This method sends an HTTP GET request to retrieve the game data for the specified player. If
-    /// the game is successfully retrieved, it is returned as part of the result. If the game is not found or an error
-    /// occurs, the result will indicate failure with an appropriate error message.</remarks>
-    /// <param name="alias">The alias of the player whose game is being retrieved. Cannot be null or empty.</param>
-    /// <param name="gameId">The unique identifier of the game to retrieve. Cannot be null or empty.</param>
-    /// <returns>A task that represents the asynchronous operation. The task result contains an <see cref="ApiResult{T}"/> object
-    /// that indicates the success or failure of the operation. On success, the result contains the <see
-    /// cref="GameModel"/> representing the retrieved game. On failure, the result contains an error message.</returns>
-    public async Task<ApiResult<GameModel>> GetGameAsync(string alias, string gameId)
+    public async Task<ApiResult<GameModel>> GetGameAsync(string profileId, string gameId)
     {
         try
         {
-            _logger.LogInformation("Getting game {GameId} for player: {Alias}", gameId, alias);
-            
-            var response = await _httpClient.GetAsync($"api/players/{Uri.EscapeDataString(alias)}/games/{Uri.EscapeDataString(gameId)}");
+            _logger.LogInformation("Getting game {GameId} for profile: {ProfileId}", gameId, profileId);
+
+            var response = await _httpClient.GetAsync($"api/players/{Uri.EscapeDataString(profileId)}/games/{Uri.EscapeDataString(gameId)}");
 
             if (response.IsSuccessStatusCode)
             {
                 var game = await response.Content.ReadFromJsonAsync<GameModel>(_jsonOptions);
                 if (game != null)
                 {
-                    _logger.LogInformation("Retrieved game {GameId} for player: {Alias}", gameId, alias);
+                    _logger.LogInformation("Retrieved game {GameId} for profile: {ProfileId}", gameId, profileId);
                     return ApiResult<GameModel>.Success(game);
                 }
                 else
                 {
-                    _logger.LogWarning("Game {GameId} not found for player: {Alias}", gameId, alias);
+                    _logger.LogWarning("Game {GameId} not found for profile: {ProfileId}", gameId, profileId);
                     return ApiResult<GameModel>.Failure("Game not found");
                 }
             }
@@ -310,29 +229,15 @@ public class GameApiClient(HttpClient httpClient, ILogger<GameApiClient> logger)
         }
     }
 
-    /// <summary>
-    /// Sends a move request for a player in a specified game to the server.
-    /// </summary>
-    /// <remarks>This method sends an HTTP PUT request to the server to register the player's move.  If the
-    /// request is successful, the server processes the move and updates the game state.  If the request fails, an error
-    /// message is returned in the result.</remarks>
-    /// <param name="alias">The alias of the player making the move. Cannot be null or empty.</param>
-    /// <param name="gameId">The unique identifier of the game. Cannot be null or empty.</param>
-    /// <param name="row">The row index of the move. Must be a valid row within the game board.</param>
-    /// <param name="column">The column index of the move. Must be a valid column within the game board.</param>
-    /// <param name="value">The optional value associated with the move, if applicable.</param>
-    /// <param name="playDuration">The duration of the player's turn.</param>
-    /// <returns>An <see cref="ApiResult{T}"/> containing the result of the move operation.  If successful, the result contains
-    /// an empty object. If the operation fails, the result contains an error message.</returns>
-    public async Task<ApiResult<bool>> MakeMoveAsync(string alias, string gameId, int row, int column, int? value, TimeSpan playDuration)
+    public async Task<ApiResult<bool>> MakeMoveAsync(string profileId, string gameId, int row, int column, int? value, TimeSpan playDuration)
     {
         try
         {
-            _logger.LogInformation("Making move for game {GameId}, player: {Alias}, position: ({Row}, {Column}), value: {Value}", 
-                gameId, alias, row, column, value);
-            
+            _logger.LogInformation("Making move for game {GameId}, profile: {ProfileId}, position: ({Row}, {Column}), value: {Value}",
+                gameId, profileId, row, column, value);
+
             var request = new MoveRequest(row, column, value, playDuration);
-            var response = await _httpClient.PutAsJsonAsync($"api/players/{Uri.EscapeDataString(alias)}/games/{Uri.EscapeDataString(gameId)}/actions", request, _jsonOptions);
+            var response = await _httpClient.PutAsJsonAsync($"api/players/{Uri.EscapeDataString(profileId)}/games/{Uri.EscapeDataString(gameId)}/actions", request, _jsonOptions);
 
             if (response.IsSuccessStatusCode)
             {
@@ -353,31 +258,18 @@ public class GameApiClient(HttpClient httpClient, ILogger<GameApiClient> logger)
         }
     }
 
-    /// <summary>
-    /// Removes a possible value from a specific cell in a game for a given player.
-    /// </summary>
-    /// <remarks>This method sends an HTTP DELETE request to the server to remove the specified possible value
-    /// from the given cell in the game. If the operation is successful, the method returns a success result. Otherwise,
-    /// it returns a failure result with an error message.</remarks>
-    /// <param name="alias">The alias of the player for whom the possible value is being removed.</param>
-    /// <param name="gameId">The unique identifier of the game.</param>
-    /// <param name="row">The row index of the cell from which the possible value is to be removed.</param>
-    /// <param name="column">The column index of the cell from which the possible value is to be removed.</param>
-    /// <param name="value">The possible value to be removed from the specified cell.</param>
-    /// <returns>An <see cref="ApiResult{T}"/> containing an empty object if the operation succeeds, or an error message if it
-    /// fails.</returns>
-    public async Task<ApiResult<bool>> RemovePossibleValueAsync(string alias, string gameId, int row, int column, int value)
+    public async Task<ApiResult<bool>> RemovePossibleValueAsync(string profileId, string gameId, int row, int column, int value)
     {
         try
         {
             _logger.LogInformation("Removing possible value {Value} for game {GameId}, position: ({Row}, {Column})", value, gameId, row, column);
-            
+
             var request = new PossibleValueRequest(row, column, value);
-            var requestMessage = new HttpRequestMessage(HttpMethod.Delete, $"api/players/{Uri.EscapeDataString(alias)}/games/{Uri.EscapeDataString(gameId)}/possible-values")
+            var requestMessage = new HttpRequestMessage(HttpMethod.Delete, $"api/players/{Uri.EscapeDataString(profileId)}/games/{Uri.EscapeDataString(gameId)}/possible-values")
             {
                 Content = JsonContent.Create(request, options: _jsonOptions)
             };
-            
+
             var response = await _httpClient.SendAsync(requestMessage);
 
             if (response.IsSuccessStatusCode)
@@ -399,27 +291,17 @@ public class GameApiClient(HttpClient httpClient, ILogger<GameApiClient> logger)
         }
     }
 
-    /// <summary>
-    /// Resets the specified game for the given player.
-    /// </summary>
-    /// <remarks>This method sends a request to reset the specified game for the player identified by
-    /// <paramref name="alias"/>. If the operation is successful, the game is reset, and an empty object is returned. 
-    /// If the operation fails, an error message is included in the result.</remarks>
-    /// <param name="alias">The alias of the player whose game is being reset. Cannot be null or empty.</param>
-    /// <param name="gameId">The unique identifier of the game to reset. Cannot be null or empty.</param>
-    /// <returns>An <see cref="ApiResult{T}"/> containing the result of the operation.  If successful, the result contains an
-    /// empty object.  If the operation fails, the result contains an error message.</returns>
-    public async Task<ApiResult<bool>> ResetGameAsync(string alias, string gameId)
+    public async Task<ApiResult<bool>> ResetGameAsync(string profileId, string gameId)
     {
         try
         {
-            _logger.LogInformation("Resetting game {GameId} for player: {Alias}", gameId, alias);
-            
-            var response = await _httpClient.PostAsync($"api/players/{Uri.EscapeDataString(alias)}/games/{Uri.EscapeDataString(gameId)}/actions/reset", null);
+            _logger.LogInformation("Resetting game {GameId} for profile: {ProfileId}", gameId, profileId);
+
+            var response = await _httpClient.PostAsync($"api/players/{Uri.EscapeDataString(profileId)}/games/{Uri.EscapeDataString(gameId)}/actions/reset", null);
 
             if (response.IsSuccessStatusCode)
             {
-                _logger.LogInformation("Game {GameId} reset successfully for player: {Alias}", gameId, alias);
+                _logger.LogInformation("Game {GameId} reset successfully for profile: {ProfileId}", gameId, profileId);
                 return ApiResult<bool>.Success(true);
             }
             else
@@ -436,24 +318,18 @@ public class GameApiClient(HttpClient httpClient, ILogger<GameApiClient> logger)
         }
     }
 
-    /// <summary>
-    /// Saves the specified game asynchronously.
-    /// </summary>
-    /// <param name="game">The game model to be saved. Cannot be <see langword="null"/>.</param>
-    /// <returns>A task that represents the asynchronous save operation. The task result contains  an <see cref="ApiResult{T}"/>
-    /// indicating whether the save operation was successful.</returns>
     public async Task<ApiResult<bool>> SaveGameAsync(GameModel game)
     {
         try
         {
             if (game == null) throw new ArgumentNullException(nameof(game));
 
-            _logger.LogInformation("Saving game {GameId} for player: {Alias}", game.Id, game.PlayerAlias);
-            
-            var response = await _httpClient.PutAsJsonAsync($"api/players/{Uri.EscapeDataString(game.PlayerAlias)}/games/{Uri.EscapeDataString(game.Id)}", game, _jsonOptions);
+            _logger.LogInformation("Saving game {GameId} for profile: {ProfileId}", game.Id, game.ProfileId);
+
+            var response = await _httpClient.PutAsJsonAsync($"api/players/{Uri.EscapeDataString(game.ProfileId)}/games/{Uri.EscapeDataString(game.Id)}", game, _jsonOptions);
             if (response.IsSuccessStatusCode)
             {
-                _logger.LogInformation("Game {GameId} saved successfully for player: {Alias}", game.Id, game.PlayerAlias);
+                _logger.LogInformation("Game {GameId} saved successfully for profile: {ProfileId}", game.Id, game.ProfileId);
                 return ApiResult<bool>.Success(true);
             }
 
@@ -468,24 +344,24 @@ public class GameApiClient(HttpClient httpClient, ILogger<GameApiClient> logger)
         }
     }
 
-    public async Task<ApiResult<bool>> AbandonGameAsync(string alias, string gameId)
-        => await PostStatusAsync(alias, gameId, "abandon");
+    public async Task<ApiResult<bool>> AbandonGameAsync(string profileId, string gameId)
+        => await PostStatusAsync(profileId, gameId, "abandon");
 
-    public async Task<ApiResult<bool>> CompleteGameAsync(string alias, string gameId)
-        => await PostStatusAsync(alias, gameId, "complete");
+    public async Task<ApiResult<bool>> CompleteGameAsync(string profileId, string gameId)
+        => await PostStatusAsync(profileId, gameId, "complete");
 
-    public async Task<ApiResult<bool>> PauseGameAsync(string alias, string gameId)
-        => await PostStatusAsync(alias, gameId, "pause");
+    public async Task<ApiResult<bool>> PauseGameAsync(string profileId, string gameId)
+        => await PostStatusAsync(profileId, gameId, "pause");
 
-    public async Task<ApiResult<bool>> ResumeGameAsync(string alias, string gameId)
-        => await PostStatusAsync(alias, gameId, "resume");
+    public async Task<ApiResult<bool>> ResumeGameAsync(string profileId, string gameId)
+        => await PostStatusAsync(profileId, gameId, "resume");
 
-    private async Task<ApiResult<bool>> PostStatusAsync(string alias, string gameId, string action)
+    private async Task<ApiResult<bool>> PostStatusAsync(string profileId, string gameId, string action)
     {
         try
         {
-            _logger.LogInformation("Posting game status '{Action}' for game {GameId}, player: {Alias}", action, gameId, alias);
-            var response = await _httpClient.PostAsync($"api/players/{Uri.EscapeDataString(alias)}/games/{Uri.EscapeDataString(gameId)}/status/{action}", null);
+            _logger.LogInformation("Posting game status '{Action}' for game {GameId}, profile: {ProfileId}", action, gameId, profileId);
+            var response = await _httpClient.PostAsync($"api/players/{Uri.EscapeDataString(profileId)}/games/{Uri.EscapeDataString(gameId)}/status/{action}", null);
             if (response.IsSuccessStatusCode)
             {
                 _logger.LogInformation("Game status '{Action}' applied successfully for game {GameId}", action, gameId);
@@ -503,25 +379,13 @@ public class GameApiClient(HttpClient httpClient, ILogger<GameApiClient> logger)
         }
     }
 
-    /// <summary>
-    /// Attempts to undo the last move for a specified player in a given game.
-    /// </summary>
-    /// <remarks>This method sends a request to the server to undo the last move for the specified player in
-    /// the specified game. The operation may fail if the server rejects the request or if an exception occurs during
-    /// the process.</remarks>
-    /// <param name="alias">The alias of the player for whom the move should be undone. Cannot be null or empty.</param>
-    /// <param name="gameId">The unique identifier of the game in which the move should be undone. Cannot be null or empty.</param>
-    /// <returns>A task that represents the asynchronous operation. The task result contains an <see cref="ApiResult{T}"/>
-    /// object: <list type="bullet"> <item><description>On success, the result contains an empty
-    /// object.</description></item> <item><description>On failure, the result contains an error message describing the
-    /// issue.</description></item> </list></returns>
-    public async Task<ApiResult<bool>> UndoMoveAsync(string alias, string gameId)
+    public async Task<ApiResult<bool>> UndoMoveAsync(string profileId, string gameId)
     {
         try
         {
-            _logger.LogInformation("Undoing move for game {GameId}, player: {Alias}", gameId, alias);
-            
-            var response = await _httpClient.PostAsync($"api/players/{Uri.EscapeDataString(alias)}/games/{Uri.EscapeDataString(gameId)}/actions/undo", null);
+            _logger.LogInformation("Undoing move for game {GameId}, profile: {ProfileId}", gameId, profileId);
+
+            var response = await _httpClient.PostAsync($"api/players/{Uri.EscapeDataString(profileId)}/games/{Uri.EscapeDataString(gameId)}/actions/undo", null);
 
             if (response.IsSuccessStatusCode)
             {
@@ -542,31 +406,20 @@ public class GameApiClient(HttpClient httpClient, ILogger<GameApiClient> logger)
         }
     }
 
-    /// <summary>
-    /// Validates a game for a specific player by sending a validation request to the server.
-    /// </summary>
-    /// <remarks>This method sends an HTTP POST request to the server to validate the specified game for the
-    /// given player. If the server responds with a success status code, the validation result is deserialized and
-    /// returned. If the response cannot be deserialized or the server returns an error, the method returns a failure
-    /// result with an appropriate error message.</remarks>
-    /// <param name="alias">The alias of the player for whom the game is being validated. Cannot be null or empty.</param>
-    /// <param name="gameId">The unique identifier of the game to validate. Cannot be null or empty.</param>
-    /// <returns>An <see cref="ApiResult{T}"/> containing a <see cref="ValidationResultModel"/> if the validation is successful.
-    /// If the validation fails, the result contains an error message describing the failure.</returns>
-    public async Task<ApiResult<ValidationResultModel>> ValidateGameAsync(string alias, string gameId)
+    public async Task<ApiResult<ValidationResultModel>> ValidateGameAsync(string profileId, string gameId)
     {
         try
         {
-            _logger.LogInformation("Validating game {GameId} for player: {Alias}", gameId, alias);
-            
-            var response = await _httpClient.PostAsync($"api/players/{Uri.EscapeDataString(alias)}/games/{Uri.EscapeDataString(gameId)}/status/validate", null);
+            _logger.LogInformation("Validating game {GameId} for profile: {ProfileId}", gameId, profileId);
+
+            var response = await _httpClient.PostAsync($"api/players/{Uri.EscapeDataString(profileId)}/games/{Uri.EscapeDataString(gameId)}/status/validate", null);
 
             if (response.IsSuccessStatusCode)
             {
                 var result = await response.Content.ReadFromJsonAsync<ValidationResultModel>(_jsonOptions);
                 if (result != null)
                 {
-                    _logger.LogInformation("Game {GameId} validated successfully for player: {Alias}", gameId, alias);
+                    _logger.LogInformation("Game {GameId} validated successfully for profile: {ProfileId}", gameId, profileId);
                     return ApiResult<ValidationResultModel>.Success(result);
                 }
                 else

--- a/src/frontend/Sudoku.Blazor/Services/HttpClients/IGameApiClient.cs
+++ b/src/frontend/Sudoku.Blazor/Services/HttpClients/IGameApiClient.cs
@@ -10,61 +10,61 @@ public interface IGameApiClient
     /// <summary>
     /// Adds a possible value to a cell
     /// </summary>
-    /// <param name="alias">The player's alias</param>
+    /// <param name="profileId">The player's profile ID</param>
     /// <param name="gameId">The game id</param>
     /// <param name="row">The row of the cell</param>
     /// <param name="column">The column of the cell</param>
     /// <param name="value">The possible value to add</param>
     /// <returns>Success or failure result</returns>
-    Task<ApiResult<bool>> AddPossibleValueAsync(string alias, string gameId, int row, int column, int value);
+    Task<ApiResult<bool>> AddPossibleValueAsync(string profileId, string gameId, int row, int column, int value);
 
     /// <summary>
     /// Clears all possible values from a cell
     /// </summary>
-    /// <param name="alias">The player's alias</param>
+    /// <param name="profileId">The player's profile ID</param>
     /// <param name="gameId">The game id</param>
     /// <param name="row">The row of the cell</param>
     /// <param name="column">The column of the cell</param>
     /// <returns>Success or failure result</returns>
-    Task<ApiResult<bool>> ClearPossibleValuesAsync(string alias, string gameId, int row, int column);
+    Task<ApiResult<bool>> ClearPossibleValuesAsync(string profileId, string gameId, int row, int column);
 
     /// <summary>
     /// Creates a new game for the specified player with the given difficulty
     /// </summary>
-    /// <param name="alias">The alias of the player</param>
+    /// <param name="profileId">The player's profile ID</param>
     /// <param name="difficulty">The difficulty level of the game</param>
     /// <returns>The created game</returns>
-    Task<ApiResult<GameModel>> CreateGameAsync(string alias, string difficulty);
+    Task<ApiResult<GameModel>> CreateGameAsync(string profileId, string difficulty);
 
     /// <summary>
     /// Deletes all games for a player
     /// </summary>
-    /// <param name="alias">The player's alias</param>
+    /// <param name="profileId">The player's profile ID</param>
     /// <returns>Success or failure result</returns>
-    Task<ApiResult<bool>> DeleteAllGamesAsync(string alias);
+    Task<ApiResult<bool>> DeleteAllGamesAsync(string profileId);
 
     /// <summary>
     /// Deletes a specific game for a player
     /// </summary>
-    /// <param name="alias">The player's alias</param>
+    /// <param name="profileId">The player's profile ID</param>
     /// <param name="gameId">The game id to delete</param>
     /// <returns>Success or failure result</returns>
-    Task<ApiResult<bool>> DeleteGameAsync(string alias, string gameId);
+    Task<ApiResult<bool>> DeleteGameAsync(string profileId, string gameId);
 
     /// <summary>
     /// Gets all games for a specific player
     /// </summary>
-    /// <param name="alias">The player's alias</param>
+    /// <param name="profileId">The player's profile ID</param>
     /// <returns>A list of games for the player</returns>
-    Task<ApiResult<List<GameModel>>> GetAllGamesAsync(string alias);
+    Task<ApiResult<List<GameModel>>> GetAllGamesAsync(string profileId);
 
     /// <summary>
     /// Gets a specific game by id for a player
     /// </summary>
-    /// <param name="alias">The player's alias</param>
+    /// <param name="profileId">The player's profile ID</param>
     /// <param name="gameId">The game id</param>
     /// <returns>The game if found</returns>
-    Task<ApiResult<GameModel>> GetGameAsync(string alias, string gameId);
+    Task<ApiResult<GameModel>> GetGameAsync(string profileId, string gameId);
 
     /// <summary>
     /// Attempts to make a move in the specified game for the given player alias asynchronously.
@@ -80,26 +80,26 @@ public interface IGameApiClient
     /// <param name="playDuration">The duration of the player's turn.</param>
     /// <returns>A task that represents the asynchronous operation. The result contains an ApiResult indicating whether the move
     /// was successful (<see langword="true"/> if the move was made; otherwise, <see langword="false"/>).</returns>
-    Task<ApiResult<bool>> MakeMoveAsync(string alias, string gameId, int row, int column, int? value, TimeSpan playDuration);
+    Task<ApiResult<bool>> MakeMoveAsync(string profileId, string gameId, int row, int column, int? value, TimeSpan playDuration);
 
     /// <summary>
     /// Removes a possible value from a cell
     /// </summary>
-    /// <param name="alias">The player's alias</param>
+    /// <param name="profileId">The player's profile ID</param>
     /// <param name="gameId">The game id</param>
     /// <param name="row">The row of the cell</param>
     /// <param name="column">The column of the cell</param>
     /// <param name="value">The possible value to remove</param>
     /// <returns>Success or failure result</returns>
-    Task<ApiResult<bool>> RemovePossibleValueAsync(string alias, string gameId, int row, int column, int value);
+    Task<ApiResult<bool>> RemovePossibleValueAsync(string profileId, string gameId, int row, int column, int value);
 
     /// <summary>
     /// Resets a game to its initial state
     /// </summary>
-    /// <param name="alias">The player's alias</param>
+    /// <param name="profileId">The player's profile ID</param>
     /// <param name="gameId">The game id</param>
     /// <returns>Success or failure result</returns>
-    Task<ApiResult<bool>> ResetGameAsync(string alias, string gameId);
+    Task<ApiResult<bool>> ResetGameAsync(string profileId, string gameId);
 
     /// <summary>
     /// Saves the specified game asynchronously.
@@ -110,30 +110,30 @@ public interface IGameApiClient
     Task<ApiResult<bool>> SaveGameAsync(GameModel game);
 
     /// <summary>Abandons an in-progress or paused game.</summary>
-    Task<ApiResult<bool>> AbandonGameAsync(string alias, string gameId);
+    Task<ApiResult<bool>> AbandonGameAsync(string profileId, string gameId);
 
     /// <summary>Marks a game as complete.</summary>
-    Task<ApiResult<bool>> CompleteGameAsync(string alias, string gameId);
+    Task<ApiResult<bool>> CompleteGameAsync(string profileId, string gameId);
 
     /// <summary>Pauses an in-progress game.</summary>
-    Task<ApiResult<bool>> PauseGameAsync(string alias, string gameId);
+    Task<ApiResult<bool>> PauseGameAsync(string profileId, string gameId);
 
     /// <summary>Resumes a paused or not-started game.</summary>
-    Task<ApiResult<bool>> ResumeGameAsync(string alias, string gameId);
+    Task<ApiResult<bool>> ResumeGameAsync(string profileId, string gameId);
 
     /// <summary>
     /// Undoes the last move in a game
     /// </summary>
-    /// <param name="alias">The player's alias</param>
+    /// <param name="profileId">The player's profile ID</param>
     /// <param name="gameId">The game id</param>
     /// <returns>Success or failure result</returns>
-    Task<ApiResult<bool>> UndoMoveAsync(string alias, string gameId);
+    Task<ApiResult<bool>> UndoMoveAsync(string profileId, string gameId);
 
     /// <summary>
     /// Validates a game to check if it's completed correctly
     /// </summary>
-    /// <param name="alias">The player's alias</param>
+    /// <param name="profileId">The player's profile ID</param>
     /// <param name="gameId">The game id</param>
     /// <returns>Result of the validation</returns>
-    Task<ApiResult<ValidationResultModel>> ValidateGameAsync(string alias, string gameId);
+    Task<ApiResult<ValidationResultModel>> ValidateGameAsync(string profileId, string gameId);
 }

--- a/src/frontend/Sudoku.Blazor/Services/PlayerManager.cs
+++ b/src/frontend/Sudoku.Blazor/Services/PlayerManager.cs
@@ -80,10 +80,10 @@ public class PlayerManager(IPlayerApiClient playerApiClient, ILocalStorageServic
         var legacyAlias = await localStorageService.GetAliasAsync();
         if (!string.IsNullOrEmpty(legacyAlias))
         {
-            var normalizedAlias = legacyAlias.Trim().ToLowerInvariant();
-            var canRetry = normalizedAlias.Length < 50;
+            var aliasName = legacyAlias.Trim();
+            var canRetry = aliasName.Length < 50;
 
-            var createResult = await playerApiClient.CreateProfileAsync(normalizedAlias);
+            var createResult = await playerApiClient.CreateProfileAsync(aliasName);
             if (createResult.IsSuccess && createResult.Value != null)
             {
                 await localStorageService.SetProfileAsync(new ProfileInfo
@@ -98,7 +98,7 @@ public class PlayerManager(IPlayerApiClient playerApiClient, ILocalStorageServic
             if (createResult.StatusCode == 409 && canRetry)
             {
                 var suffix = Random.Shared.Next(10, 100).ToString();
-                var aliasWithSuffix = normalizedAlias[..Math.Min(normalizedAlias.Length, 48)] + suffix;
+                var aliasWithSuffix = aliasName[..Math.Min(aliasName.Length, 48)] + suffix;
                 var retryResult = await playerApiClient.CreateProfileAsync(aliasWithSuffix);
                 if (retryResult.IsSuccess && retryResult.Value != null)
                 {

--- a/src/frontend/Sudoku.Blazor/Services/PlayerManager.cs
+++ b/src/frontend/Sudoku.Blazor/Services/PlayerManager.cs
@@ -15,6 +15,12 @@ public class PlayerManager(IPlayerApiClient playerApiClient, ILocalStorageServic
         return await localStorageService.GetAliasAsync();
     }
 
+    public async Task<string?> GetCurrentProfileIdAsync()
+    {
+        var profile = await localStorageService.GetProfileAsync();
+        return profile?.ProfileId;
+    }
+
     public async Task SetCurrentPlayerAsync(string alias)
     {
         if (string.IsNullOrEmpty(alias))

--- a/src/frontend/Sudoku.Blazor/Sudoku.Blazor.csproj
+++ b/src/frontend/Sudoku.Blazor/Sudoku.Blazor.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.2.4" />
+    <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.3.0" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
     <PackageReference Include="BlazorApplicationInsights" Version="3.3.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.14.0" />

--- a/src/frontend/Sudoku.React/src/api/apiClient.ts
+++ b/src/frontend/Sudoku.React/src/api/apiClient.ts
@@ -47,8 +47,8 @@ export const apiClient = {
       body: JSON.stringify({ newAlias }),
     }),
 
-  createGame: async (alias: string, difficulty: string): Promise<GameModel> => {
-    const res = await fetch(`${BASE_URL}/api/players/${alias}/games/${difficulty}`, {
+  createGame: async (profileId: string, difficulty: string): Promise<GameModel> => {
+    const res = await fetch(`${BASE_URL}/api/players/${profileId}/games/${difficulty}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
     });
@@ -56,87 +56,87 @@ export const apiClient = {
     const location = res.headers.get('Location');
     const gameId = location?.split('/').pop();
     if (!gameId) throw new Error('No Location header in createGame response');
-    return request(`/api/players/${alias}/games/${gameId}`);
+    return request(`/api/players/${profileId}/games/${gameId}`);
   },
 
-  getGames: (alias: string): Promise<GameModel[]> =>
-    request(`/api/players/${alias}/games`),
+  getGames: (profileId: string): Promise<GameModel[]> =>
+    request(`/api/players/${profileId}/games`),
 
-  getGame: (alias: string, gameId: string): Promise<GameModel> =>
-    request(`/api/players/${alias}/games/${gameId}`),
+  getGame: (profileId: string, gameId: string): Promise<GameModel> =>
+    request(`/api/players/${profileId}/games/${gameId}`),
 
-  deleteGame: (alias: string, gameId: string): Promise<void> =>
-    request(`/api/players/${alias}/games/${gameId}`, { method: 'DELETE' }),
+  deleteGame: (profileId: string, gameId: string): Promise<void> =>
+    request(`/api/players/${profileId}/games/${gameId}`, { method: 'DELETE' }),
 
   makeMove: async (
-    alias: string,
+    profileId: string,
     gameId: string,
     row: number,
     column: number,
     value: number | null,
     playDuration: string
   ): Promise<GameModel> => {
-    await request(`/api/players/${alias}/games/${gameId}/actions`, {
+    await request(`/api/players/${profileId}/games/${gameId}/actions`, {
       method: 'PUT',
       body: JSON.stringify({ row, column, value, playDuration }),
     });
-    return request(`/api/players/${alias}/games/${gameId}`);
+    return request(`/api/players/${profileId}/games/${gameId}`);
   },
 
-  resetGame: async (alias: string, gameId: string): Promise<GameModel> => {
-    await request(`/api/players/${alias}/games/${gameId}/actions/reset`, { method: 'POST' });
-    return request(`/api/players/${alias}/games/${gameId}`);
+  resetGame: async (profileId: string, gameId: string): Promise<GameModel> => {
+    await request(`/api/players/${profileId}/games/${gameId}/actions/reset`, { method: 'POST' });
+    return request(`/api/players/${profileId}/games/${gameId}`);
   },
 
-  undoMove: async (alias: string, gameId: string): Promise<GameModel> => {
-    await request(`/api/players/${alias}/games/${gameId}/actions/undo`, { method: 'POST' });
-    return request(`/api/players/${alias}/games/${gameId}`);
+  undoMove: async (profileId: string, gameId: string): Promise<GameModel> => {
+    await request(`/api/players/${profileId}/games/${gameId}/actions/undo`, { method: 'POST' });
+    return request(`/api/players/${profileId}/games/${gameId}`);
   },
 
-  pauseGame: (alias: string, gameId: string): Promise<void> =>
-    request(`/api/players/${alias}/games/${gameId}/status/pause`, { method: 'POST' }),
+  pauseGame: (profileId: string, gameId: string): Promise<void> =>
+    request(`/api/players/${profileId}/games/${gameId}/status/pause`, { method: 'POST' }),
 
-  resumeGame: (alias: string, gameId: string): Promise<void> =>
-    request(`/api/players/${alias}/games/${gameId}/status/resume`, { method: 'POST' }),
+  resumeGame: (profileId: string, gameId: string): Promise<void> =>
+    request(`/api/players/${profileId}/games/${gameId}/status/resume`, { method: 'POST' }),
 
   addPossibleValue: async (
-    alias: string,
+    profileId: string,
     gameId: string,
     row: number,
     column: number,
     value: number
   ): Promise<GameModel> => {
-    await request(`/api/players/${alias}/games/${gameId}/possible-values`, {
+    await request(`/api/players/${profileId}/games/${gameId}/possible-values`, {
       method: 'POST',
       body: JSON.stringify({ row, column, value }),
     });
-    return request(`/api/players/${alias}/games/${gameId}`);
+    return request(`/api/players/${profileId}/games/${gameId}`);
   },
 
   removePossibleValue: async (
-    alias: string,
+    profileId: string,
     gameId: string,
     row: number,
     column: number,
     value: number
   ): Promise<GameModel> => {
-    await request(`/api/players/${alias}/games/${gameId}/possible-values`, {
+    await request(`/api/players/${profileId}/games/${gameId}/possible-values`, {
       method: 'DELETE',
       body: JSON.stringify({ row, column, value }),
     });
-    return request(`/api/players/${alias}/games/${gameId}`);
+    return request(`/api/players/${profileId}/games/${gameId}`);
   },
 
   clearPossibleValues: async (
-    alias: string,
+    profileId: string,
     gameId: string,
     row: number,
     column: number
   ): Promise<GameModel> => {
-    await request(`/api/players/${alias}/games/${gameId}/possible-values/clear`, {
+    await request(`/api/players/${profileId}/games/${gameId}/possible-values/clear`, {
       method: 'DELETE',
       body: JSON.stringify({ row, column }),
     });
-    return request(`/api/players/${alias}/games/${gameId}`);
+    return request(`/api/players/${profileId}/games/${gameId}`);
   },
 };

--- a/src/frontend/Sudoku.React/src/hooks/useGameService.test.ts
+++ b/src/frontend/Sudoku.React/src/hooks/useGameService.test.ts
@@ -30,7 +30,8 @@ const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 const mockGames: GameModel[] = [
   {
     id: 'game-1',
-    playerAlias: 'test-player',
+    profileId: 'profile-test',
+    displayName: 'test-player',
     status: 'In Progress',
     difficulty: 'Easy',
     createdAt: '2024-01-01T00:00:00Z',
@@ -47,7 +48,8 @@ const mockGames: GameModel[] = [
   },
   {
     id: 'game-2',
-    playerAlias: 'test-player',
+    profileId: 'profile-test',
+    displayName: 'test-player',
     status: 'Completed',
     difficulty: 'Medium',
     createdAt: '2024-01-02T00:00:00Z',
@@ -64,7 +66,8 @@ const mockGames: GameModel[] = [
   },
   {
     id: 'game-3',
-    playerAlias: 'test-player',
+    profileId: 'profile-test',
+    displayName: 'test-player',
     status: 'In Progress',
     difficulty: 'Hard',
     createdAt: '2024-01-03T00:00:00Z',

--- a/src/frontend/Sudoku.React/src/hooks/useGameService.ts
+++ b/src/frontend/Sudoku.React/src/hooks/useGameService.ts
@@ -8,25 +8,25 @@ export interface UseGameServiceReturn {
   isLoading: boolean;
   error: string | null;
   isLoaded: boolean;
-  loadGames: (playerAlias: string, forceRefresh?: boolean) => Promise<void>;
-  deleteGame: (playerAlias: string, gameId: string) => Promise<void>;
-  createGame: (playerAlias: string, difficulty: string) => Promise<GameModel>;
+  loadGames: (profileId: string, forceRefresh?: boolean) => Promise<void>;
+  deleteGame: (profileId: string, gameId: string) => Promise<void>;
+  createGame: (profileId: string, difficulty: string) => Promise<GameModel>;
   clearCache: () => void;
-  refreshGames: (playerAlias: string) => Promise<void>;
-  
+  refreshGames: (profileId: string) => Promise<void>;
+
   // Single game management
   currentGame: GameModel | null;
   isGameLoading: boolean;
   gameError: string | null;
-  getGame: (playerAlias: string, gameId: string) => Promise<GameModel>;
-  pauseGame: (playerAlias: string, gameId: string) => Promise<void>;
-  resumeGame: (playerAlias: string, gameId: string) => Promise<void>;
-  makeMove: (playerAlias: string, gameId: string, row: number, column: number, value: number | null, duration: string) => Promise<GameModel>;
-  undoMove: (playerAlias: string, gameId: string) => Promise<GameModel>;
-  resetGame: (playerAlias: string, gameId: string) => Promise<GameModel>;
-  addPossibleValue: (playerAlias: string, gameId: string, row: number, column: number, value: number) => Promise<GameModel>;
-  removePossibleValue: (playerAlias: string, gameId: string, row: number, column: number, value: number) => Promise<GameModel>;
-  clearPossibleValues: (playerAlias: string, gameId: string, row: number, column: number) => Promise<GameModel>;
+  getGame: (profileId: string, gameId: string) => Promise<GameModel>;
+  pauseGame: (profileId: string, gameId: string) => Promise<void>;
+  resumeGame: (profileId: string, gameId: string) => Promise<void>;
+  makeMove: (profileId: string, gameId: string, row: number, column: number, value: number | null, duration: string) => Promise<GameModel>;
+  undoMove: (profileId: string, gameId: string) => Promise<GameModel>;
+  resetGame: (profileId: string, gameId: string) => Promise<GameModel>;
+  addPossibleValue: (profileId: string, gameId: string, row: number, column: number, value: number) => Promise<GameModel>;
+  removePossibleValue: (profileId: string, gameId: string, row: number, column: number, value: number) => Promise<GameModel>;
+  clearPossibleValues: (profileId: string, gameId: string, row: number, column: number) => Promise<GameModel>;
   clearCurrentGame: () => void;
 }
 
@@ -50,12 +50,12 @@ export function useGameService(): UseGameServiceReturn {
     setError(null);
   }, []);
 
-  const loadGames = useCallback(async (playerAlias: string, forceRefresh = false) => {
-    if (!playerAlias) return;
-    
+  const loadGames = useCallback(async (profileId: string, forceRefresh = false) => {
+    if (!profileId) return;
+
     // Use ref to prevent concurrent calls since state updates are async
     if (loadingRef.current) return;
-    
+
     loadingRef.current = true;
     setIsLoading(true);
     setError(null);
@@ -81,12 +81,12 @@ export function useGameService(): UseGameServiceReturn {
       }
 
       // Fetch from API
-      const games = await apiClient.getGames(playerAlias);
+      const games = await apiClient.getGames(profileId);
       const availableGames = games.filter(g => g.status !== 'Completed');
-      
+
       // Cache the full games array (including completed games for future use)
       localStorage.setItem('savedGames', JSON.stringify(games));
-      
+
       setSavedGames(availableGames);
       setIsLoaded(true);
     } catch (err) {
@@ -100,14 +100,14 @@ export function useGameService(): UseGameServiceReturn {
     }
   }, []);
 
-  const deleteGame = useCallback(async (playerAlias: string, gameId: string) => {
-    if (!playerAlias || loadingRef.current) return;
+  const deleteGame = useCallback(async (profileId: string, gameId: string) => {
+    if (!profileId || loadingRef.current) return;
 
     setError(null);
 
     try {
       // Delete from API
-      await apiClient.deleteGame(playerAlias, gameId);
+      await apiClient.deleteGame(profileId, gameId);
     } catch (err) {
       if (!(err instanceof Error) || !err.message.startsWith('HTTP 404')) {
         const errorMessage = err instanceof Error ? err.message : 'Failed to delete game';
@@ -136,25 +136,25 @@ export function useGameService(): UseGameServiceReturn {
     }
   }, [isLoading]);
 
-  const refreshGames = useCallback(async (playerAlias: string) => {
-    await loadGames(playerAlias, true);
+  const refreshGames = useCallback(async (profileId: string) => {
+    await loadGames(profileId, true);
   }, [loadGames]);
 
-  const createGame = useCallback(async (playerAlias: string, difficulty: string): Promise<GameModel> => {
-    if (!playerAlias) {
-      throw new Error('Player alias is required');
+  const createGame = useCallback(async (profileId: string, difficulty: string): Promise<GameModel> => {
+    if (!profileId) {
+      throw new Error('Profile ID is required');
     }
 
     setError(null);
 
     try {
       // Create the game via API
-      const newGame = await apiClient.createGame(playerAlias, difficulty);
+      const newGame = await apiClient.createGame(profileId, difficulty);
 
       // Update localStorage cache with the new game
       const cachedGames = localStorage.getItem('savedGames');
       let updatedGames: GameModel[];
-      
+
       if (cachedGames) {
         try {
           const parsedGames: GameModel[] = JSON.parse(cachedGames);
@@ -189,16 +189,16 @@ export function useGameService(): UseGameServiceReturn {
     setGameError(null);
   }, []);
 
-  const getGame = useCallback(async (playerAlias: string, gameId: string): Promise<GameModel> => {
-    if (!playerAlias || !gameId) {
-      throw new Error('Player alias and game ID are required');
+  const getGame = useCallback(async (profileId: string, gameId: string): Promise<GameModel> => {
+    if (!profileId || !gameId) {
+      throw new Error('Profile ID and game ID are required');
     }
 
     setIsGameLoading(true);
     setGameError(null);
 
     try {
-      const game = await apiClient.getGame(playerAlias, gameId);
+      const game = await apiClient.getGame(profileId, gameId);
       setCurrentGame(game);
       return game;
     } catch (err) {
@@ -211,33 +211,33 @@ export function useGameService(): UseGameServiceReturn {
     }
   }, []);
 
-  const pauseGame = useCallback(async (playerAlias: string, gameId: string): Promise<void> => {
-    if (!playerAlias || !gameId) return;
+  const pauseGame = useCallback(async (profileId: string, gameId: string): Promise<void> => {
+    if (!profileId || !gameId) return;
     try {
-      await apiClient.pauseGame(playerAlias, gameId);
+      await apiClient.pauseGame(profileId, gameId);
     } catch (err) {
       console.error('Failed to pause game:', err);
     }
   }, []);
 
-  const resumeGame = useCallback(async (playerAlias: string, gameId: string): Promise<void> => {
-    if (!playerAlias || !gameId) return;
+  const resumeGame = useCallback(async (profileId: string, gameId: string): Promise<void> => {
+    if (!profileId || !gameId) return;
     try {
-      await apiClient.resumeGame(playerAlias, gameId);
+      await apiClient.resumeGame(profileId, gameId);
     } catch (err) {
       console.error('Failed to resume game:', err);
     }
   }, []);
 
-  const makeMove = useCallback(async (playerAlias: string, gameId: string, row: number, column: number, value: number | null, duration: string): Promise<GameModel> => {
-    if (!playerAlias || !gameId) {
-      throw new Error('Player alias and game ID are required');
+  const makeMove = useCallback(async (profileId: string, gameId: string, row: number, column: number, value: number | null, duration: string): Promise<GameModel> => {
+    if (!profileId || !gameId) {
+      throw new Error('Profile ID and game ID are required');
     }
 
     setGameError(null);
 
     try {
-      const updatedGame = await apiClient.makeMove(playerAlias, gameId, row, column, value, duration);
+      const updatedGame = await apiClient.makeMove(profileId, gameId, row, column, value, duration);
       setCurrentGame(updatedGame);
       return updatedGame;
     } catch (err) {
@@ -248,15 +248,15 @@ export function useGameService(): UseGameServiceReturn {
     }
   }, []);
 
-  const undoMove = useCallback(async (playerAlias: string, gameId: string): Promise<GameModel> => {
-    if (!playerAlias || !gameId) {
-      throw new Error('Player alias and game ID are required');
+  const undoMove = useCallback(async (profileId: string, gameId: string): Promise<GameModel> => {
+    if (!profileId || !gameId) {
+      throw new Error('Profile ID and game ID are required');
     }
 
     setGameError(null);
 
     try {
-      const updatedGame = await apiClient.undoMove(playerAlias, gameId);
+      const updatedGame = await apiClient.undoMove(profileId, gameId);
       setCurrentGame(updatedGame);
       return updatedGame;
     } catch (err) {
@@ -267,15 +267,15 @@ export function useGameService(): UseGameServiceReturn {
     }
   }, []);
 
-  const resetGame = useCallback(async (playerAlias: string, gameId: string): Promise<GameModel> => {
-    if (!playerAlias || !gameId) {
-      throw new Error('Player alias and game ID are required');
+  const resetGame = useCallback(async (profileId: string, gameId: string): Promise<GameModel> => {
+    if (!profileId || !gameId) {
+      throw new Error('Profile ID and game ID are required');
     }
 
     setGameError(null);
 
     try {
-      const updatedGame = await apiClient.resetGame(playerAlias, gameId);
+      const updatedGame = await apiClient.resetGame(profileId, gameId);
       setCurrentGame(updatedGame);
       return updatedGame;
     } catch (err) {
@@ -286,15 +286,15 @@ export function useGameService(): UseGameServiceReturn {
     }
   }, []);
 
-  const addPossibleValue = useCallback(async (playerAlias: string, gameId: string, row: number, column: number, value: number): Promise<GameModel> => {
-    if (!playerAlias || !gameId) {
-      throw new Error('Player alias and game ID are required');
+  const addPossibleValue = useCallback(async (profileId: string, gameId: string, row: number, column: number, value: number): Promise<GameModel> => {
+    if (!profileId || !gameId) {
+      throw new Error('Profile ID and game ID are required');
     }
 
     setGameError(null);
 
     try {
-      const updatedGame = await apiClient.addPossibleValue(playerAlias, gameId, row, column, value);
+      const updatedGame = await apiClient.addPossibleValue(profileId, gameId, row, column, value);
       setCurrentGame(updatedGame);
       return updatedGame;
     } catch (err) {
@@ -305,15 +305,15 @@ export function useGameService(): UseGameServiceReturn {
     }
   }, []);
 
-  const removePossibleValue = useCallback(async (playerAlias: string, gameId: string, row: number, column: number, value: number): Promise<GameModel> => {
-    if (!playerAlias || !gameId) {
-      throw new Error('Player alias and game ID are required');
+  const removePossibleValue = useCallback(async (profileId: string, gameId: string, row: number, column: number, value: number): Promise<GameModel> => {
+    if (!profileId || !gameId) {
+      throw new Error('Profile ID and game ID are required');
     }
 
     setGameError(null);
 
     try {
-      const updatedGame = await apiClient.removePossibleValue(playerAlias, gameId, row, column, value);
+      const updatedGame = await apiClient.removePossibleValue(profileId, gameId, row, column, value);
       setCurrentGame(updatedGame);
       return updatedGame;
     } catch (err) {
@@ -324,15 +324,15 @@ export function useGameService(): UseGameServiceReturn {
     }
   }, []);
 
-  const clearPossibleValues = useCallback(async (playerAlias: string, gameId: string, row: number, column: number): Promise<GameModel> => {
-    if (!playerAlias || !gameId) {
-      throw new Error('Player alias and game ID are required');
+  const clearPossibleValues = useCallback(async (profileId: string, gameId: string, row: number, column: number): Promise<GameModel> => {
+    if (!profileId || !gameId) {
+      throw new Error('Profile ID and game ID are required');
     }
 
     setGameError(null);
 
     try {
-      const updatedGame = await apiClient.clearPossibleValues(playerAlias, gameId, row, column);
+      const updatedGame = await apiClient.clearPossibleValues(profileId, gameId, row, column);
       setCurrentGame(updatedGame);
       return updatedGame;
     } catch (err) {
@@ -354,7 +354,7 @@ export function useGameService(): UseGameServiceReturn {
     createGame,
     clearCache,
     refreshGames,
-    
+
     // Single game management
     currentGame,
     isGameLoading,

--- a/src/frontend/Sudoku.React/src/pages/CreateProfilePage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/CreateProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { apiClient } from '../api/apiClient';
 import type { ProfileInfo } from '../types';
@@ -13,14 +13,14 @@ export default function CreateProfilePage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const validate = (value: string): string | null => {
-    const trimmed = value.trim().toLowerCase();
+    const trimmed = value.trim();
     if (trimmed.length < 2) return 'Alias must be at least 2 characters.';
     if (trimmed.length > 50) return 'Alias cannot exceed 50 characters.';
-    if (!/^[a-z0-9 ]+$/.test(trimmed)) return 'Alias can only contain letters, numbers, and spaces.';
+    if (!/^[a-z0-9 ]+$/i.test(trimmed)) return 'Alias can only contain letters, numbers, and spaces.';
     return null;
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.SubmitEvent<HTMLFormElement>) => {
     e.preventDefault();
     setError(null);
 
@@ -32,7 +32,7 @@ export default function CreateProfilePage() {
 
     setIsSubmitting(true);
     try {
-      const result = await apiClient.createProfile(alias.trim().toLowerCase());
+      const result = await apiClient.createProfile(alias.trim());
 
       if (result.status === 201 && result.data) {
         const info: ProfileInfo = { profileId: result.data.profileId, alias: result.data.alias };

--- a/src/frontend/Sudoku.React/src/pages/GameListPage.test.tsx
+++ b/src/frontend/Sudoku.React/src/pages/GameListPage.test.tsx
@@ -27,7 +27,7 @@ function renderPage() {
 
 beforeEach(() => {
   mockNavigate.mockClear();
-  mockUsePlayerService.mockReturnValue({ isNewPlayer: false, isInitialized: true, playerAlias: 'test-user' });
+  mockUsePlayerService.mockReturnValue({ isNewPlayer: false, isInitialized: true, playerAlias: 'test-user', profileId: 'profile-test-user' });
   mockUseGameService.mockReturnValue({ savedGames: [], isLoaded: true, isLoading: false, error: null, loadGames: vi.fn(), deleteGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn() });
 });
 
@@ -60,7 +60,7 @@ describe('GameListPage', () => {
     const mockLoadGames = vi.fn();
     mockUseGameService.mockReturnValue({ savedGames: [], isLoaded: true, isLoading: false, error: null, loadGames: mockLoadGames, deleteGame: vi.fn() });
     renderPage();
-    await waitFor(() => { expect(mockLoadGames).toHaveBeenCalledWith('test-user'); });
+    await waitFor(() => { expect(mockLoadGames).toHaveBeenCalledWith('profile-test-user'); });
   });
 
   it('navigates to /game/:id when a game is selected', async () => {
@@ -79,11 +79,11 @@ describe('GameListPage', () => {
     mockUseGameService.mockReturnValue({ savedGames: [game], isLoaded: true, isLoading: false, error: null, loadGames: vi.fn(), deleteGame: mockDeleteGame });
     renderPage();
     await user.click(screen.getByTitle('Delete game'));
-    await waitFor(() => { expect(mockDeleteGame).toHaveBeenCalledWith('test-user', 'del123'); });
+    await waitFor(() => { expect(mockDeleteGame).toHaveBeenCalledWith('profile-test-user', 'del123'); });
   });
 
   it('redirects to / when new player visits', () => {
-    mockUsePlayerService.mockReturnValue({ isNewPlayer: true, isInitialized: false, playerAlias: null });
+    mockUsePlayerService.mockReturnValue({ isNewPlayer: true, isInitialized: false, playerAlias: null, profileId: null });
     renderPage();
     expect(mockNavigate).toHaveBeenCalledWith('/');
   });

--- a/src/frontend/Sudoku.React/src/pages/GameListPage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/GameListPage.tsx
@@ -9,20 +9,20 @@ import styles from './GameListPage.module.css';
 
 export default function GameListPage() {
   const navigate = useNavigate();
-  const { isNewPlayer, playerAlias } = usePlayerService();
+  const { isNewPlayer, profileId } = usePlayerService();
   const { savedGames, isLoaded, isLoading, error, loadGames, deleteGame } = useGameService();
 
   useEffect(() => {
     if (isNewPlayer) { navigate('/'); return; }
-    if (playerAlias) loadGames(playerAlias);
-  }, [isNewPlayer, playerAlias, loadGames, navigate]);
+    if (profileId) loadGames(profileId);
+  }, [isNewPlayer, profileId, loadGames, navigate]);
 
   const handleSelect = (game: GameModel) => navigate(`/game/${game.id}`);
 
   const handleDelete = async (game: GameModel) => {
-    if (!playerAlias) return;
+    if (!profileId) return;
     try {
-      await deleteGame(playerAlias, game.id);
+      await deleteGame(profileId, game.id);
     } catch (e) {
       console.error('Failed to delete game', e);
     }

--- a/src/frontend/Sudoku.React/src/pages/GamePage.integration.test.tsx
+++ b/src/frontend/Sudoku.React/src/pages/GamePage.integration.test.tsx
@@ -42,7 +42,7 @@ beforeEach(() => {
   // Mock usePlayerService to return successful initialization
   vi.mocked(usePlayerService).mockReturnValue({
     playerAlias: 'test-player',
-    profileId: null,
+    profileId: 'test-player',
     isInitialized: true,
     isNewPlayer: false,
     isLoading: false,

--- a/src/frontend/Sudoku.React/src/pages/GamePage.test.tsx
+++ b/src/frontend/Sudoku.React/src/pages/GamePage.test.tsx
@@ -57,12 +57,10 @@ function renderGamePage(gameId = 'test-game') {
 beforeEach(() => {
   vi.clearAllMocks();
   mockNavigate.mockClear();
-  localStorage.setItem('playerAlias', 'test-player');
-  
   // Mock usePlayerService to return successful initialization
   vi.mocked(usePlayerService).mockReturnValue({
     playerAlias: 'test-player',
-    profileId: null,
+    profileId: 'test-player',
     isInitialized: true,
     isNewPlayer: false,
     isLoading: false,

--- a/src/frontend/Sudoku.React/src/pages/GamePage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/GamePage.tsx
@@ -14,7 +14,7 @@ import styles from './GamePage.module.css';
 export default function GamePage() {
   const { puzzleId } = useParams<{ puzzleId: string }>();
   const navigate = useNavigate();
-  const { playerAlias, isInitialized, isNewPlayer, isLoading: playerLoading, error: playerError } = usePlayerService();
+  const { profileId, isInitialized, isNewPlayer, isLoading: playerLoading, error: playerError } = usePlayerService();
   const {
     currentGame,
     isGameLoading,
@@ -80,23 +80,23 @@ export default function GamePage() {
   };
 
   const pauseGameStatus = useCallback(async () => {
-    if (!game || solvedRef.current || !playerAlias) return;
+    if (!game || solvedRef.current || !profileId) return;
     stopTimer();
     try {
-      await pauseGame(playerAlias, game.id);
+      await pauseGame(profileId, game.id);
     } catch {
       // ignore
     }
-  }, [game, playerAlias, stopTimer, pauseGame]);
+  }, [game, profileId, stopTimer, pauseGame]);
 
   useEffect(() => {
-    if (!puzzleId || !playerAlias || !isInitialized) return;
+    if (!puzzleId || !profileId || !isInitialized) return;
     const load = async () => {
       try {
-        const g = await getGame(playerAlias, puzzleId);
+        const g = await getGame(profileId, puzzleId);
         const duration = g.statistics?.playDuration ?? '00:00:00';
         startTimer(duration);
-        await resumeGame(playerAlias, g.id);
+        await resumeGame(profileId, g.id);
       } catch (e) {
         console.error('Failed to load game', e);
         navigate('/');
@@ -107,7 +107,7 @@ export default function GamePage() {
       stopTimer();
       clearCurrentGame();
     };
-  }, [puzzleId, playerAlias, isInitialized, getGame, resumeGame, startTimer, stopTimer, navigate, clearCurrentGame]);
+  }, [puzzleId, profileId, isInitialized, getGame, resumeGame, startTimer, stopTimer, navigate, clearCurrentGame]);
 
   useEffect(() => {
     const handleVisibilityChange = () => {
@@ -131,9 +131,9 @@ export default function GamePage() {
         solvedRef.current = true;
         stopTimer();
         setSolved(true);
-        if (playerAlias) {
+        if (profileId) {
           try {
-            await deleteGame(playerAlias, game.id);
+            await deleteGame(profileId, game.id);
           } catch {
             // ignore
           }
@@ -145,49 +145,49 @@ export default function GamePage() {
   };
 
   const handleNumberInput = async (value: number) => {
-    if (!game || !selectedCell || !playerAlias) return;
+    if (!game || !selectedCell || !profileId) return;
     const cell = game.cells.find(c => c.row === selectedCell.row && c.column === selectedCell.column);
     if (!cell || cell.isFixed) return;
 
     if (pencilMode) {
       await handleCellAction(game.cells, async () => {
         if (cell.possibleValues.includes(value)) {
-          return removePossibleValue(playerAlias, game.id, selectedCell.row, selectedCell.column, value);
+          return removePossibleValue(profileId, game.id, selectedCell.row, selectedCell.column, value);
         } else {
-          return addPossibleValue(playerAlias, game.id, selectedCell.row, selectedCell.column, value);
+          return addPossibleValue(profileId, game.id, selectedCell.row, selectedCell.column, value);
         }
       });
     } else {
       await handleCellAction(game.cells, () =>
-        makeMove(playerAlias, game.id, selectedCell.row, selectedCell.column, value, formatDuration(elapsedRef.current))
+        makeMove(profileId, game.id, selectedCell.row, selectedCell.column, value, formatDuration(elapsedRef.current))
       );
     }
   };
 
   const handleErase = async () => {
-    if (!game || !selectedCell || !playerAlias) return;
+    if (!game || !selectedCell || !profileId) return;
     const cell = game.cells.find(c => c.row === selectedCell.row && c.column === selectedCell.column);
     if (!cell || cell.isFixed) return;
 
     if (pencilMode && cell.possibleValues.length > 0) {
       await handleCellAction(game.cells, () =>
-        clearPossibleValues(playerAlias, game.id, selectedCell.row, selectedCell.column)
+        clearPossibleValues(profileId, game.id, selectedCell.row, selectedCell.column)
       );
     } else if (!pencilMode && cell.hasValue) {
       await handleCellAction(game.cells, () =>
-        makeMove(playerAlias, game.id, selectedCell.row, selectedCell.column, null, formatDuration(elapsedRef.current))
+        makeMove(profileId, game.id, selectedCell.row, selectedCell.column, null, formatDuration(elapsedRef.current))
       );
     }
   };
 
   const handleUndo = async () => {
-    if (!game || !playerAlias) return;
-    await handleCellAction(game.cells, () => undoMove(playerAlias, game.id));
+    if (!game || !profileId) return;
+    await handleCellAction(game.cells, () => undoMove(profileId, game.id));
   };
 
   const handleReset = async () => {
-    if (!game || !playerAlias) return;
-    await handleCellAction(game.cells, () => resetGame(playerAlias, game.id));
+    if (!game || !profileId) return;
+    await handleCellAction(game.cells, () => resetGame(profileId, game.id));
   };
 
   const handleHome = async () => {

--- a/src/frontend/Sudoku.React/src/pages/NewGamePage.test.tsx
+++ b/src/frontend/Sudoku.React/src/pages/NewGamePage.test.tsx
@@ -43,7 +43,7 @@ beforeEach(() => {
   // Default mock implementations
   mockUsePlayerService.mockReturnValue({
     playerAlias: 'test-player',
-    profileId: null,
+    profileId: 'profile-123',
     isInitialized: true,
     isLoading: false,
     error: null,

--- a/src/frontend/Sudoku.React/src/pages/NewGamePage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/NewGamePage.tsx
@@ -8,16 +8,16 @@ import styles from './NewGamePage.module.css';
 export default function NewGamePage() {
   const { difficulty } = useParams<{ difficulty: string }>();
   const navigate = useNavigate();
-  const { playerAlias, isInitialized, isNewPlayer } = usePlayerService();
+  const { profileId, isInitialized, isNewPlayer } = usePlayerService();
   const { createGame } = useGameService();
 
   useEffect(() => {
     const create = async () => {
-      if (!isInitialized || !playerAlias || !difficulty) {
+      if (!isInitialized || !profileId || !difficulty) {
         return;
       }
       try {
-        const game = await createGame(playerAlias, difficulty);
+        const game = await createGame(profileId, difficulty);
         navigate(`/game/${game.id}`, { replace: true });
       } catch (e) {
         console.error('Failed to create game', e);
@@ -25,7 +25,7 @@ export default function NewGamePage() {
       }
     };
     create();
-  }, [difficulty, navigate, playerAlias, isInitialized, createGame]);
+  }, [difficulty, navigate, profileId, isInitialized, createGame]);
 
   useEffect(() => {
     if (isNewPlayer) navigate('/');

--- a/src/frontend/Sudoku.React/src/pages/ProfilePage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/ProfilePage.tsx
@@ -40,7 +40,7 @@ export default function ProfilePage() {
   }, [isInitialized, playerAlias]);
 
   const validateAlias = (value: string): string | null => {
-    const trimmed = value.trim().toLowerCase();
+    const trimmed = value.trim();
     if (trimmed.length < 2) return 'Alias must be at least 2 characters.';
     if (trimmed.length > 50) return 'Alias cannot exceed 50 characters.';
     if (!/^[a-z0-9 ]+$/.test(trimmed)) return 'Alias can only contain letters, numbers, and spaces.';
@@ -72,7 +72,7 @@ export default function ProfilePage() {
 
     setIsSaving(true);
     try {
-      const result = await apiClient.updateProfileAlias(playerAlias, newAlias.trim().toLowerCase());
+      const result = await apiClient.updateProfileAlias(playerAlias, newAlias.trim());
 
       if (result.status === 200 && result.data) {
         const stored = localStorage.getItem(PROFILE_KEY);

--- a/src/frontend/Sudoku.React/src/test/helpers.ts
+++ b/src/frontend/Sudoku.React/src/test/helpers.ts
@@ -35,7 +35,8 @@ export function make81Cells(overrides: Partial<CellModel>[] = []): CellModel[] {
 export function makeGame(overrides: Partial<GameModel> = {}): GameModel {
   return {
     id: 'game-1',
-    playerAlias: 'player1',
+    profileId: 'profile-1',
+    displayName: 'player1',
     difficulty: 'Easy',
     status: 'InProgress',
     statistics: makeStats(),

--- a/src/frontend/Sudoku.React/src/types/index.ts
+++ b/src/frontend/Sudoku.React/src/types/index.ts
@@ -34,7 +34,8 @@ export interface ProfileInfo {
 
 export interface GameModel {
   id: string;
-  playerAlias: string;
+  profileId: string;
+  displayName: string;
   difficulty: string;
   status: string;
   statistics: GameStatisticsModel;


### PR DESCRIPTION
## Description
Replaces all game lookups keyed on the mutable PlayerAlias string with the stable, immutable ProfileId GUID. Renames GameDto.PlayerAlias to DisplayName, adds ProfileId to SudokuGame/SudokuGameDocument/GameDto, updates all four game controller routes from {alias} to {profileId}, updates IGameRepository/CosmosDbGameRepository/AzureBlobGameRepository SQL filters to c.profileId, and removes .ToLowerInvariant() from CreateProfileCommandHandler, GetProfileByAliasQueryHandler, and UpdateProfileAliasCommandHandler so aliases are stored with original casing. React and Blazor frontends updated atomically to pass profileId in all game API calls.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

## Screenshots (if applicable)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation (if necessary)