### PR TITLE
Fix Dependabot npm vulnerabilities (react-router, brace-expansion)

### DIFF
--- a/src/frontend/Sudoku.React/package-lock.json
+++ b/src/frontend/Sudoku.React/package-lock.json
@@ -3920,9 +3920,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4483,9 +4483,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7521,9 +7521,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -7543,12 +7543,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
-      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.1"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/src/frontend/Sudoku.React/package.json
+++ b/src/frontend/Sudoku.React/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router-dom": "^7.13.1"
+    "react-router-dom": "^7.17.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",


### PR DESCRIPTION
## Description

Triages and resolves all **6 open Dependabot alerts** (4 high, 2 moderate). Every alert was in the React frontend; the .NET backend reported **no vulnerable packages** (`dotnet list package --vulnerable --include-transitive` is clean across all 9 projects).

The fixes are within the existing semver caret ranges, so this is a lockfile bump plus an explicit floor raise — no breaking changes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other (please describe): Security / dependency maintenance

## Changes Made

- **`react-router` / `react-router-dom` 7.13.1 → 7.17.0** — clears the high-severity cluster: unauth RCE via vendored turbo-stream (GHSA-49rj-9fvp-4h2h), open redirect (GHSA-2j2x-hqr9-3h42), two XSS (GHSA-8646-j5j9-6r62, GHSA-f22v-gfqf-p8f3), and two DoS (GHSA-8x6r-g9mw-2r78, GHSA-rxv8-25v2-qmq8).
- **`brace-expansion`** bumped to patched versions on both transitive trees (moderate ReDoS) — 5.0.4 → 5.0.6 and 1.1.12 → 1.1.15.
- **Raised the declared `react-router-dom` floor to `^7.17.0`** in `package.json` so a fresh install can't resolve back below the patched version.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass — 151 frontend tests green
- [x] Production build succeeds (`npm run build`)
- [x] `npm audit` reports **0 vulnerabilities**
- [ ] I have added new tests (if applicable) — N/A, dependency-only change

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary) — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)