### PR TITLE
Restrict profile names to letters, numbers, dashes, and underscores

### DIFF
--- a/src/backend/Sudoku.Domain/ValueObjects/PlayerAlias.cs
+++ b/src/backend/Sudoku.Domain/ValueObjects/PlayerAlias.cs
@@ -16,22 +16,24 @@ public record PlayerAlias
             throw new InvalidPlayerAliasException("Player alias cannot be null or empty");
         }
 
-        if (value.Length > 50)
+        var trimmed = value.Trim();
+
+        if (trimmed.Length > 50)
         {
             throw new InvalidPlayerAliasException("Player alias cannot exceed 50 characters");
         }
 
-        if (value.Length < 2)
+        if (trimmed.Length < 2)
         {
             throw new InvalidPlayerAliasException("Player alias must be at least 2 characters");
         }
 
-        if (!value.All(c => char.IsLetterOrDigit(c) || c == ' '))
+        if (!trimmed.All(c => char.IsLetterOrDigit(c) || c == '-' || c == '_'))
         {
-            throw new InvalidPlayerAliasException("Player alias can only contain letters, numbers, and spaces");
+            throw new InvalidPlayerAliasException("Player alias can only contain letters, numbers, dashes, and underscores");
         }
 
-        return new PlayerAlias(value.Trim());
+        return new PlayerAlias(trimmed);
     }
 
     public static implicit operator string(PlayerAlias playerAlias) => playerAlias.Value;

--- a/src/backend/Tests/Domain/PlayerAliasTests.cs
+++ b/src/backend/Tests/Domain/PlayerAliasTests.cs
@@ -7,10 +7,12 @@ public class PlayerAliasTests : MoqBaseTestByType<PlayerAlias>
 {
     [Theory]
     [InlineData("John")]
-    [InlineData("Jane Doe")]
+    [InlineData("Jane-Doe")]
+    [InlineData("player_one")]
     [InlineData("Player123")]
+    [InlineData("No-Hyphens")]
     [InlineData("AB")]  // Minimum length (2)
-    [InlineData("A very long player name with exactly 50 characters")] // Exactly 50 chars
+    [InlineData("A-very-long-player-name-with-exactly-50-chars12345")] // Exactly 50 chars
     public void Create_WithValidAlias_CreatesPlayerAlias(string aliasValue)
     {
         // Act
@@ -66,7 +68,7 @@ public class PlayerAliasTests : MoqBaseTestByType<PlayerAlias>
     [InlineData("John@Doe")]
     [InlineData("Player#1")]
     [InlineData("Hello!")]
-    [InlineData("No-Hyphens")]
+    [InlineData("Jane Doe")]
     public void Create_WithInvalidCharacters_ThrowsInvalidPlayerAliasException(string aliasValue)
     {
         // Act
@@ -74,45 +76,45 @@ public class PlayerAliasTests : MoqBaseTestByType<PlayerAlias>
 
         // Assert
         act.Should().Throw<InvalidPlayerAliasException>()
-            .WithMessage("Player alias can only contain letters, numbers, and spaces");
+            .WithMessage("Player alias can only contain letters, numbers, dashes, and underscores");
     }
 
     [Fact]
     public void Create_TrimsSpaces_FromBeginningAndEnd()
     {
         // Arrange
-        var aliasWithSpaces = "  John Doe  ";
+        var aliasWithSpaces = "  JohnDoe  ";
 
         // Act
         var alias = PlayerAlias.Create(aliasWithSpaces);
 
         // Assert
-        alias.Value.Should().Be("John Doe");
+        alias.Value.Should().Be("JohnDoe");
     }
 
     [Fact]
     public void ImplicitConversion_ToString_ReturnsValue()
     {
         // Arrange
-        var alias = PlayerAlias.Create("John Doe");
+        var alias = PlayerAlias.Create("John-Doe");
 
         // Act
         string aliasValue = alias;
 
         // Assert
-        aliasValue.Should().Be("John Doe");
+        aliasValue.Should().Be("John-Doe");
     }
 
     [Fact]
     public void ToString_ReturnsValue()
     {
         // Arrange
-        var alias = PlayerAlias.Create("John Doe");
+        var alias = PlayerAlias.Create("John-Doe");
 
         // Act
         var result = alias.ToString();
 
         // Assert
-        result.Should().Be("John Doe");
+        result.Should().Be("John-Doe");
     }
 }

--- a/src/backend/Tests/Domain/PlayerAliasTests.cs
+++ b/src/backend/Tests/Domain/PlayerAliasTests.cs
@@ -10,9 +10,10 @@ public class PlayerAliasTests : MoqBaseTestByType<PlayerAlias>
     [InlineData("Jane-Doe")]
     [InlineData("player_one")]
     [InlineData("Player123")]
-    [InlineData("No-Hyphens")]
+    [InlineData("Hyphenated-Name")]
     [InlineData("AB")]  // Minimum length (2)
     [InlineData("A-very-long-player-name-with-exactly-50-chars12345")] // Exactly 50 chars
+    [InlineData("  A-very-long-player-name-with-exactly-50-chars12345  ")] // Padded to >50 but trimmed = 50
     public void Create_WithValidAlias_CreatesPlayerAlias(string aliasValue)
     {
         // Act

--- a/src/frontend/Sudoku.React/src/pages/CreateProfilePage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/CreateProfilePage.tsx
@@ -17,7 +17,7 @@ export default function CreateProfilePage() {
     const trimmed = value.trim();
     if (trimmed.length < 2) return 'Alias must be at least 2 characters.';
     if (trimmed.length > 50) return 'Alias cannot exceed 50 characters.';
-    if (!/^[a-z0-9 ]+$/i.test(trimmed)) return 'Alias can only contain letters, numbers, and spaces.';
+    if (!/^[a-z0-9_-]+$/i.test(trimmed)) return 'Alias can only contain letters, numbers, dashes, and underscores.';
     return null;
   };
 
@@ -71,7 +71,7 @@ export default function CreateProfilePage() {
             type="text"
             value={alias}
             onChange={e => setAlias(e.target.value)}
-            placeholder="e.g. sudoku master"
+            placeholder="e.g. sudoku-master"
             className={styles.input}
             maxLength={50}
             aria-describedby={error ? 'alias-error' : undefined}
@@ -82,7 +82,7 @@ export default function CreateProfilePage() {
             <p id="alias-error" className={styles.error} role="alert">{error}</p>
           )}
           <p className={styles.hint}>
-            2–50 characters · letters, numbers, and spaces only · case-insensitive
+            2–50 characters · letters, numbers, dashes, and underscores only · case-insensitive
           </p>
           <button
             type="submit"

--- a/src/frontend/Sudoku.React/src/pages/CreateProfilePage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/CreateProfilePage.tsx
@@ -82,7 +82,7 @@ export default function CreateProfilePage() {
             <p id="alias-error" className={styles.error} role="alert">{error}</p>
           )}
           <p className={styles.hint}>
-            2–50 characters · letters, numbers, dashes, and underscores only · case-insensitive
+            2–50 characters · letters, numbers, dashes, and underscores only
           </p>
           <button
             type="submit"

--- a/src/frontend/Sudoku.React/src/pages/ProfilePage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/ProfilePage.tsx
@@ -48,7 +48,7 @@ export default function ProfilePage() {
     const trimmed = value.trim();
     if (trimmed.length < 2) return 'Alias must be at least 2 characters.';
     if (trimmed.length > 50) return 'Alias cannot exceed 50 characters.';
-    if (!/^[a-zA-Z0-9 ]+$/.test(trimmed)) return 'Alias can only contain letters, numbers, and spaces.';
+    if (!/^[a-z0-9_-]+$/i.test(trimmed)) return 'Alias can only contain letters, numbers, dashes, and underscores.';
     return null;
   };
 


### PR DESCRIPTION
## What changed
- PlayerAlias value object now rejects spaces; only letters, numbers, dashes (-), and underscores (_) are allowed
- Trim is applied before character validation so leading/trailing whitespace is still silently stripped
- Frontend regex, error message, input placeholder, and hint text updated to match

## Why
Spaces in profile names can look ambiguous in URLs and display contexts. Dashes and underscores are conventional word separators for identifiers and carry no security risk.

## Test plan
- [ ] All 588 backend unit tests pass (dotnet test)
- [ ] PlayerAliasTests updated: spaces moved to invalid list, dashes/underscores/hyphenated names added to valid list
- [ ] Try creating a profile with a space in the name on /create-profile -- should show inline error before submission
- [ ] Try sudoku-master and sudoku_master -- both should be accepted