### PR TITLE
Fix profile deletion to clear local game cache and handle 404 gracefully

### DIFF
--- a/src/frontend/Sudoku.React/src/pages/ProfilePage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/ProfilePage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { apiClient } from '../api/apiClient';
 import { usePlayerService } from '../hooks/usePlayerService';
+import { useGameService } from '../hooks/useGameService';
 import Layout from '../components/Layout';
 import styles from './ProfilePage.module.css';
 
@@ -10,6 +11,7 @@ const PROFILE_KEY = 'sudoku-profile';
 export default function ProfilePage() {
   const navigate = useNavigate();
   const { playerAlias, isInitialized, isNewPlayer, clearPlayer } = usePlayerService();
+  const { clearCache } = useGameService();
   const [createdAt, setCreatedAt] = useState<string | null>(null);
   const [isEditing, setIsEditing] = useState(false);
   const [newAlias, setNewAlias] = useState('');
@@ -113,12 +115,15 @@ export default function ProfilePage() {
     try {
       const result = await apiClient.deleteProfile(playerAlias);
       if (result.status === 204) {
+        clearCache();
         clearPlayer();
         navigate('/');
         return;
       }
       if (result.status === 404) {
-        setDeleteError('Profile not found. It may have already been deleted.');
+        clearCache();
+        clearPlayer();
+        navigate('/');
         return;
       }
       setDeleteError('Something went wrong. Please try again.');


### PR DESCRIPTION
## Summary
- When deleting a profile, the `savedGames` localStorage cache is now cleared so stale game data doesn't linger on the device
- A 404 response from the server (profile not found) is now treated as a successful deletion — clears local storage and redirects home instead of showing an error

## Changes
- `ProfilePage.tsx`: imports `useGameService` and calls `clearCache()` alongside `clearPlayer()` on both the 204 and 404 delete response paths

## Test plan
- [ ] Delete a profile on a device that has cached games — verify the games list is empty after re-login
- [ ] Attempt to delete a profile that doesn't exist on the server — verify the app redirects home cleanly with no error message
- [ ] All 586 .NET tests and 151 React tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)