### PR TITLE
Provision Functions app and BlobDeleted Event Grid subscription via Bicep

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ on:
 env:
   AZURE_API_NAME: XenobiasoftSudokuApi-prod
   AZURE_MCP_NAME: XenobiasoftSudokuMcp-prod
+  AZURE_FUNCTIONS_NAME: XenobiasoftSudokuFunctions-prod
   AZURE_SWA_NAME: swa-sudoku-xenobiasoft-prod
   DOTNET_VERSION: "10.x"
 
@@ -73,6 +74,9 @@ jobs:
       - name: Publish MCP Server
         run: dotnet publish src/backend/Sudoku.McpServer/Sudoku.McpServer.csproj --configuration Release --output ${{ github.workspace }}/publish-mcp --no-restore --no-build
 
+      - name: Publish Functions
+        run: dotnet publish src/backend/Sudoku.Functions/Sudoku.Functions.csproj --configuration Release --output ${{ github.workspace }}/publish-functions --no-restore --no-build
+
       - name: Upload publish-api artifact
         uses: actions/upload-artifact@v4
         with:
@@ -84,6 +88,12 @@ jobs:
         with:
           name: publish-mcp
           path: ${{ github.workspace }}/publish-mcp
+
+      - name: Upload publish-functions artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-functions
+          path: ${{ github.workspace }}/publish-functions
 
   build-frontend:
     runs-on: ubuntu-latest
@@ -284,6 +294,18 @@ jobs:
         with:
           app-name: ${{ env.AZURE_MCP_NAME }}
           package: ${{ github.workspace }}/publish-mcp
+
+      - name: Download publish-functions artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: publish-functions
+          path: ${{ github.workspace }}/publish-functions
+
+      - name: Deploy Functions
+        uses: Azure/functions-action@v1
+        with:
+          app-name: ${{ env.AZURE_FUNCTIONS_NAME }}
+          package: ${{ github.workspace }}/publish-functions
 
   deploy-swa:
     needs: [deploy-infra, build-frontend, changes]

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -23,6 +23,9 @@ param apiAppName string
 @description('Name of the MCP server app.')
 param mcpAppName string
 
+@description('Name of the Azure Functions app (puzzle-pool background jobs).')
+param functionAppName string
+
 @description('App Service Plan SKU.')
 param appServicePlanSku string = 'B1'
 
@@ -157,6 +160,26 @@ module mcp 'modules/mcp.bicep' = {
   }
 }
 
+module functions 'modules/functions.bicep' = {
+  name: 'functions'
+  params: {
+    location: location
+    environment: environment
+    appServicePlanName: appServicePlanName
+    functionAppName: functionAppName
+    storageAccountName: storage.outputs.storageAccountName
+    eventGridTopicName: storage.outputs.eventGridTopicName
+    keyVaultName: keyVaultName
+    cosmosDbAccountName: cosmosDbAccountName
+    appInsightsConnectionString: monitoring.outputs.appInsightsConnectionString
+    keyVaultUri: keyvault.outputs.keyVaultUri
+    cosmosDbEndpoint: storage.outputs.cosmosDbEndpoint
+  }
+  dependsOn: [
+    compute
+  ]
+}
+
 module staticwebapp 'modules/staticwebapp.bicep' = {
   name: 'staticwebapp'
   params: {
@@ -178,6 +201,7 @@ output staticWebAppUrl string = staticwebapp.outputs.staticWebAppUrl
 output resourceGroupName string = resourceGroup().name
 output apiAppUrl string = compute.outputs.apiAppUrl
 output mcpAppUrl string = mcp.outputs.mcpAppUrl
+output functionAppUrl string = functions.outputs.functionAppUrl
 output appInsightsConnectionString string = monitoring.outputs.appInsightsConnectionString
 output cosmosDbEndpoint string = storage.outputs.cosmosDbEndpoint
 output keyVaultUri string = keyvault.outputs.keyVaultUri

--- a/infra/modules/functions.bicep
+++ b/infra/modules/functions.bicep
@@ -1,0 +1,211 @@
+// ---------------------------------------------------------------------------
+// Azure Functions App
+//
+// Hosts the puzzle-pool background functions:
+//   PuzzlePoolSeedFunction   — TimerTrigger, nightly top-up of the pool
+//   PuzzleReplenishFunction  — EventGridTrigger, replenishes one puzzle each
+//                              time a puzzle blob is deleted from the pool
+//
+// Runs on the shared App Service Plan (B1, Linux) alongside the API and MCP
+// apps. Reuses the existing storage account for the Functions runtime
+// (AzureWebJobsStorage).
+//
+// Auth model
+//   Outbound — SystemAssigned Managed Identity → Key Vault / Cosmos / Blob.
+//   The identity must be granted the same data-plane roles as the API app
+//   (Key Vault Secrets User, Storage Blob Data Contributor, and the Cosmos
+//   SQL data role). Those grants are managed outside this template, matching
+//   the existing API setup.
+// ---------------------------------------------------------------------------
+
+param location string
+param environment string
+param appServicePlanName string
+param functionAppName string
+
+@description('Name of the existing storage account reused for the Functions runtime and puzzle blobs.')
+param storageAccountName string
+
+@description('Name of the existing Event Grid system topic to subscribe to (created in the storage module).')
+param eventGridTopicName string
+
+@description('Name of the existing Key Vault (for the Key Vault Secrets User role assignment).')
+param keyVaultName string
+
+@description('Name of the existing Cosmos DB account (for the SQL data-plane role assignment).')
+param cosmosDbAccountName string
+
+param appInsightsConnectionString string
+param keyVaultUri string
+param cosmosDbEndpoint string
+
+var tags = {
+  environment: environment
+  project: 'XenobiaSoftSudoku'
+  component: 'functions'
+}
+
+// ---------------------------------------------------------------------------
+// Reference shared / existing resources (read-only)
+// ---------------------------------------------------------------------------
+
+resource appServicePlan 'Microsoft.Web/serverfarms@2023-12-01' existing = {
+  name: appServicePlanName
+}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
+  name: storageAccountName
+}
+
+resource eventGridTopic 'Microsoft.EventGrid/systemTopics@2022-06-15' existing = {
+  name: eventGridTopicName
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' existing = {
+  name: cosmosDbAccountName
+}
+
+var storageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};AccountKey=${storageAccount.listKeys().keys[0].value};EndpointSuffix=${az.environment().suffixes.storage}'
+
+// ---------------------------------------------------------------------------
+// Function App
+// ---------------------------------------------------------------------------
+
+resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: functionAppName
+  location: location
+  kind: 'functionapp,linux'
+  tags: tags
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    serverFarmId: appServicePlan.id
+    httpsOnly: true
+    clientAffinityEnabled: false
+    reserved: true
+    keyVaultReferenceIdentity: 'SystemAssigned'
+    siteConfig: {
+      linuxFxVersion: 'DOTNET-ISOLATED|10.0'
+      alwaysOn: true
+      http20Enabled: true
+      minTlsVersion: '1.2'
+      scmMinTlsVersion: '1.2'
+      ftpsState: 'FtpsOnly'
+      numberOfWorkers: 1
+      use32BitWorkerProcess: false
+    }
+  }
+}
+
+resource functionAppSettings 'Microsoft.Web/sites/config@2023-12-01' = {
+  parent: functionApp
+  name: 'appsettings'
+  properties: {
+    // Functions runtime
+    FUNCTIONS_EXTENSION_VERSION: '~4'
+    FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
+    AzureWebJobsStorage: storageConnectionString
+    WEBSITE_RUN_FROM_PACKAGE: '1'
+
+    // Observability
+    APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
+
+    // Application configuration (mirrors the API app)
+    ConnectionStrings__AzureKeyVault: keyVaultUri
+    CosmosDb__UseManagedIdentity: 'true'
+    CosmosDb__AccountEndpoint: cosmosDbEndpoint
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Event Grid subscription — BlobDeleted on the sudoku-puzzles container
+//                           → PuzzleReplenishFunction
+//
+// Uses the AzureFunction destination so it binds directly to the function
+// resource (no host key / webhook URL required).
+// ---------------------------------------------------------------------------
+
+resource puzzleReplenishSubscription 'Microsoft.EventGrid/systemTopics/eventSubscriptions@2022-06-15' = {
+  name: 'puzzle-replenish-sub'
+  parent: eventGridTopic
+  properties: {
+    destination: {
+      endpointType: 'AzureFunction'
+      properties: {
+        resourceId: '${functionApp.id}/functions/PuzzleReplenishFunction'
+        maxEventsPerBatch: 1
+        preferredBatchSizeInKilobytes: 64
+      }
+    }
+    filter: {
+      includedEventTypes: [
+        'Microsoft.Storage.BlobDeleted'
+      ]
+      subjectBeginsWith: '/blobServices/default/containers/sudoku-puzzles/'
+    }
+    eventDeliverySchema: 'EventGridSchema'
+    retryPolicy: {
+      maxDeliveryAttempts: 30
+      eventTimeToLiveInMinutes: 1440
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RBAC — grant the Function App's managed identity the same data-plane access
+// the API app uses.
+//
+//   Storage Blob Data Contributor  (ba92f5b4-2d11-453d-a403-e96b0029c9fe)
+//     Read/write puzzle blobs in the sudoku-puzzles container.
+//   Key Vault Secrets User         (4633458b-17de-408a-b874-0445c86b69e6)
+//     Resolve Key Vault references / configuration secrets.
+//   Cosmos DB Built-in Data Contributor (00000000-...-000000000002)
+//     Cosmos data-plane access (SQL role assignment, not Azure RBAC).
+// ---------------------------------------------------------------------------
+
+var storageBlobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+var keyVaultSecretsUserRoleId        = '4633458b-17de-408a-b874-0445c86b69e6'
+var cosmosDataContributorRoleId      = '00000000-0000-0000-0000-000000000002'
+
+resource blobDataContributorAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: storageAccount
+  name: guid(storageAccount.id, functionApp.id, storageBlobDataContributorRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributorRoleId)
+    principalId: functionApp.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource keyVaultSecretsUserAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: keyVault
+  name: guid(keyVault.id, functionApp.id, keyVaultSecretsUserRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: functionApp.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource cosmosDataContributorAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-05-15' = {
+  parent: cosmosDbAccount
+  name: guid(cosmosDbAccount.id, functionApp.id, cosmosDataContributorRoleId)
+  properties: {
+    roleDefinitionId: '${cosmosDbAccount.id}/sqlRoleDefinitions/${cosmosDataContributorRoleId}'
+    principalId: functionApp.identity.principalId
+    scope: cosmosDbAccount.id
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Outputs
+// ---------------------------------------------------------------------------
+
+output functionAppName string = functionApp.name
+output functionAppUrl string = functionApp.properties.defaultHostName
+output functionAppPrincipalId string = functionApp.identity.principalId

--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -3,10 +3,6 @@ param environment string
 param storageAccountName string
 param cosmosDbAccountName string
 
-@description('URL of the PuzzleReplenishFunction endpoint. Leave empty to skip Event Grid subscription creation.')
-@secure()
-param puzzleReplenishFunctionUrl string = ''
-
 @description('Enable the Cosmos DB free tier. Only one account per subscription may use this. Set to false if another account in the subscription already uses it.')
 param cosmosDbEnableFreeTier bool = true
 
@@ -272,7 +268,9 @@ resource profilesThroughput 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/
 }
 
 // ---------------------------------------------------------------------------
-// Event Grid — BlobDeleted on sudoku-puzzles container → PuzzleReplenishFunction
+// Event Grid system topic — source of BlobDeleted events on this account.
+// The eventSubscription that routes BlobDeleted → PuzzleReplenishFunction
+// lives in the functions module (it needs the Function App resource id).
 // ---------------------------------------------------------------------------
 
 resource puzzlePoolEventGridTopic 'Microsoft.EventGrid/systemTopics@2022-06-15' = {
@@ -285,31 +283,8 @@ resource puzzlePoolEventGridTopic 'Microsoft.EventGrid/systemTopics@2022-06-15' 
   }
 }
 
-resource puzzleReplenishSubscription 'Microsoft.EventGrid/systemTopics/eventSubscriptions@2022-06-15' = if (!empty(puzzleReplenishFunctionUrl)) {
-  name: 'puzzle-replenish-sub'
-  parent: puzzlePoolEventGridTopic
-  properties: {
-    destination: {
-      endpointType: 'WebHook'
-      properties: {
-        endpointUrl: puzzleReplenishFunctionUrl
-      }
-    }
-    filter: {
-      includedEventTypes: [
-        'Microsoft.Storage.BlobDeleted'
-      ]
-      subjectBeginsWith: '/blobServices/default/containers/sudoku-puzzles/'
-    }
-    eventDeliverySchema: 'EventGridSchema'
-    retryPolicy: {
-      maxDeliveryAttempts: 30
-      eventTimeToLiveInMinutes: 1440
-    }
-  }
-}
-
 output storageAccountId string = storageAccount.id
 output storageAccountName string = storageAccount.name
 output cosmosDbAccountId string = cosmosDbAccount.id
 output cosmosDbEndpoint string = cosmosDbAccount.properties.documentEndpoint
+output eventGridTopicName string = puzzlePoolEventGridTopic.name

--- a/infra/params/prod.bicepparam
+++ b/infra/params/prod.bicepparam
@@ -8,6 +8,7 @@ param environment = 'prod'
 param appServicePlanName = 'XenobiasoftServicePlan-prod'
 param apiAppName = 'XenobiasoftSudokuApi-prod'
 param mcpAppName = 'XenobiasoftSudokuMcp-prod'
+param functionAppName = 'XenobiasoftSudokuFunctions-prod'
 param appServicePlanSku = 'B1'
 
 // Static Web App

--- a/infra/params/staging.bicepparam
+++ b/infra/params/staging.bicepparam
@@ -7,6 +7,7 @@ param environment = 'staging'
 // Compute
 param appServicePlanName = 'XenobiasoftServicePlan-staging'
 param apiAppName = 'XenobiasoftSudokuApi-staging'
+param functionAppName = 'XenobiasoftSudokuFunctions-staging'
 param appServicePlanSku = 'B1'
 
 // Static Web App — uses the same prod SWA; staging environment slot uses


### PR DESCRIPTION
## Description

Adds the `Sudoku.Functions` app to infrastructure-as-code and wires the **BlobDeleted → PuzzleReplenishFunction** Event Grid subscription.

This fixes the root cause of *"no subscriptions appear on the Event Grid topic"*: the only subscription resource was in `storage.bicep`, gated on a `puzzleReplenishFunctionUrl` param that defaulted to `''` and was never passed from `main.bicep` — so the condition was always false and the subscription was never created. On top of that, there was **no Function App in Bicep at all**, so the trigger target didn't exist as IaC.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Other (please describe): Infrastructure-as-code / CI pipeline

## Changes Made

- **New `infra/modules/functions.bicep`** — Linux Function App (.NET 10 isolated) on the shared B1 plan with `alwaysOn`, reusing the existing storage account for `AzureWebJobsStorage`, with app settings mirroring the API app.
- **Event Grid subscription via `endpointType: 'AzureFunction'`** — binds directly to `…/functions/PuzzleReplenishFunction` (no webhook URL / host key). Filter is `Microsoft.Storage.BlobDeleted` only, scoped to the `sudoku-puzzles` container.
- **RBAC in IaC** — grants the Function identity Storage Blob Data Contributor, Key Vault Secrets User, and the Cosmos DB Built-in Data Contributor SQL role (matching the `mcp.bicep` pattern).
- **`storage.bicep`** — removed the dead WebHook subscription and `puzzleReplenishFunctionUrl` param; now outputs the system topic name.
- **`main.bicep`** — wired in the `functions` module (with `dependsOn: [compute]`), added `functionAppName` param and `functionAppUrl` output.
- **`prod.bicepparam` / `staging.bicepparam`** — added `functionAppName`.
- **`.github/workflows/main.yml`** — publish + deploy `Sudoku.Functions` (`Azure/functions-action@v1`).

## Testing

- [x] I have tested these changes locally (`az bicep build --file infra/main.bicep` compiles cleanly with no warnings/errors)
- [ ] All existing tests pass
- [ ] I have added new tests (if applicable) — N/A, infrastructure-only change

## Notes / first-deploy ordering

- `deploy-infra` runs before `deploy-apps`, so on the very first run the `PuzzleReplenishFunction` code isn't live when the subscription is created. The `AzureFunction` destination stores the resource id without an invocation handshake, so creation should still succeed; if it ever errors on a first run, re-running the workflow (with code now live) resolves it.
- The deploying service principal needs permission to create role assignments — already confirmed, since `mcp.bicep` creates role assignments today.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)