### PR TITLE
Use WebHook destination for puzzle-replenish Event Grid subscription

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -307,9 +307,13 @@ jobs:
           app-name: ${{ env.AZURE_FUNCTIONS_NAME }}
           package: ${{ github.workspace }}/publish-functions
 
-      # Created here (not in Bicep) because Event Grid validates that the target
-      # function exists when the subscription is created. Infra is deployed
-      # before the function code, so this must run after the package is live.
+      # Created here (not in Bicep) because the subscription must point at a live
+      # function. We use the WebHook destination against the Functions Event Grid
+      # extension URL rather than the AzureFunction destination: the latter
+      # resolves the function through the ARM "list functions" API, which is not
+      # reliably populated for dotnet-isolated apps on a Linux plan and returns
+      # NotFound. The WebHook path uses the eventgrid_extension system key, and
+      # the Functions runtime auto-answers Event Grid's validation handshake.
       # The command is an upsert, so it is safe to re-run on every deploy.
       - name: Create Event Grid subscription (BlobDeleted -> PuzzleReplenishFunction)
         shell: bash
@@ -317,33 +321,43 @@ jobs:
           set -euo pipefail
           RG="rg-xenobiasoft-sudoku-prod-westus2"
           TOPIC="sudoku-puzzle-pool-prod"
-          FUNC_ID=$(az functionapp show \
-            --name "${AZURE_FUNCTIONS_NAME}" \
-            --resource-group "$RG" \
-            --query id -o tsv)
-          ENDPOINT="${FUNC_ID}/functions/PuzzleReplenishFunction"
+          FUNC_APP="${AZURE_FUNCTIONS_NAME}"
+          FUNC_NAME="PuzzleReplenishFunction"
 
-          # The function may take a moment to be indexed after deployment, so
-          # retry until Event Grid can validate the endpoint.
-          for i in {1..12}; do
-            if az eventgrid system-topic event-subscription create \
-                --name puzzle-replenish-sub \
-                --system-topic-name "$TOPIC" \
-                --resource-group "$RG" \
-                --endpoint-type azurefunction \
-                --endpoint "$ENDPOINT" \
-                --included-event-types Microsoft.Storage.BlobDeleted \
-                --subject-begins-with "/blobServices/default/containers/sudoku-puzzles/" \
-                --max-delivery-attempts 30 \
-                --event-ttl 1440; then
-              echo "Event Grid subscription created/updated."
-              exit 0
+          # The eventgrid_extension system key only exists once the host has
+          # loaded the Event Grid-triggered function, so polling for it also
+          # gates on the function being indexed and running.
+          SYSKEY=""
+          for i in {1..15}; do
+            SYSKEY=$(az functionapp keys list \
+              --name "$FUNC_APP" --resource-group "$RG" \
+              --query "systemKeys.eventgrid_extension" -o tsv 2>/dev/null || true)
+            if [ -n "$SYSKEY" ] && [ "$SYSKEY" != "null" ]; then
+              echo "eventgrid_extension system key is available."
+              break
             fi
-            echo "Attempt $i failed (function may still be indexing). Retrying in 20s..."
+            echo "Waiting for function to index / system key to appear ($i/15)..."
             sleep 20
           done
-          echo "ERROR: Failed to create Event Grid subscription after retries." >&2
-          exit 1
+          if [ -z "$SYSKEY" ] || [ "$SYSKEY" = "null" ]; then
+            echo "ERROR: eventgrid_extension system key never appeared; the function did not index." >&2
+            exit 1
+          fi
+          echo "::add-mask::$SYSKEY"
+
+          ENDPOINT="https://${FUNC_APP}.azurewebsites.net/runtime/webhooks/eventgrid?functionName=${FUNC_NAME}&code=${SYSKEY}"
+
+          az eventgrid system-topic event-subscription create \
+            --name puzzle-replenish-sub \
+            --system-topic-name "$TOPIC" \
+            --resource-group "$RG" \
+            --endpoint-type webhook \
+            --endpoint "$ENDPOINT" \
+            --included-event-types Microsoft.Storage.BlobDeleted \
+            --subject-begins-with "/blobServices/default/containers/sudoku-puzzles/" \
+            --max-delivery-attempts 30 \
+            --event-ttl 1440
+          echo "Event Grid subscription created/updated."
 
   deploy-swa:
     needs: [deploy-infra, build-frontend, changes]


### PR DESCRIPTION
## Description

Follow-up to #301. `deploy-infra` now succeeds and `Deploy Functions` deploys the code, but the subscription step still failed — it retried the `AzureFunction` destination 12 times over 4 minutes and got `NotFound` every time:

```
InvalidRequest: Webhook endpoint validation failed ... StatusCode: NotFound
```

**Root cause:** the `AzureFunction` destination makes Event Grid resolve the target via the ARM *"list functions"* API. For **dotnet-isolated functions on a Linux plan**, that listing is not reliably populated, so Event Grid never sees `PuzzleReplenishFunction` — independent of whether the function is actually running.

## Fix

Switch the `deploy-apps` step to the **WebHook destination** against the Functions Event Grid extension URL:

```
https://<app>.azurewebsites.net/runtime/webhooks/eventgrid?functionName=PuzzleReplenishFunction&code=<eventgrid_extension key>
```

- Doesn't depend on the ARM function listing; the Functions runtime auto-answers Event Grid's validation handshake.
- Polls for the `eventgrid_extension` system key first — that key only exists once the host has loaded the Event Grid-triggered function, so it doubles as a readiness gate.
- The system key is masked (`::add-mask::`) so it never appears in logs.

This is effectively the destination the original Bicep was reaching for with the (never-wired) `puzzleReplenishFunctionUrl` param.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other (please describe): CI/CD deployment

## Changes Made

- Rewrote the "Create Event Grid subscription" step in `main.yml` to fetch the `eventgrid_extension` system key (with retry) and create the subscription via the WebHook endpoint type. Filter unchanged (`Microsoft.Storage.BlobDeleted`, `sudoku-puzzles` container).

## Testing

- [x] `az bicep build` still clean (no infra changes)
- [ ] Validated on merge to `main` (deploy is push-to-main only)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)