### PR TITLE
Removed legacy player alias from local storage

### DIFF
--- a/.github/agents.md
+++ b/.github/agents.md
@@ -64,7 +64,8 @@ public class SudokuGame : AggregateRoot
     private readonly List<DomainEvent> _domainEvents;
 
     public GameId Id { get; private set; }
-    public PlayerAlias PlayerAlias { get; private set; }
+    public ProfileId ProfileId { get; private set; }
+    public PlayerAlias DisplayName { get; private set; }
     public GameDifficulty Difficulty { get; private set; }
     public GameStatus Status { get; private set; }
 
@@ -72,7 +73,7 @@ public class SudokuGame : AggregateRoot
     private SudokuGame() { }
 
     // Public factory method
-    public static SudokuGame Create(PlayerAlias playerAlias, GameDifficulty difficulty)
+    public static SudokuGame Create(ProfileId profileId, PlayerAlias displayName, GameDifficulty difficulty, IEnumerable<Cell> initialCells)
     {
         // Validation and creation logic
     }
@@ -91,7 +92,7 @@ public class SudokuGame : AggregateRoot
 
 ```csharp
 // Use CQRS pattern
-public record CreateGameCommand(string PlayerAlias, GameDifficulty Difficulty);
+public record CreateGameCommand(string ProfileId, string DisplayName, string Difficulty);
 public record GetGameQuery(GameId GameId);
 
 // Command/Query handlers
@@ -309,23 +310,23 @@ If a client needs the updated resource after a command, it issues a separate GET
 
 ```csharp
 // COMMAND endpoint — mutates state, returns no data
-[HttpPost("{alias}/games/{difficulty}")]
+[HttpPost("{profileId}/games/{difficulty}")]
 [ProducesResponseType(StatusCodes.Status201Created)]
 [ProducesResponseType(StatusCodes.Status400BadRequest)]
-public async Task<ActionResult> CreateGame(string alias, string difficulty)
+public async Task<ActionResult> CreateGame(string profileId, string difficulty)
 {
-    var result = await _gameService.CreateGameAsync(alias, difficulty);
+    var result = await _gameService.CreateGameAsync(profileId, difficulty);
     if (!result.IsSuccess)
         return BadRequest(result.Error);
 
-    return Created($"/api/players/{alias}/games/{result.Value.Id}", null);
+    return Created($"/api/players/{profileId}/games/{result.Value.Id}", null);
 }
 
 // QUERY endpoint — reads state, returns data
-[HttpGet("{alias}/games/{gameId}")]
+[HttpGet("{profileId}/games/{gameId}")]
 [ProducesResponseType(typeof(GameDto), StatusCodes.Status200OK)]
 [ProducesResponseType(StatusCodes.Status404NotFound)]
-public async Task<ActionResult<GameDto>> GetGame(string alias, string gameId)
+public async Task<ActionResult<GameDto>> GetGame(string profileId, string gameId)
 {
     var result = await _gameService.GetGameAsync(gameId);
     if (!result.IsSuccess)
@@ -384,7 +385,7 @@ public record GameId(Guid Value)
 ### Domain Events
 
 ```csharp
-public record GameCreatedEvent(GameId GameId, PlayerAlias PlayerAlias, GameDifficulty Difficulty) : DomainEvent;
+public record GameCreatedEvent(GameId GameId, ProfileId ProfileId, PlayerAlias DisplayName, GameDifficulty Difficulty) : DomainEvent;
 public record MoveMadeEvent(GameId GameId, int Row, int Column, int Value) : DomainEvent;
 ```
 
@@ -398,13 +399,13 @@ public interface ISpecification<T>
 
 public class GameByPlayerSpecification : ISpecification<Game>
 {
-    private readonly PlayerAlias _playerAlias;
+    private readonly ProfileId _profileId;
 
     public Expression<Func<Game, bool>> Criteria
     {
         get
         {
-            return game => game.PlayerAlias == _playerAlias;
+            return game => game.ProfileId == _profileId;
         }
     }
 }

--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -37,15 +37,15 @@
 
 ## User Profiles & Identity
 
-- [ ] **[P1]** **Profile creation flow** — Replace the auto-generated alias with an explicit "create your profile" onboarding step when a user first visits the app. The user picks their own alias/display name.
+- [x] **[P1]** **Profile creation flow** — Replace the auto-generated alias with an explicit "create your profile" onboarding step when a user first visits the app. The user picks their own alias/display name.
 - [ ] **[P4]** **Passwordless profile locking** — Secure profiles without traditional passwords. Options to explore: a device-bound passkey (WebAuthn/FIDO2), a one-time magic link sent to email, or a PIN stored in a signed/encrypted browser token. Goal: prevent another user from claiming or hijacking an existing alias.
-- [ ] **[P1]** **User profile page** — A dedicated page where users can view and edit their alias/display name, see their profile info, and manage their identity across sessions.
+- [x] **[P1]** **User profile page** — A dedicated page where users can view and edit their alias/display name, see their profile info, and manage their identity across sessions.
 
 ---
 
 ## Navigation & UX
 
-- [ ] **[P1]** **New landing/home page** — Replace the current entry point with a proper home screen offering clear navigation to: Manage Profile, View Game Stats, Start a New Game, and Browse Game List.
+- [x] **[P1]** **New landing/home page** — Replace the current entry point with a proper home screen offering clear navigation to: Manage Profile, View Game Stats, Start a New Game, and Browse Game List.
 - [ ] **[P2]** **Game stats page** — Surface per-user statistics: games played, win rate, average solve time by difficulty, best times, streaks, etc.
 
 ---

--- a/src/backend/Tests/Blazor/Pages/GamePageTests.cs
+++ b/src/backend/Tests/Blazor/Pages/GamePageTests.cs
@@ -14,8 +14,13 @@ namespace UnitTests.Blazor.Pages;
 
 public class GamePageTests : BunitContext
 {
-    private const string Alias = "test-alias";
     private const string PuzzleId = "test-puzzleId";
+
+    private readonly ProfileInfo _profile = new ProfileInfo
+    {
+        Alias = "test-alias",
+        ProfileId = Guid.NewGuid().ToString()
+    };
 
     private readonly Mock<INotificationService> _mockNotificationService = new();
     private readonly Mock<IGameManager> _mockGameManager = new();
@@ -27,14 +32,14 @@ public class GamePageTests : BunitContext
         var loadedGameState = GameModelFactory
             .Build()
             .WithDifficulty(GameDifficulty.Easy)
-            .WithProfileId(Alias)
+            .WithProfileId(_profile.ProfileId)
             .WithId(PuzzleId)
             .Create();
         var mockGameTimer = new Mock<IGameTimer>();
         _mockGameManager.Setup(x => x.CurrentStatistics).Returns(gameStatistics);
         _mockGameManager.Setup(x => x.Game).Returns(loadedGameState);
         _mockGameManager.Setup(x => x.Timer).Returns(mockGameTimer.Object);
-        _mockPlayerManager.SetupGetCurrentProfileIdAsync(Alias);
+        _mockPlayerManager.SetupCurrentProfile(_profile);
         Services.AddSingleton(_mockNotificationService.Object);
         Services.AddSingleton(_mockGameManager.Object);
         Services.AddSingleton(_mockPlayerManager.Object);
@@ -83,7 +88,7 @@ public class GamePageTests : BunitContext
         // Arrange
         var gameState = new GameModel
         {
-            ProfileId = Alias,
+            ProfileId = _profile.ProfileId,
             Cells = GameModelFactory.GetSolvedPuzzle().Cells,
             Id = PuzzleId
         };
@@ -163,7 +168,7 @@ public class GamePageTests : BunitContext
         // Arrange
         var gameState = new GameModel
         {
-            ProfileId = Alias,
+            ProfileId = _profile.ProfileId,
             Cells = GameModelFactory.GetSolvedPuzzle().Cells,
             Id = PuzzleId
         };
@@ -186,7 +191,7 @@ public class GamePageTests : BunitContext
         // Arrange
         var gameState = new GameModel
         {
-            ProfileId = Alias,
+            ProfileId = _profile.ProfileId,
             Cells = GameModelFactory.GetSolvedPuzzle().Cells,
             Id = PuzzleId
         };
@@ -210,7 +215,7 @@ public class GamePageTests : BunitContext
         // Arrange
         var gameState = new GameModel
         {
-            ProfileId = Alias,
+            ProfileId = _profile.ProfileId,
             Cells = GameModelFactory.GetSolvedPuzzle().Cells,
             Id = PuzzleId
         };
@@ -291,7 +296,7 @@ public class GamePageTests : BunitContext
         Render<Game>(parameters => parameters.Add(p => p.PuzzleId, PuzzleId));
 
         // Assert
-        _mockGameManager.VerifyLoadsAsyncCalled(Alias, PuzzleId, Times.Once);
+        _mockGameManager.VerifyLoadsAsyncCalled(_profile.ProfileId, PuzzleId, Times.Once);
     }
 
     [Fact]

--- a/src/backend/Tests/Blazor/Pages/IndexPageTests.cs
+++ b/src/backend/Tests/Blazor/Pages/IndexPageTests.cs
@@ -27,21 +27,11 @@ public class IndexPageTests : BunitContext
     {
         var profile = new ProfileInfo { ProfileId = Guid.NewGuid().ToString(), Alias = alias };
         _mockLocalStorage.Setup(x => x.GetProfileAsync()).ReturnsAsync(profile);
-        _mockLocalStorage.Setup(x => x.GetAliasAsync()).ReturnsAsync((string?)null);
     }
 
     private void SetupNewPlayer()
     {
         _mockLocalStorage.Setup(x => x.GetProfileAsync()).ReturnsAsync((ProfileInfo?)null);
-        _mockLocalStorage.Setup(x => x.GetAliasAsync()).ReturnsAsync((string?)null);
-    }
-
-    private void SetupLegacyPlayer(string alias)
-    {
-        _mockLocalStorage.Setup(x => x.GetProfileAsync()).ReturnsAsync((ProfileInfo?)null);
-        _mockLocalStorage.Setup(x => x.GetAliasAsync()).ReturnsAsync(alias);
-        _mockLocalStorage.Setup(x => x.SetProfileAsync(It.IsAny<ProfileInfo>())).Returns(Task.CompletedTask);
-        _mockLocalStorage.Setup(x => x.RemoveAliasAsync()).Returns(Task.CompletedTask);
     }
 
     [Fact]
@@ -115,14 +105,5 @@ public class IndexPageTests : BunitContext
         // LocalStorageService is the only service injected — no IPlayerApiClient or IGameManager
         // This test verifies no backend dependency is needed
         _mockLocalStorage.Verify(x => x.GetProfileAsync(), Times.AtLeastOnce);
-    }
-
-    [Fact]
-    public void LegacyMigration_WritesProfileAndRemovesAlias()
-    {
-        SetupLegacyPlayer("old-alias");
-        Render<IndexPage>();
-        _mockLocalStorage.Verify(x => x.SetProfileAsync(It.Is<ProfileInfo>(p => p.Alias == "old-alias")), Times.Once);
-        _mockLocalStorage.Verify(x => x.RemoveAliasAsync(), Times.Once);
     }
 }

--- a/src/backend/Tests/Blazor/Pages/NewPageTests.cs
+++ b/src/backend/Tests/Blazor/Pages/NewPageTests.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Sudoku.Blazor.Components.Pages;
+using Sudoku.Blazor.Models;
 using Sudoku.Blazor.Services.Abstractions;
 
 namespace UnitTests.Blazor.Pages;
@@ -11,14 +12,19 @@ public class NewPageTests : BunitContext
 {
     private readonly Mock<IGameManager>? _mockGameManager;
 
+    private readonly ProfileInfo _profile = new ProfileInfo
+    {
+        Alias = "test-displayName",
+        ProfileId = Guid.NewGuid().ToString()
+    };
+
     public NewPageTests()
     {
-        var alias = "game-alias";
         _mockGameManager = new Mock<IGameManager>();
         var playerManager = new Mock<IPlayerManager>();
-        playerManager.SetupGetCurrentProfileIdAsync(alias);
+        playerManager.SetupCurrentProfile(_profile);
 
-        _mockGameManager.SetupCreateGameAsync(alias, "Medium");
+        _mockGameManager.SetupCreateGameAsync(_profile.ProfileId, "Medium");
 
         Services.AddSingleton(_mockGameManager.Object);
         Services.AddSingleton(playerManager.Object);
@@ -42,7 +48,7 @@ public class NewPageTests : BunitContext
         Render<New>(parameters => parameters.Add(p => p.Difficulty, "Medium"));
 
         // Assert
-        _mockGameManager!.VerifyCreateGameAsyncCalled("game-alias", "Medium", Times.Once);
+        _mockGameManager!.VerifyCreateGameAsyncCalled(_profile.ProfileId, "Medium", Times.Once);
     }
 
     [Fact]

--- a/src/backend/Tests/Blazor/Services/LocalStorageServiceTests.cs
+++ b/src/backend/Tests/Blazor/Services/LocalStorageServiceTests.cs
@@ -87,53 +87,6 @@ public class LocalStorageServiceTests : MoqBaseTestByAbstraction<LocalStorageSer
 
     #endregion
 
-    #region GetAliasAsync Tests
-
-    [Fact]
-    public async Task GetAliasAsync_WhenAliasExists_ReturnsAlias()
-    {
-        // Arrange
-        var expectedAlias = Container.Create<string>();
-        _mockJsRuntime.SetupAliasV2(expectedAlias);
-        var sut = ResolveSut();
-
-        // Act
-        var result = await sut.GetAliasAsync();
-
-        // Assert
-        result.Should().Be(expectedAlias);
-    }
-
-    [Fact]
-    public async Task GetAliasAsync_WhenAliasIsNull_ReturnsNull()
-    {
-        // Arrange
-        _mockJsRuntime.SetupAliasV2(null);
-        var sut = ResolveSut();
-
-        // Act
-        var result = await sut.GetAliasAsync();
-
-        // Assert
-        result.Should().BeEmpty();
-    }
-
-    [Fact]
-    public async Task GetAliasAsync_CallsJsRuntimeWithCorrectKey()
-    {
-        // Arrange
-        _mockJsRuntime.SetupAliasV2("test");
-        var sut = ResolveSut();
-
-        // Act
-        await sut.GetAliasAsync();
-
-        // Assert
-        _mockJsRuntime.VerifyGetsAliasV2(Times.Once);
-    }
-
-    #endregion
-
     #region LoadGameAsync Tests
 
     [Fact]
@@ -375,52 +328,6 @@ public class LocalStorageServiceTests : MoqBaseTestByAbstraction<LocalStorageSer
 
         // Assert
         _mockJsRuntime.VerifyLoadsSavedGamesV2(Times.Once);
-    }
-
-    #endregion
-
-    #region SetAliasAsync Tests
-
-    [Fact]
-    public async Task SetAliasAsync_CallsJsRuntimeWithCorrectParameters()
-    {
-        // Arrange
-        var alias = Container.Create<string>();
-        var sut = ResolveSut();
-
-        // Act
-        await sut.SetAliasAsync(alias);
-
-        // Assert
-        _mockJsRuntime.VerifySavesAliasV2(alias, Times.Once);
-    }
-
-    [Fact]
-    public async Task SetAliasAsync_WithEmptyAlias_StillCallsJsRuntime()
-    {
-        // Arrange
-        var emptyAlias = string.Empty;
-        var sut = ResolveSut();
-
-        // Act
-        await sut.SetAliasAsync(emptyAlias);
-
-        // Assert
-        _mockJsRuntime.VerifySavesAliasV2(emptyAlias, Times.Once);
-    }
-
-    [Fact]
-    public async Task SetAliasAsync_WithNullAlias_StillCallsJsRuntime()
-    {
-        // Arrange
-        string nullAlias = null!;
-        var sut = ResolveSut();
-
-        // Act
-        await sut.SetAliasAsync(nullAlias);
-
-        // Assert
-        _mockJsRuntime.VerifySavesAliasV2(nullAlias, Times.Once);
     }
 
     #endregion

--- a/src/backend/Tests/Blazor/Services/PlayerManagerTests.cs
+++ b/src/backend/Tests/Blazor/Services/PlayerManagerTests.cs
@@ -1,85 +1,217 @@
 using DepenMock.Moq;
+using Sudoku.Blazor.Models;
 using Sudoku.Blazor.Services;
 using Sudoku.Blazor.Services.Abstractions;
+using Sudoku.Blazor.Services.HttpClients;
 
 namespace UnitTests.Blazor.Services;
 
 public class PlayerManagerTests : MoqBaseTestByAbstraction<PlayerManager, IPlayerManager>
 {
-    private const string TestAlias = "TestPlayer";
-
     private readonly Mock<ILocalStorageService> _mockLocalStorageService;
+    private readonly Mock<IPlayerApiClient> _mockPlayerApiClient;
+    private readonly IPlayerManager _sut;
 
     public PlayerManagerTests()
     {
         _mockLocalStorageService = Container.ResolveMock<ILocalStorageService>().AsMoq();
+        _mockPlayerApiClient = Container.ResolveMock<IPlayerApiClient>().AsMoq();
+
+        _sut = ResolveSut();
     }
 
     [Fact]
-    public async Task GetCurrentPlayerAsync_ReturnsAliasFromLocalStorage()
+    public async Task CreateProfileAsync_CallsApiClient()
     {
         // Arrange
-        var expectedAlias = TestAlias;
-        _mockLocalStorageService.SetupGetAliasAsync(expectedAlias);
-        var sut = ResolveSut();
+        var displayName = Container.Create<string>();
 
         // Act
-        var result = await sut.GetCurrentPlayerAsync();
+        await _sut.CreateProfileAsync(displayName);
 
         // Assert
-        result.Should().Be(expectedAlias);
+        _mockPlayerApiClient.VerifyCreatesProfile(displayName);
     }
 
     [Fact]
-    public async Task GetCurrentPlayerAsync_WhenNoAliasStored_ReturnsNull()
+    public async Task CreateProfileAsync_WhenCreateProfileSuccess_SavesToLocalStorage()
     {
         // Arrange
-        _mockLocalStorageService.SetupGetAliasAsync(null);
-        var sut = ResolveSut();
+        var profile = Container.Create<ProfileInfo>();
+        var profileDto = Container.Build<ProfileDto>()
+            .With(x => x.Alias, profile.Alias)
+            .With(x => x.ProfileId, profile.ProfileId)
+            .Create();
+        _mockPlayerApiClient.SetupCreateProfile(profileDto);
 
         // Act
-        var result = await sut.GetCurrentPlayerAsync();
+        await _sut.CreateProfileAsync(profile.Alias);
+
+        // Assert
+        _mockLocalStorageService.VerifySavesProfile(profile);
+    }
+
+    [Fact]
+    public async Task CreateProfileAsync_WhenApiClientReturnsFailure_ReturnsFailureResult()
+    {
+        // Arrange
+        var errorMessage = Container.Create<string>();
+        _mockPlayerApiClient.SetupCreateProfileFailure(errorMessage);
+
+        // Act
+        var result = await _sut.CreateProfileAsync(Container.Create<string>());
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(errorMessage);
+    }
+
+    [Fact]
+    public async Task GetCurrentProfileAsync_ReturnsProfileFromLocalStorage()
+    {
+        // Arrange
+        var profile = Container.Create<ProfileInfo>();
+        _mockLocalStorageService.SetupGetProfile(profile);
+
+        // Act
+        var result = await _sut.GetCurrentProfileAsync();
+
+        // Assert
+        result.Should().BeEquivalentTo(profile);
+    }
+
+    [Fact]
+    public async Task GetCurrentProfileAsync_WhenNoProfileInStorage_ReturnsNull()
+    {
+        // Arrange
+        _mockLocalStorageService.SetupGetProfileReturnsNull();
+
+        // Act
+        var result = await _sut.GetCurrentProfileAsync();
 
         // Assert
         result.Should().BeNull();
     }
 
     [Fact]
-    public async Task SetCurrentPlayerAsync_WithEmptyAlias_ThrowsArgumentException()
+    public async Task EnsureProfileInitializedAsync_WhenNoProfileInStorage_ReturnsFalse()
     {
         // Arrange
-        var sut = ResolveSut();
+        _mockLocalStorageService.SetupGetProfileReturnsNull();
 
         // Act
-        Func<Task> act = async () => await sut.SetCurrentPlayerAsync(string.Empty);
+        var result = await _sut.EnsureProfileInitializedAsync();
 
         // Assert
-        await act.Should().ThrowAsync<ArgumentException>().WithMessage("Alias not set.");
+        result.Should().BeFalse();
     }
 
     [Fact]
-    public async Task SetCurrentPlayerAsync_WithNullAlias_ThrowsArgumentException()
+    public async Task EnsureProfileInitializedAsync_WhenProfileExistsInStorageAndBackend_ReturnsTrue()
     {
         // Arrange
-        var sut = ResolveSut();
+        var profile = Container.Create<ProfileInfo>();
+        var profileDto = Container.Build<ProfileDto>()
+            .With(x => x.Alias, profile.Alias)
+            .With(x => x.ProfileId, profile.ProfileId)
+            .Create();
+        _mockLocalStorageService.SetupGetProfile(profile);
+        _mockPlayerApiClient.SetupGetProfile(profileDto);
 
         // Act
-        Func<Task> act = async () => await sut.SetCurrentPlayerAsync(null!);
+        var result = await _sut.EnsureProfileInitializedAsync();
 
         // Assert
-        await act.Should().ThrowAsync<ArgumentException>().WithMessage("Alias not set.");
+        result.Should().BeTrue();
     }
 
     [Fact]
-    public async Task SetCurrentPlayerAsync_WithValidAlias_CallsLocalStorageService()
+    public async Task EnsureProfileInitializedAsync_WhenProfileInStorageButNotBackend_RecreatesProfileAndReturnsTrue()
     {
         // Arrange
-        var sut = ResolveSut();
+        var profile = Container.Create<ProfileInfo>();
+        var profileDto = Container.Build<ProfileDto>()
+            .With(x => x.Alias, profile.Alias)
+            .With(x => x.ProfileId, profile.ProfileId)
+            .Create();
+        _mockLocalStorageService.SetupGetProfile(profile);
+        _mockPlayerApiClient.SetupGetProfileReturnsNull();
+        _mockPlayerApiClient.SetupCreateProfile(profileDto);
 
         // Act
-        await sut.SetCurrentPlayerAsync(TestAlias);
+        var result = await _sut.EnsureProfileInitializedAsync();
 
         // Assert
-        _mockLocalStorageService.Verify(x => x.SetAliasAsync(TestAlias), Times.Once);
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task EnsureProfileInitializedAsync_WhenBackendUnavailable_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var profile = Container.Create<ProfileInfo>();
+        var errorMessage = Container.Create<string>();
+        _mockLocalStorageService.SetupGetProfile(profile);
+        _mockPlayerApiClient.SetupGetProfileFailure(errorMessage);
+
+        // Act
+        var act = async () => await _sut.EnsureProfileInitializedAsync();
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage($"*{errorMessage}*");
+    }
+
+    [Fact]
+    public async Task UpdateAliasAsync_WhenNoProfileInStorage_ReturnsFailureResult()
+    {
+        // Arrange
+        _mockLocalStorageService.SetupGetProfileReturnsNull();
+
+        // Act
+        var result = await _sut.UpdateAliasAsync(Container.Create<string>());
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("Profile not found");
+    }
+
+    [Fact]
+    public async Task UpdateAliasAsync_WhenUpdateSucceeds_UpdatesLocalStorageAndReturnsSuccess()
+    {
+        // Arrange
+        var profile = Container.Create<ProfileInfo>();
+        var newAlias = Container.Create<string>();
+        var updatedDto = Container.Build<ProfileDto>()
+            .With(x => x.ProfileId, profile.ProfileId)
+            .With(x => x.Alias, newAlias)
+            .Create();
+        _mockLocalStorageService.SetupGetProfile(profile);
+        _mockPlayerApiClient.SetupUpdateProfileAlias(updatedDto);
+
+        // Act
+        var result = await _sut.UpdateAliasAsync(newAlias);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Alias.Should().Be(newAlias);
+        _mockLocalStorageService.VerifySavesProfile(result.Value);
+    }
+
+    [Fact]
+    public async Task UpdateAliasAsync_WhenApiClientReturnsFailure_ReturnsFailureResult()
+    {
+        // Arrange
+        var profile = Container.Create<ProfileInfo>();
+        var errorMessage = Container.Create<string>();
+        _mockLocalStorageService.SetupGetProfile(profile);
+        _mockPlayerApiClient.SetupUpdateProfileAliasFailure(errorMessage);
+
+        // Act
+        var result = await _sut.UpdateAliasAsync(Container.Create<string>());
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(errorMessage);
     }
 }

--- a/src/backend/Tests/Mocks/MockLocalStorageServiceV2Extensions.cs
+++ b/src/backend/Tests/Mocks/MockLocalStorageServiceV2Extensions.cs
@@ -7,46 +7,19 @@ public static class MockLocalStorageServiceV2Extensions
 {
     extension(Mock<ILocalStorageService> mock)
     {
-        public void SetupGetAliasAsync(string? alias)
+        public void SetupGetProfile(ProfileInfo profile)
         {
-            mock
-                .Setup(x => x.GetAliasAsync())
-                .ReturnsAsync(alias);
-            mock
-                .Setup(x => x.GetProfileAsync())
-                .ReturnsAsync((Sudoku.Blazor.Models.ProfileInfo?)null);
+            mock.Setup(x => x.GetProfileAsync()).ReturnsAsync(profile);
         }
 
-        public void SetupLoadGameAsync(GameModel? gameState)
+        public void SetupGetProfileReturnsNull()
         {
-            mock
-                .Setup(x => x.LoadGameAsync(It.IsAny<string>()))
-                .ReturnsAsync(gameState);
+            mock.Setup(x => x.GetProfileAsync()).ReturnsAsync((ProfileInfo?)null);
         }
 
-        public void VerifyDeleteGameAsyncCalled(Func<Times> times)
+        public void VerifySavesProfile(ProfileInfo profile)
         {
-            mock.Verify(x => x.DeleteGameAsync(It.IsAny<string>()), times);
-        }
-
-        public void VerifySaveGameAsyncCalled(Func<Times> times)
-        {
-            mock.Verify(x => x.SaveGameStateAsync(It.IsAny<GameModel>()), Times.Once);
-        }
-
-        public void VerifySetAliasAsyncCalled(Func<Times> times)
-        {
-            mock.Verify(x => x.SetAliasAsync(It.IsAny<string>()), times);
-        }
-
-        public void VerifyLoadGameAsyncCalled(Func<Times> times)
-        {
-            mock.Verify(x => x.LoadGameAsync(It.IsAny<string>()), times);
-        }
-
-        public void VerifyLoadGamesAsyncCalled(Func<Times> times)
-        {
-            mock.Verify(x => x.LoadGameStatesAsync(), times);
+            mock.Verify(x => x.SetProfileAsync(It.Is<ProfileInfo>(p => p.Alias == profile.Alias && p.ProfileId == profile.ProfileId)), Times.Once);
         }
     }
 }

--- a/src/backend/Tests/Mocks/MockPlayerApiClientExtensions.cs
+++ b/src/backend/Tests/Mocks/MockPlayerApiClientExtensions.cs
@@ -1,0 +1,58 @@
+﻿using Sudoku.Blazor.Models;
+using Sudoku.Blazor.Services.HttpClients;
+
+namespace UnitTests.Mocks;
+
+public static class MockPlayerApiClientExtensions
+{
+    extension(Mock<IPlayerApiClient> mock)
+    {
+        public void SetupCreateProfile(ProfileDto dto)
+        {
+            var apiResult = ApiResult<ProfileDto>.Success(dto);
+            mock.Setup(x => x.CreateProfileAsync(It.IsAny<string>()))
+                .ReturnsAsync(apiResult);
+        }
+
+        public void SetupCreateProfileFailure(string error = "Failed to create profile", int statusCode = 500)
+        {
+            mock.Setup(x => x.CreateProfileAsync(It.IsAny<string>()))
+                .ReturnsAsync(ApiResult<ProfileDto>.Failure(error, statusCode));
+        }
+
+        public void SetupGetProfile(ProfileDto dto)
+        {
+            mock.Setup(x => x.GetProfileAsync(It.IsAny<string>()))
+                .ReturnsAsync(ApiResult<ProfileDto?>.Success(dto));
+        }
+
+        public void SetupGetProfileReturnsNull()
+        {
+            mock.Setup(x => x.GetProfileAsync(It.IsAny<string>()))
+                .ReturnsAsync(ApiResult<ProfileDto?>.Success(null));
+        }
+
+        public void SetupGetProfileFailure(string error = "Failed to get profile", int statusCode = 500)
+        {
+            mock.Setup(x => x.GetProfileAsync(It.IsAny<string>()))
+                .ReturnsAsync(ApiResult<ProfileDto?>.Failure(error, statusCode));
+        }
+
+        public void SetupUpdateProfileAlias(ProfileDto dto)
+        {
+            mock.Setup(x => x.UpdateProfileAliasAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(ApiResult<ProfileDto>.Success(dto));
+        }
+
+        public void SetupUpdateProfileAliasFailure(string error = "Failed to update alias", int statusCode = 500)
+        {
+            mock.Setup(x => x.UpdateProfileAliasAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(ApiResult<ProfileDto>.Failure(error, statusCode));
+        }
+
+        public void VerifyCreatesProfile(string displayName)
+        {
+            mock.Verify(x => x.CreateProfileAsync(displayName), Times.Once);
+        }
+    }
+}

--- a/src/backend/Tests/Mocks/MockPlayerManagerExtensions.cs
+++ b/src/backend/Tests/Mocks/MockPlayerManagerExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Sudoku.Blazor.Services.Abstractions;
+﻿using Sudoku.Blazor.Models;
+using Sudoku.Blazor.Services.Abstractions;
 
 namespace UnitTests.Mocks;
 
@@ -6,22 +7,10 @@ public static class MockPlayerManagerExtensions
 {
     extension(Mock<IPlayerManager> mock)
     {
-        public void SetupGetCurrentPlayerAsync(string alias)
+        public void SetupCurrentProfile(ProfileInfo profile)
         {
-            mock.Setup(x => x.GetCurrentPlayerAsync())
-                .ReturnsAsync(alias);
-            mock.Setup(x => x.EnsureProfileInitializedAsync())
-                .ReturnsAsync(true);
-            mock.Setup(x => x.TryGetPlayerAlias())
-                .ReturnsAsync(alias);
-        }
-
-        public void SetupGetCurrentProfileIdAsync(string profileId)
-        {
-            mock.Setup(x => x.GetCurrentProfileIdAsync())
-                .ReturnsAsync(profileId);
-            mock.Setup(x => x.EnsureProfileInitializedAsync())
-                .ReturnsAsync(true);
+            mock.Setup(x => x.GetCurrentProfileAsync())
+                .ReturnsAsync(profile);
         }
     }
 }

--- a/src/frontend/Sudoku.Blazor/Components/Pages/CreateProfile.razor.cs
+++ b/src/frontend/Sudoku.Blazor/Components/Pages/CreateProfile.razor.cs
@@ -1,19 +1,15 @@
-using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Components;
-using Sudoku.Blazor.Models;
 using Sudoku.Blazor.Services.Abstractions;
-using Sudoku.Blazor.Services.HttpClients;
 
 namespace Sudoku.Blazor.Components.Pages;
 
 public partial class CreateProfile
 {
     [Inject] public required NavigationManager NavigationManager { get; set; }
-    [Inject] public required IPlayerApiClient PlayerApiClient { get; set; }
-    [Inject] public required ILocalStorageService LocalStorageService { get; set; }
+    [Inject] public required IPlayerManager PlayerManager { get; set; }
     [Inject] public required ILogger<CreateProfile> Logger { get; set; }
 
-    private CreateProfileModel _model = new();
+    private Models.CreateProfileModel _model = new();
     private string? _errorMessage;
     private bool _hasError;
     private bool _isSubmitting;
@@ -22,21 +18,14 @@ public partial class CreateProfile
     {
         _errorMessage = null;
         _hasError = false;
-
-        var trimmedAlias = _model.Alias.Trim();
         _isSubmitting = true;
 
         try
         {
-            var result = await PlayerApiClient.CreateProfileAsync(trimmedAlias);
+            var result = await PlayerManager.CreateProfileAsync(_model.Alias.Trim());
 
-            if (result.IsSuccess && result.Value != null)
+            if (result.IsSuccess)
             {
-                await LocalStorageService.SetProfileAsync(new ProfileInfo
-                {
-                    ProfileId = result.Value.ProfileId,
-                    Alias = result.Value.Alias
-                });
                 NavigationManager.NavigateTo("/");
                 return;
             }
@@ -61,14 +50,5 @@ public partial class CreateProfile
         {
             _isSubmitting = false;
         }
-    }
-
-    private class CreateProfileModel
-    {
-        [Required(ErrorMessage = "Alias is required.")]
-        [MinLength(2, ErrorMessage = "Alias must be at least 2 characters.")]
-        [MaxLength(50, ErrorMessage = "Alias cannot exceed 50 characters.")]
-        [RegularExpression(@"^[a-zA-Z0-9 ]+$", ErrorMessage = "Alias can only contain letters, numbers, and spaces.")]
-        public string Alias { get; set; } = string.Empty;
     }
 }

--- a/src/frontend/Sudoku.Blazor/Components/Pages/Game.razor.cs
+++ b/src/frontend/Sudoku.Blazor/Components/Pages/Game.razor.cs
@@ -55,7 +55,9 @@ public partial class Game
 
     private async Task LoadGameStateAsync()
     {
-        ProfileId = await PlayerManager.GetCurrentProfileIdAsync() ?? string.Empty;
+        var profile = await PlayerManager.GetCurrentProfileAsync();
+        ProfileId = profile!.ProfileId;
+
         Logger.LogInformation("Loading game {PuzzleId} for profile {ProfileId}", PuzzleId, ProfileId);
 
         await GameManager.LoadGameAsync(ProfileId, PuzzleId!);

--- a/src/frontend/Sudoku.Blazor/Components/Pages/Index.razor.cs
+++ b/src/frontend/Sudoku.Blazor/Components/Pages/Index.razor.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Components;
-using Sudoku.Blazor.Models;
 using Sudoku.Blazor.Services.Abstractions;
 
 namespace Sudoku.Blazor.Components.Pages;
@@ -18,39 +17,12 @@ public partial class Index
 
         Logger.LogInformation("Home page initializing");
 
-        await MigrateProfileIfNeededAsync();
-
         var profile = await LocalStorageService.GetProfileAsync();
         _isReturningPlayer = profile != null;
 
         Logger.LogInformation("Home page initialized, returning player: {IsReturningPlayer}", _isReturningPlayer);
 
         StateHasChanged();
-    }
-
-    private async Task MigrateProfileIfNeededAsync()
-    {
-        try
-        {
-            var profile = await LocalStorageService.GetProfileAsync();
-            if (profile != null) return;
-
-            var legacyAlias = await LocalStorageService.GetAliasAsync();
-            if (string.IsNullOrEmpty(legacyAlias)) return;
-
-            await LocalStorageService.SetProfileAsync(new ProfileInfo
-            {
-                ProfileId = Guid.NewGuid().ToString(),
-                Alias = legacyAlias.Trim()
-            });
-            await LocalStorageService.RemoveAliasAsync();
-
-            Logger.LogInformation("Migrated legacy alias to profile");
-        }
-        catch (Exception ex)
-        {
-            Logger.LogWarning(ex, "Profile migration failed silently, treating as new player");
-        }
     }
 
     private void NavigateToProfile()

--- a/src/frontend/Sudoku.Blazor/Components/Pages/New.razor.cs
+++ b/src/frontend/Sudoku.Blazor/Components/Pages/New.razor.cs
@@ -20,7 +20,8 @@ public partial class New
 
     private async Task GenerateNewGameAsync()
     {
-        var profileId = await PlayerManager.GetCurrentProfileIdAsync();
+        var profile = await PlayerManager.GetCurrentProfileAsync();
+        var profileId = profile!.ProfileId;
 
         Logger.LogInformation("Generating new game with difficulty {Difficulty} for profile {ProfileId}", Difficulty, profileId);
 

--- a/src/frontend/Sudoku.Blazor/Components/Pages/Profile.razor
+++ b/src/frontend/Sudoku.Blazor/Components/Pages/Profile.razor
@@ -44,14 +44,6 @@
                 }
             </div>
 
-            @if (_createdAt.HasValue)
-            {
-                <div class="profile-field">
-                    <span class="field-label">Member since</span>
-                    <span>@_createdAt.Value.ToLocalTime().ToString("MMMM d, yyyy")</span>
-                </div>
-            }
-
             <p class="warning-note">
                 Your profile is stored in this browser. Clearing browser data will require you to create a new profile.
             </p>

--- a/src/frontend/Sudoku.Blazor/Components/Pages/Profile.razor
+++ b/src/frontend/Sudoku.Blazor/Components/Pages/Profile.razor
@@ -20,7 +20,7 @@
                     <EditForm Model="@_editModel" OnValidSubmit="HandleSaveAliasAsync">
                         <DataAnnotationsValidator />
                         <div class="edit-row">
-                            <InputText @bind-Value="_editModel.NewAlias" class="form-control" maxlength="50" />
+                            <InputText @bind-Value="_editModel.DisplayName" class="form-control" maxlength="50" />
                             <div class="edit-actions">
                                 <button type="submit" class="btn btn-primary" disabled="@_isSaving">
                                     @(_isSaving ? "Saving…" : "Save")
@@ -28,7 +28,7 @@
                                 <button type="button" class="btn btn-outline-secondary" @onclick="CancelEdit">Cancel</button>
                             </div>
                         </div>
-                        <ValidationMessage For="@(() => _editModel.NewAlias)" />
+                        <ValidationMessage For="@(() => _editModel.DisplayName)" />
                         @if (!string.IsNullOrEmpty(_editError))
                         {
                             <div class="error-message" role="alert">@_editError</div>

--- a/src/frontend/Sudoku.Blazor/Components/Pages/Profile.razor.cs
+++ b/src/frontend/Sudoku.Blazor/Components/Pages/Profile.razor.cs
@@ -11,7 +11,6 @@ public partial class Profile
     [Inject] public required ILogger<EditProfileModel> Logger { get; set; }
 
     private string? _alias;
-    private DateTime? _createdAt;
     private bool _isLoading = true;
     private bool _isEditing;
     private bool _isSaving;
@@ -32,7 +31,6 @@ public partial class Profile
             }
 
             _alias = profile.Alias;
-            _createdAt = await PlayerManager.GetProfileCreatedAtAsync();
         }
         catch (Exception ex)
         {

--- a/src/frontend/Sudoku.Blazor/Components/Pages/Profile.razor.cs
+++ b/src/frontend/Sudoku.Blazor/Components/Pages/Profile.razor.cs
@@ -1,8 +1,6 @@
-using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Components;
 using Sudoku.Blazor.Models;
 using Sudoku.Blazor.Services.Abstractions;
-using Sudoku.Blazor.Services.HttpClients;
 
 namespace Sudoku.Blazor.Components.Pages;
 
@@ -10,9 +8,7 @@ public partial class Profile
 {
     [Inject] public required NavigationManager NavigationManager { get; set; }
     [Inject] public required IPlayerManager PlayerManager { get; set; }
-    [Inject] public required IPlayerApiClient PlayerApiClient { get; set; }
-    [Inject] public required ILocalStorageService LocalStorageService { get; set; }
-    [Inject] public required ILogger<Profile> Logger { get; set; }
+    [Inject] public required ILogger<EditProfileModel> Logger { get; set; }
 
     private string? _alias;
     private DateTime? _createdAt;
@@ -20,7 +16,7 @@ public partial class Profile
     private bool _isEditing;
     private bool _isSaving;
     private string? _editError;
-    private EditAliasModel _editModel = new();
+    private EditProfileModel _editModel = new();
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -36,12 +32,7 @@ public partial class Profile
             }
 
             _alias = profile.Alias;
-
-            var getResult = await PlayerApiClient.GetProfileAsync(profile.Alias);
-            if (getResult.IsSuccess && getResult.Value != null)
-            {
-                _createdAt = getResult.Value.CreatedAt;
-            }
+            _createdAt = await PlayerManager.GetProfileCreatedAtAsync();
         }
         catch (Exception ex)
         {
@@ -58,7 +49,7 @@ public partial class Profile
 
     private void StartEdit()
     {
-        _editModel = new EditAliasModel { NewAlias = _alias ?? string.Empty };
+        _editModel = new EditProfileModel { DisplayName = _alias ?? string.Empty };
         _editError = null;
         _isEditing = true;
     }
@@ -72,25 +63,15 @@ public partial class Profile
     private async Task HandleSaveAliasAsync()
     {
         _editError = null;
-        if (_alias == null) return;
-
-        var aliasName = _editModel.NewAlias.Trim();
         _isSaving = true;
 
         try
         {
-            var result = await PlayerApiClient.UpdateProfileAliasAsync(_alias, aliasName);
+            var result = await PlayerManager.UpdateAliasAsync(_editModel.DisplayName.Trim());
 
-            if (result.IsSuccess && result.Value != null)
+            if (result.IsSuccess)
             {
-                var storedProfile = await LocalStorageService.GetProfileAsync();
-                if (storedProfile != null)
-                {
-                    storedProfile.Alias = result.Value.Alias;
-                    await LocalStorageService.SetProfileAsync(storedProfile);
-                }
-
-                _alias = result.Value.Alias;
+                _alias = result.Value!.Alias;
                 _isEditing = false;
                 StateHasChanged();
                 return;
@@ -119,14 +100,5 @@ public partial class Profile
         {
             _isSaving = false;
         }
-    }
-
-    private class EditAliasModel
-    {
-        [Required(ErrorMessage = "Alias is required.")]
-        [MinLength(2, ErrorMessage = "Alias must be at least 2 characters.")]
-        [MaxLength(50, ErrorMessage = "Alias cannot exceed 50 characters.")]
-        [RegularExpression(@"^[a-zA-Z0-9 ]+$", ErrorMessage = "Alias can only contain letters, numbers, and spaces.")]
-        public string NewAlias { get; set; } = string.Empty;
     }
 }

--- a/src/frontend/Sudoku.Blazor/Models/CreateProfileModel.cs
+++ b/src/frontend/Sudoku.Blazor/Models/CreateProfileModel.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Sudoku.Blazor.Models;
+
+public class CreateProfileModel
+{
+    [Required(ErrorMessage = "Alias is required.")]
+    [MinLength(2, ErrorMessage = "Alias must be at least 2 characters.")]
+    [MaxLength(50, ErrorMessage = "Alias cannot exceed 50 characters.")]
+    [RegularExpression(@"^[a-zA-Z0-9 ]+$", ErrorMessage = "Alias can only contain letters, numbers, and spaces.")]
+    public string Alias { get; set; } = string.Empty;
+}

--- a/src/frontend/Sudoku.Blazor/Models/EditProfileModel.cs
+++ b/src/frontend/Sudoku.Blazor/Models/EditProfileModel.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Sudoku.Blazor.Models;
+
+public class EditProfileModel
+{
+    [Required(ErrorMessage = "Profile DisplayName is required.")]
+    [MinLength(2, ErrorMessage = "Profile DisplayName must be at least 2 characters.")]
+    [MaxLength(50, ErrorMessage = "Profile DisplayName cannot exceed 50 characters.")]
+    [RegularExpression(@"^[a-zA-Z0-9 ]+$", ErrorMessage = "Profile DisplayName can only contain letters, numbers, and spaces.")]
+    public string DisplayName { get; set; } = string.Empty;
+}

--- a/src/frontend/Sudoku.Blazor/Services/Abstractions/ILocalStorageService.cs
+++ b/src/frontend/Sudoku.Blazor/Services/Abstractions/ILocalStorageService.cs
@@ -5,12 +5,9 @@ namespace Sudoku.Blazor.Services.Abstractions;
 public interface ILocalStorageService
 {
     Task DeleteGameAsync(string gameId);
-    Task<string?> GetAliasAsync();
+    Task<ProfileInfo?> GetProfileAsync();
     Task<GameModel?> LoadGameAsync(string gameId);
     Task<List<GameModel>> LoadGameStatesAsync();
     Task SaveGameStateAsync(GameModel gameState);
-    Task SetAliasAsync(string alias);
-    Task<ProfileInfo?> GetProfileAsync();
     Task SetProfileAsync(ProfileInfo profile);
-    Task RemoveAliasAsync();
 }

--- a/src/frontend/Sudoku.Blazor/Services/Abstractions/IPlayerManager.cs
+++ b/src/frontend/Sudoku.Blazor/Services/Abstractions/IPlayerManager.cs
@@ -4,13 +4,8 @@ namespace Sudoku.Blazor.Services.Abstractions;
 
 public interface IPlayerManager
 {
-    Task<string?> GetCurrentPlayerAsync();
-    Task<string?> GetCurrentProfileIdAsync();
-    Task SetCurrentPlayerAsync(string alias);
-    Task<string> TryGetPlayerAlias();
-    Task<ProfileInfo?> GetCurrentProfileAsync();
+    Task<ApiResult<ProfileInfo>> CreateProfileAsync(string displayName);
     Task<bool> EnsureProfileInitializedAsync();
-    Task<ApiResult<ProfileInfo>> CreateProfileAsync(string alias);
-    Task<DateTime?> GetProfileCreatedAtAsync();
+    Task<ProfileInfo?> GetCurrentProfileAsync();
     Task<ApiResult<ProfileInfo>> UpdateAliasAsync(string newAlias);
 }

--- a/src/frontend/Sudoku.Blazor/Services/Abstractions/IPlayerManager.cs
+++ b/src/frontend/Sudoku.Blazor/Services/Abstractions/IPlayerManager.cs
@@ -10,4 +10,7 @@ public interface IPlayerManager
     Task<string> TryGetPlayerAlias();
     Task<ProfileInfo?> GetCurrentProfileAsync();
     Task<bool> EnsureProfileInitializedAsync();
+    Task<ApiResult<ProfileInfo>> CreateProfileAsync(string alias);
+    Task<DateTime?> GetProfileCreatedAtAsync();
+    Task<ApiResult<ProfileInfo>> UpdateAliasAsync(string newAlias);
 }

--- a/src/frontend/Sudoku.Blazor/Services/LocalStorageService.cs
+++ b/src/frontend/Sudoku.Blazor/Services/LocalStorageService.cs
@@ -1,15 +1,16 @@
-using System.Text.Json;
 using Sudoku.Blazor.Models;
 using Sudoku.Blazor.Services.Abstractions;
+using System.Text.Json;
 
 namespace Sudoku.Blazor.Services;
 
-using ILocalStorageService = Abstractions.ILocalStorageService;
-
 public class LocalStorageService(IJsRuntimeWrapper jsRuntime) : ILocalStorageService
 {
+    private readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions
+    {
+        PropertyNameCaseInsensitive = true
+    };
     private const string SavedGamesKey = "savedGames";
-    private const string AliasKey = "sudoku-alias";
     private const string ProfileKey = "sudoku-profile";
 
     public async Task DeleteGameAsync(string gameId)
@@ -24,11 +25,24 @@ public class LocalStorageService(IJsRuntimeWrapper jsRuntime) : ILocalStorageSer
         await SaveGameStateAsync(games);
     }
 
-    public async Task<string?> GetAliasAsync()
+    public async Task<ProfileInfo?> GetProfileAsync()
     {
-        var alias = await jsRuntime.GetAsync(AliasKey);
+        var json = await jsRuntime.GetAsync(ProfileKey);
+        if (string.IsNullOrWhiteSpace(json)) return null;
 
-        return alias;
+        try
+        {
+            var profile = JsonSerializer.Deserialize<ProfileInfo>(json, _serializerOptions);
+            if (profile == null || string.IsNullOrWhiteSpace(profile.ProfileId) || string.IsNullOrWhiteSpace(profile.Alias))
+            {
+                return null;
+            }
+            return profile;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 
     public async Task<GameModel?> LoadGameAsync(string gameId)
@@ -50,7 +64,7 @@ public class LocalStorageService(IJsRuntimeWrapper jsRuntime) : ILocalStorageSer
 
         try
         {
-            var games = JsonSerializer.Deserialize<List<GameModel>>(json) ?? [];
+            var games = JsonSerializer.Deserialize<List<GameModel>>(json, _serializerOptions) ?? [];
             return games.Where(x => !string.IsNullOrWhiteSpace(x.Id)).ToList();
         }
         catch (JsonException)
@@ -74,45 +88,16 @@ public class LocalStorageService(IJsRuntimeWrapper jsRuntime) : ILocalStorageSer
         await SaveGameStateAsync(games);
     }
 
-    public async Task SetAliasAsync(string alias)
+    private async Task SaveGameStateAsync(IEnumerable<GameModel> gameState)
     {
-        await jsRuntime.SetAsync(AliasKey, alias);
-    }
+        var json = JsonSerializer.Serialize(gameState);
 
-    public async Task RemoveAliasAsync()
-    {
-        await jsRuntime.RemoveAsync(AliasKey);
-    }
-
-    public async Task<ProfileInfo?> GetProfileAsync()
-    {
-        var json = await jsRuntime.GetAsync(ProfileKey);
-        if (string.IsNullOrWhiteSpace(json)) return null;
-
-        try
-        {
-            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-            var profile = JsonSerializer.Deserialize<ProfileInfo>(json, options);
-            if (profile == null || string.IsNullOrWhiteSpace(profile.ProfileId) || string.IsNullOrWhiteSpace(profile.Alias))
-                return null;
-            return profile;
-        }
-        catch (JsonException)
-        {
-            return null;
-        }
+        await jsRuntime.SetAsync(SavedGamesKey, json);
     }
 
     public async Task SetProfileAsync(ProfileInfo profile)
     {
         var json = JsonSerializer.Serialize(profile);
         await jsRuntime.SetAsync(ProfileKey, json);
-    }
-
-    private async Task SaveGameStateAsync(IEnumerable<GameModel> gameState)
-    {
-        var json = JsonSerializer.Serialize(gameState);
-
-        await jsRuntime.SetAsync(SavedGamesKey, json);
     }
 }

--- a/src/frontend/Sudoku.Blazor/Services/PlayerManager.cs
+++ b/src/frontend/Sudoku.Blazor/Services/PlayerManager.cs
@@ -46,6 +46,40 @@ public class PlayerManager(IPlayerApiClient playerApiClient, ILocalStorageServic
         return await localStorageService.GetProfileAsync();
     }
 
+    public async Task<ApiResult<ProfileInfo>> CreateProfileAsync(string alias)
+    {
+        var result = await playerApiClient.CreateProfileAsync(alias);
+        if (result.IsSuccess && result.Value != null)
+        {
+            var profile = new ProfileInfo { ProfileId = result.Value.ProfileId, Alias = result.Value.Alias };
+            await localStorageService.SetProfileAsync(profile);
+            return ApiResult<ProfileInfo>.Success(profile);
+        }
+        return ApiResult<ProfileInfo>.Failure(result.Error ?? "Failed to create profile", result.StatusCode);
+    }
+
+    public async Task<DateTime?> GetProfileCreatedAtAsync()
+    {
+        var profile = await localStorageService.GetProfileAsync();
+        if (profile == null) return null;
+        var result = await playerApiClient.GetProfileAsync(profile.Alias);
+        return result.IsSuccess ? result.Value?.CreatedAt : null;
+    }
+
+    public async Task<ApiResult<ProfileInfo>> UpdateAliasAsync(string newAlias)
+    {
+        var profile = await localStorageService.GetProfileAsync();
+        if (profile == null) return ApiResult<ProfileInfo>.Failure("Profile not found", 404);
+        var result = await playerApiClient.UpdateProfileAliasAsync(profile.Alias, newAlias);
+        if (result.IsSuccess && result.Value != null)
+        {
+            profile.Alias = result.Value.Alias;
+            await localStorageService.SetProfileAsync(profile);
+            return ApiResult<ProfileInfo>.Success(profile);
+        }
+        return ApiResult<ProfileInfo>.Failure(result.Error ?? "Failed to update alias", result.StatusCode);
+    }
+
     public async Task<bool> EnsureProfileInitializedAsync()
     {
         var profile = await localStorageService.GetProfileAsync();

--- a/src/frontend/Sudoku.Blazor/Services/PlayerManager.cs
+++ b/src/frontend/Sudoku.Blazor/Services/PlayerManager.cs
@@ -1,103 +1,41 @@
 using Sudoku.Blazor.Models;
+using Sudoku.Blazor.Services.Abstractions;
 using Sudoku.Blazor.Services.HttpClients;
-using ILocalStorageService = Sudoku.Blazor.Services.Abstractions.ILocalStorageService;
 
 namespace Sudoku.Blazor.Services;
 
-using IPlayerManager = Abstractions.IPlayerManager;
-
 public class PlayerManager(IPlayerApiClient playerApiClient, ILocalStorageService localStorageService) : IPlayerManager
 {
-    public async Task<string?> GetCurrentPlayerAsync()
+    public async Task<ApiResult<ProfileInfo>> CreateProfileAsync(string displayName)
     {
-        var profile = await localStorageService.GetProfileAsync();
-        if (profile != null) return profile.Alias;
-        return await localStorageService.GetAliasAsync();
-    }
-
-    public async Task<string?> GetCurrentProfileIdAsync()
-    {
-        var profile = await localStorageService.GetProfileAsync();
-        return profile?.ProfileId;
-    }
-
-    public async Task SetCurrentPlayerAsync(string alias)
-    {
-        if (string.IsNullOrEmpty(alias))
-        {
-            throw new ArgumentException("Alias not set.");
-        }
-
-        await localStorageService.SetAliasAsync(alias);
-    }
-
-    public async Task<string> TryGetPlayerAlias()
-    {
-        var profile = await localStorageService.GetProfileAsync();
-        if (profile != null) return profile.Alias;
-
-        var alias = await localStorageService.GetAliasAsync();
-
-        return alias ?? string.Empty;
-    }
-
-    public async Task<ProfileInfo?> GetCurrentProfileAsync()
-    {
-        return await localStorageService.GetProfileAsync();
-    }
-
-    public async Task<ApiResult<ProfileInfo>> CreateProfileAsync(string alias)
-    {
-        var result = await playerApiClient.CreateProfileAsync(alias);
-        if (result.IsSuccess && result.Value != null)
+        var result = await playerApiClient.CreateProfileAsync(displayName);
+        if (result is { IsSuccess: true, Value: not null })
         {
             var profile = new ProfileInfo { ProfileId = result.Value.ProfileId, Alias = result.Value.Alias };
             await localStorageService.SetProfileAsync(profile);
             return ApiResult<ProfileInfo>.Success(profile);
         }
+
         return ApiResult<ProfileInfo>.Failure(result.Error ?? "Failed to create profile", result.StatusCode);
-    }
-
-    public async Task<DateTime?> GetProfileCreatedAtAsync()
-    {
-        var profile = await localStorageService.GetProfileAsync();
-        if (profile == null) return null;
-        var result = await playerApiClient.GetProfileAsync(profile.Alias);
-        return result.IsSuccess ? result.Value?.CreatedAt : null;
-    }
-
-    public async Task<ApiResult<ProfileInfo>> UpdateAliasAsync(string newAlias)
-    {
-        var profile = await localStorageService.GetProfileAsync();
-        if (profile == null) return ApiResult<ProfileInfo>.Failure("Profile not found", 404);
-        var result = await playerApiClient.UpdateProfileAliasAsync(profile.Alias, newAlias);
-        if (result.IsSuccess && result.Value != null)
-        {
-            profile.Alias = result.Value.Alias;
-            await localStorageService.SetProfileAsync(profile);
-            return ApiResult<ProfileInfo>.Success(profile);
-        }
-        return ApiResult<ProfileInfo>.Failure(result.Error ?? "Failed to update alias", result.StatusCode);
     }
 
     public async Task<bool> EnsureProfileInitializedAsync()
     {
         var profile = await localStorageService.GetProfileAsync();
+
         if (profile != null)
         {
             var getResult = await playerApiClient.GetProfileAsync(profile.Alias);
 
             if (!getResult.IsSuccess)
             {
-                // Transient backend failure — throw so caller can route to an error page
                 throw new InvalidOperationException($"Backend unavailable while verifying profile: {getResult.Error}");
             }
 
             if (getResult.Value != null) return true;
 
-            // Profile exists in localStorage but 404 in backend (orphaned) — attempt re-create
             var recreateResult = await playerApiClient.CreateProfileAsync(profile.Alias);
-            if (recreateResult.IsSuccess && recreateResult.Value != null)
+            if (recreateResult is { IsSuccess: true, Value: not null })
             {
                 await localStorageService.SetProfileAsync(new ProfileInfo
                 {
@@ -106,49 +44,29 @@ public class PlayerManager(IPlayerApiClient playerApiClient, ILocalStorageServic
                 });
                 return true;
             }
-
-            return false;
-        }
-
-        // Check for legacy alias and attempt silent migration
-        var legacyAlias = await localStorageService.GetAliasAsync();
-        if (!string.IsNullOrEmpty(legacyAlias))
-        {
-            var aliasName = legacyAlias.Trim();
-            var canRetry = aliasName.Length < 50;
-
-            var createResult = await playerApiClient.CreateProfileAsync(aliasName);
-            if (createResult.IsSuccess && createResult.Value != null)
-            {
-                await localStorageService.SetProfileAsync(new ProfileInfo
-                {
-                    ProfileId = createResult.Value.ProfileId,
-                    Alias = createResult.Value.Alias
-                });
-                await localStorageService.RemoveAliasAsync();
-                return true;
-            }
-
-            if (createResult.StatusCode == 409 && canRetry)
-            {
-                var suffix = Random.Shared.Next(10, 100).ToString();
-                var aliasWithSuffix = aliasName[..Math.Min(aliasName.Length, 48)] + suffix;
-                var retryResult = await playerApiClient.CreateProfileAsync(aliasWithSuffix);
-                if (retryResult.IsSuccess && retryResult.Value != null)
-                {
-                    await localStorageService.SetProfileAsync(new ProfileInfo
-                    {
-                        ProfileId = retryResult.Value.ProfileId,
-                        Alias = retryResult.Value.Alias
-                    });
-                    await localStorageService.RemoveAliasAsync();
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         return false;
+    }
+
+    public async Task<ProfileInfo?> GetCurrentProfileAsync()
+    {
+        return await localStorageService.GetProfileAsync();
+    }
+
+    public async Task<ApiResult<ProfileInfo>> UpdateAliasAsync(string newAlias)
+    {
+        var profile = await localStorageService.GetProfileAsync();
+        if (profile == null) return ApiResult<ProfileInfo>.Failure("Profile not found", 404);
+
+        var result = await playerApiClient.UpdateProfileAliasAsync(profile.Alias, newAlias);
+        if (result.IsSuccess && result.Value != null)
+        {
+            profile.Alias = result.Value.Alias;
+            await localStorageService.SetProfileAsync(profile);
+            return ApiResult<ProfileInfo>.Success(profile);
+        }
+        
+        return ApiResult<ProfileInfo>.Failure(result.Error ?? "Failed to update alias", result.StatusCode);
     }
 }

--- a/src/frontend/Sudoku.React/.github/copilot-instructions.md
+++ b/src/frontend/Sudoku.React/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ This is a React TypeScript frontend for a Sudoku game that communicates with a s
 
 ### Core Data Flow
 
-- **Player Management**: Auto-creates anonymous players via `apiClient.createPlayer()` and stores alias in localStorage
+- **Player Management**: Manages player profiles via `apiClient.createProfile()`; stores profile object in localStorage under `sudoku-profile`
 - **Game State**: All game logic is server-side; frontend only handles presentation and input validation
 - **API Integration**: Centralized in `src/api/apiClient.ts` using environment-based URL configuration
 
@@ -33,7 +33,7 @@ export default function Component({ prop }: ComponentProps) {
 
 - **No Global State**: Uses React local state + localStorage for persistence
 - **API-Driven**: Game state lives on server; components receive via props from pages
-- **Player Session**: Player alias stored in localStorage, created automatically on first visit
+- **Player Session**: Player profile (`{ profileId, alias }`) stored under `sudoku-profile` in localStorage; new users are redirected to `/create-profile`
 
 ### Styling Conventions
 
@@ -89,7 +89,7 @@ npm run lint         # ESLint with TypeScript rules
 ### Backend API Expectations
 
 - RESTful endpoints under `/api/` namespace
-- Player alias-based routing: `/api/players/{alias}/games/{gameId}`
+- Profile-based routing: `/api/players/{profileId}/games/{gameId}`
 - Game state mutations via move API with duration tracking
 - Error responses use standard HTTP status codes
 
@@ -104,7 +104,7 @@ npm run lint         # ESLint with TypeScript rules
 ### Local Storage Schema
 
 ```js
-localStorage.playerAlias; // String: auto-generated player identifier
+localStorage['sudoku-profile']; // JSON: { profileId: string, alias: string }
 ```
 
 ## Testing & Validation Patterns

--- a/src/frontend/Sudoku.React/src/hooks/usePlayerService.test.ts
+++ b/src/frontend/Sudoku.React/src/hooks/usePlayerService.test.ts
@@ -17,7 +17,6 @@ Object.defineProperty(window, 'localStorage', {
 });
 
 const PROFILE_KEY = 'sudoku-profile';
-const LEGACY_ALIAS_KEY = 'sudoku-alias';
 
 describe('usePlayerService', () => {
   beforeEach(() => {
@@ -59,45 +58,6 @@ describe('usePlayerService', () => {
     });
   });
 
-  describe('legacy migration', () => {
-    it('migrates sudoku-alias to sudoku-profile on init', () => {
-      store[LEGACY_ALIAS_KEY] = 'OldAlias';
-      const { result } = renderHook(() => usePlayerService());
-
-      expect(result.current.isInitialized).toBe(true);
-      expect(result.current.playerAlias).toBe('OldAlias');
-
-      const writeCall = mockLocalStorage.setItem.mock.calls.find(c => c[0] === PROFILE_KEY);
-      expect(writeCall).toBeDefined();
-      const written = JSON.parse(writeCall![1]);
-      expect(written.alias).toBe('OldAlias');
-      expect(written.profileId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
-
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(LEGACY_ALIAS_KEY);
-    });
-
-    it('treats as new player when localStorage write fails during migration', () => {
-      store[LEGACY_ALIAS_KEY] = 'OldAlias';
-      mockLocalStorage.setItem.mockImplementationOnce(() => { throw new Error('Storage full'); });
-
-      const { result } = renderHook(() => usePlayerService());
-
-      expect(result.current.isNewPlayer).toBe(true);
-      expect(result.current.playerAlias).toBeNull();
-      expect(mockLocalStorage.removeItem).not.toHaveBeenCalledWith(LEGACY_ALIAS_KEY);
-    });
-
-    it('skips migration when sudoku-profile already exists', () => {
-      store[PROFILE_KEY] = JSON.stringify({ profileId: 'p1', alias: 'alice' });
-      store[LEGACY_ALIAS_KEY] = 'OldAlias';
-
-      renderHook(() => usePlayerService());
-
-      expect(mockLocalStorage.setItem).not.toHaveBeenCalled();
-      expect(mockLocalStorage.removeItem).not.toHaveBeenCalled();
-    });
-  });
-
   describe('clearPlayer', () => {
     it('clears profile and both localStorage keys', () => {
       store[PROFILE_KEY] = JSON.stringify({ profileId: 'p1', alias: 'alice' });
@@ -111,7 +71,6 @@ describe('usePlayerService', () => {
       expect(result.current.isInitialized).toBe(false);
       expect(result.current.isNewPlayer).toBe(true);
       expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(PROFILE_KEY);
-      expect(mockLocalStorage.removeItem).toHaveBeenCalledWith(LEGACY_ALIAS_KEY);
     });
   });
 

--- a/src/frontend/Sudoku.React/src/hooks/usePlayerService.ts
+++ b/src/frontend/Sudoku.React/src/hooks/usePlayerService.ts
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import type { ProfileInfo } from '../types';
 
 const PROFILE_KEY = 'sudoku-profile';
-const LEGACY_ALIAS_KEY = 'sudoku-alias';
 
 function readProfile(): ProfileInfo | null {
   try {
@@ -13,22 +12,6 @@ function readProfile(): ProfileInfo | null {
     return parsed;
   } catch {
     return null;
-  }
-}
-
-function migrateProfileIfNeeded(): void {
-  try {
-    if (localStorage.getItem(PROFILE_KEY)) return;
-    const legacyAlias = localStorage.getItem(LEGACY_ALIAS_KEY);
-    if (!legacyAlias) return;
-    const newProfile: ProfileInfo = {
-      profileId: crypto.randomUUID(),
-      alias: legacyAlias.trim(),
-    };
-    localStorage.setItem(PROFILE_KEY, JSON.stringify(newProfile));
-    localStorage.removeItem(LEGACY_ALIAS_KEY);
-  } catch {
-    // silent failure — treat as new player
   }
 }
 
@@ -45,13 +28,11 @@ export interface UsePlayerServiceReturn {
 
 export function usePlayerService(): UsePlayerServiceReturn {
   const [profile, setProfile] = useState<ProfileInfo | null>(() => {
-    migrateProfileIfNeeded();
     return readProfile();
   });
 
   const clearPlayer = () => {
     try { localStorage.removeItem(PROFILE_KEY); } catch { /* ignore */ }
-    try { localStorage.removeItem(LEGACY_ALIAS_KEY); } catch { /* ignore */ }
     setProfile(null);
   };
 


### PR DESCRIPTION
## Description
Removed the legacy player alias from local storage, as well as the logic to migrate accounts.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [x] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Refactored Blazor pages to only use the PlayerManager instead of the API client and local storage
- Removed local storage calls for player alias
- Removed logic to migrate legacy accounts to new profile

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

## Screenshots (if applicable)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation (if necessary)