### PR TITLE
Fix game creation failure caused by missing CORS Location header exposure

### DIFF
--- a/src/backend/Sudoku.Api/ApiServiceCollectionExtensions.cs
+++ b/src/backend/Sudoku.Api/ApiServiceCollectionExtensions.cs
@@ -19,7 +19,8 @@ public static class ApiServiceCollectionExtensions
                 {
                     builder.AllowAnyOrigin()
                            .AllowAnyMethod()
-                           .AllowAnyHeader();
+                           .AllowAnyHeader()
+                           .WithExposedHeaders("Location");
                 }
                 else
                 {
@@ -27,7 +28,8 @@ public static class ApiServiceCollectionExtensions
                     var allowedOrigins = config.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
                     builder.WithOrigins(allowedOrigins)
                            .AllowAnyMethod()
-                           .AllowAnyHeader();
+                           .AllowAnyHeader()
+                           .WithExposedHeaders("Location");
                 }
             });
         });


### PR DESCRIPTION
## Description

Fixes a bug where creating a new game always failed with `No Location header in createGame response`. The backend returns a `201 Created` with a `Location` header containing the new game URL, but the browser was silently stripping it before JavaScript could read it.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added `.WithExposedHeaders("Location")` to both the dev and production CORS policies in `ApiServiceCollectionExtensions.cs`

## Root Cause

The browser's Fetch API only exposes a [small set of CORS-safelisted headers](https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name) to JavaScript by default. `Location` is not in that list, so `res.headers.get('Location')` always returned `null` even though the `201` response included the header. The fix opts `Location` into the exposed set via `Access-Control-Expose-Headers`.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings