### PR TITLE
Fix Event Grid subscription deploy ordering (NotFound on fresh deploy)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -307,6 +307,44 @@ jobs:
           app-name: ${{ env.AZURE_FUNCTIONS_NAME }}
           package: ${{ github.workspace }}/publish-functions
 
+      # Created here (not in Bicep) because Event Grid validates that the target
+      # function exists when the subscription is created. Infra is deployed
+      # before the function code, so this must run after the package is live.
+      # The command is an upsert, so it is safe to re-run on every deploy.
+      - name: Create Event Grid subscription (BlobDeleted -> PuzzleReplenishFunction)
+        shell: bash
+        run: |
+          set -euo pipefail
+          RG="rg-xenobiasoft-sudoku-prod-westus2"
+          TOPIC="sudoku-puzzle-pool-prod"
+          FUNC_ID=$(az functionapp show \
+            --name "${AZURE_FUNCTIONS_NAME}" \
+            --resource-group "$RG" \
+            --query id -o tsv)
+          ENDPOINT="${FUNC_ID}/functions/PuzzleReplenishFunction"
+
+          # The function may take a moment to be indexed after deployment, so
+          # retry until Event Grid can validate the endpoint.
+          for i in {1..12}; do
+            if az eventgrid system-topic event-subscription create \
+                --name puzzle-replenish-sub \
+                --system-topic-name "$TOPIC" \
+                --resource-group "$RG" \
+                --endpoint-type azurefunction \
+                --endpoint "$ENDPOINT" \
+                --included-event-types Microsoft.Storage.BlobDeleted \
+                --subject-begins-with "/blobServices/default/containers/sudoku-puzzles/" \
+                --max-delivery-attempts 30 \
+                --event-ttl 1440; then
+              echo "Event Grid subscription created/updated."
+              exit 0
+            fi
+            echo "Attempt $i failed (function may still be indexing). Retrying in 20s..."
+            sleep 20
+          done
+          echo "ERROR: Failed to create Event Grid subscription after retries." >&2
+          exit 1
+
   deploy-swa:
     needs: [deploy-infra, build-frontend, changes]
     if: needs.changes.outputs.code == 'true'

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -168,7 +168,6 @@ module functions 'modules/functions.bicep' = {
     appServicePlanName: appServicePlanName
     functionAppName: functionAppName
     storageAccountName: storage.outputs.storageAccountName
-    eventGridTopicName: storage.outputs.eventGridTopicName
     keyVaultName: keyVaultName
     cosmosDbAccountName: cosmosDbAccountName
     appInsightsConnectionString: monitoring.outputs.appInsightsConnectionString

--- a/infra/modules/functions.bicep
+++ b/infra/modules/functions.bicep
@@ -26,9 +26,6 @@ param functionAppName string
 @description('Name of the existing storage account reused for the Functions runtime and puzzle blobs.')
 param storageAccountName string
 
-@description('Name of the existing Event Grid system topic to subscribe to (created in the storage module).')
-param eventGridTopicName string
-
 @description('Name of the existing Key Vault (for the Key Vault Secrets User role assignment).')
 param keyVaultName string
 
@@ -55,10 +52,6 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2023-12-01' existing = {
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
   name: storageAccountName
-}
-
-resource eventGridTopic 'Microsoft.EventGrid/systemTopics@2022-06-15' existing = {
-  name: eventGridTopicName
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
@@ -122,39 +115,12 @@ resource functionAppSettings 'Microsoft.Web/sites/config@2023-12-01' = {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Event Grid subscription — BlobDeleted on the sudoku-puzzles container
-//                           → PuzzleReplenishFunction
-//
-// Uses the AzureFunction destination so it binds directly to the function
-// resource (no host key / webhook URL required).
-// ---------------------------------------------------------------------------
-
-resource puzzleReplenishSubscription 'Microsoft.EventGrid/systemTopics/eventSubscriptions@2022-06-15' = {
-  name: 'puzzle-replenish-sub'
-  parent: eventGridTopic
-  properties: {
-    destination: {
-      endpointType: 'AzureFunction'
-      properties: {
-        resourceId: '${functionApp.id}/functions/PuzzleReplenishFunction'
-        maxEventsPerBatch: 1
-        preferredBatchSizeInKilobytes: 64
-      }
-    }
-    filter: {
-      includedEventTypes: [
-        'Microsoft.Storage.BlobDeleted'
-      ]
-      subjectBeginsWith: '/blobServices/default/containers/sudoku-puzzles/'
-    }
-    eventDeliverySchema: 'EventGridSchema'
-    retryPolicy: {
-      maxDeliveryAttempts: 30
-      eventTimeToLiveInMinutes: 1440
-    }
-  }
-}
+// NOTE: The Event Grid subscription (BlobDeleted → PuzzleReplenishFunction) is
+// NOT created here. Event Grid validates that the target function exists when
+// the subscription is created, but infra is deployed before the function code,
+// so on a fresh Function App the function doesn't exist yet and validation
+// fails with NotFound. The subscription is instead created in the deploy-apps
+// pipeline step, after the function package is published.
 
 // ---------------------------------------------------------------------------
 // RBAC — grant the Function App's managed identity the same data-plane access


### PR DESCRIPTION
## Description

The `deploy-infra` job has been failing on the puzzle-pool Event Grid subscription:

```
InvalidRequest: Webhook endpoint validation failed for .../eventSubscriptions/puzzle-replenish-sub.
Status: Failed, StatusCode: NotFound
```

**Root cause:** Event Grid validates that the target function actually exists when an `AzureFunction` subscription is created. But `deploy-infra` (Bicep) runs **before** `deploy-apps` (function code), so on a fresh Function App `PuzzleReplenishFunction` doesn't exist yet → validation returns `NotFound` → the whole `deploy-infra` job fails → `deploy-apps` (which `needs: deploy-infra`) never runs → the code can never deploy. A deadlock.

This is the first-deploy ordering risk called out when the Functions app was introduced (#299); this PR resolves it properly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other (please describe): CI/CD deployment ordering

## Changes Made

- **Removed the `eventSubscription` from `functions.bicep`** (plus the now-unused `eventGridTopicName` param / topic reference), and dropped the pass-through in `main.bicep`. The Function App and its RBAC role assignments stay in Bicep.
- **Create the subscription in `deploy-apps` after the function package is published**, via `az eventgrid system-topic event-subscription create` — an upsert (safe to re-run on every deploy) with a retry loop to absorb function-indexing latency after deployment.
- The Event Grid **system topic itself stays in `storage.bicep`**. Filter is unchanged: `Microsoft.Storage.BlobDeleted`, scoped to the `sudoku-puzzles` container.

## Why not keep it in Bicep?

Within a single infra deploy the function code is never present (code ships in the later `deploy-apps` job), so the subscription can't validate on a first deploy no matter the Bicep ordering. Creating it post-code-deploy is the reliable, conventional pattern.

## Testing

- [x] `az bicep build --file infra/main.bicep` compiles cleanly (no warnings/errors)
- [x] Self-reviewed the workflow change; the `az` step runs after `Deploy Functions` and after `Azure Login`
- [ ] Full validation happens on merge to `main` (deployment is push-to-main only)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)