### PR TITLE
Mobile responsive layout audit (#223)

### DIFF
--- a/src/frontend/Sudoku.React/src/components/CellInput.module.css
+++ b/src/frontend/Sudoku.React/src/components/CellInput.module.css
@@ -27,10 +27,10 @@
   display: flex;
   font-size: 1.5rem;
   font-weight: bold;
-  height: min(36px, calc((100vw - 4px) / 9));
+  height: min(36px, calc((100vw - 1rem - 12px) / 9));
   justify-content: center;
   line-height: 1.3em;
-  max-width: min(36px, calc((100vw - 4px) / 9));
+  max-width: min(36px, calc((100vw - 1rem - 12px) / 9));
   padding: .25rem;
   text-align: center;
   width: 100%;

--- a/src/frontend/Sudoku.React/src/components/CellInput.module.css
+++ b/src/frontend/Sudoku.React/src/components/CellInput.module.css
@@ -27,10 +27,10 @@
   display: flex;
   font-size: 1.5rem;
   font-weight: bold;
-  height: 36px;
+  height: min(36px, calc((100vw - 4px) / 9));
   justify-content: center;
   line-height: 1.3em;
-  max-width: 36px;
+  max-width: min(36px, calc((100vw - 4px) / 9));
   padding: .25rem;
   text-align: center;
   width: 100%;

--- a/src/frontend/Sudoku.React/src/components/GameBoard.module.css
+++ b/src/frontend/Sudoku.React/src/components/GameBoard.module.css
@@ -2,7 +2,14 @@
   align-items: center;
   display: flex;
   justify-content: center;
+  overflow-x: auto;
   padding-top: 2rem;
+}
+
+@media (max-width: 479px) {
+  .gameBoardContainer {
+    padding-top: 1rem;
+  }
 }
 
 .gameBoard {

--- a/src/frontend/Sudoku.React/src/components/GameControls.module.css
+++ b/src/frontend/Sudoku.React/src/components/GameControls.module.css
@@ -6,6 +6,12 @@
   margin-top: 2rem;
 }
 
+@media (max-width: 479px) {
+  .btnToolbar {
+    margin-top: 1rem;
+  }
+}
+
 .numberPanel {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -34,6 +40,7 @@
 
 .btn {
   padding: 0.5rem 1rem;
+  min-height: 44px;
   color: #fff;
   background-color: #1b6ec2;
   border: 1px solid #1861ac;

--- a/src/frontend/Sudoku.React/src/components/VictoryDisplay.module.css
+++ b/src/frontend/Sudoku.React/src/components/VictoryDisplay.module.css
@@ -35,6 +35,7 @@
 
 .victoryButton {
   padding: 0.6rem 1.2rem;
+  min-height: 44px;
   background-color: #6c757d;
   color: white;
   border: none;

--- a/src/frontend/Sudoku.React/src/components/VictoryDisplay.module.css
+++ b/src/frontend/Sudoku.React/src/components/VictoryDisplay.module.css
@@ -48,6 +48,16 @@
   background-color: #5a6268;
 }
 
+@media (max-width: 479px) {
+  .victoryModal {
+    padding: 1.25rem;
+  }
+
+  .victoryTitle {
+    font-size: 1.5rem;
+  }
+}
+
 @keyframes fadeIn {
   from { opacity: 0; }
   to { opacity: 1; }

--- a/src/frontend/Sudoku.React/src/pages/GameListPage.module.css
+++ b/src/frontend/Sudoku.React/src/pages/GameListPage.module.css
@@ -41,6 +41,10 @@
   font-size: 1rem;
   cursor: pointer;
   margin-top: 1rem;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.25rem;
 }
 
 .backButton:hover {

--- a/src/frontend/Sudoku.React/src/pages/GamePage.module.css
+++ b/src/frontend/Sudoku.React/src/pages/GamePage.module.css
@@ -1,4 +1,5 @@
 .gameView {
   margin: 0 auto;
   max-width: 430px;
+  padding: 0 0.5rem;
 }

--- a/src/frontend/Sudoku.React/src/pages/ProfilePage.module.css
+++ b/src/frontend/Sudoku.React/src/pages/ProfilePage.module.css
@@ -72,8 +72,11 @@
   color: #666;
   font-size: 1rem;
   cursor: pointer;
-  padding: 0;
+  padding: 0 0.25rem;
   margin-bottom: 1rem;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
 }
 
 .backButton:hover {

--- a/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.module.css
+++ b/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.module.css
@@ -42,6 +42,10 @@
   color: #666;
   font-size: 1rem;
   cursor: pointer;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.25rem;
 }
 
 .backButton:hover {


### PR DESCRIPTION
## Summary
- Closes #223
- Fix game board overflow on screens narrower than ~330px using `min()` cell sizing so cells scale down gracefully instead of clipping
- Bring all touch targets up to the 44px minimum: `.btn` action buttons (home/undo/reset/pencil) and `.backButton` on SelectDifficulty, GameList, and Profile pages
- Reduce wasted vertical space on the game page at mobile widths (board and controls spacing reduced from `2rem` to `1rem` below 480px)
- Tighten the victory modal padding and title font size on small screens (≤479px)
- Add `overflow-x: auto` to the board container as a safety net

## Test plan
- [ ] Open browser DevTools, toggle to iPhone SE (375px) — game board fits without scroll, controls are reachable
- [ ] Toggle to 320px — board cells scale down via `min()`, no horizontal overflow
- [ ] Tap all action buttons (home, undo, reset, pencil) — each is ≥44px tall
- [ ] Navigate to SelectDifficulty, GameList, and Profile pages — back button is ≥44px tall
- [ ] Trigger the victory modal on a small screen — modal fits without scrolling
- [ ] All pages listed in the issue are usable at 375px without horizontal scroll or clipped content
- [ ] `npm test` — 151 tests pass
- [ ] `npm run lint` — no new lint errors (13 pre-existing errors on main remain unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)