### PR TITLE
Fix Function App not indexing: drop WEBSITE_RUN_FROM_PACKAGE on Linux

### DIFF
--- a/infra/modules/functions.bicep
+++ b/infra/modules/functions.bicep
@@ -103,7 +103,14 @@ resource functionAppSettings 'Microsoft.Web/sites/config@2023-12-01' = {
     FUNCTIONS_EXTENSION_VERSION: '~4'
     FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
     AzureWebJobsStorage: storageConnectionString
-    WEBSITE_RUN_FROM_PACKAGE: '1'
+
+    // Deploy the pre-built publish artifact via zip-deploy to a writable
+    // wwwroot. WEBSITE_RUN_FROM_PACKAGE=1 must NOT be set: it makes wwwroot a
+    // read-only mount, so the Linux zip-deploy can't write the package and the
+    // host indexes zero functions. Disable Oryx/remote build since the artifact
+    // is already published.
+    SCM_DO_BUILD_DURING_DEPLOYMENT: 'false'
+    ENABLE_ORYX_BUILD: 'false'
 
     // Observability
     APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString


### PR DESCRIPTION
## Description

Follow-up to #302. With the WebHook subscription fix in place, `deploy-infra` and `Deploy Functions` both succeeded — but the subscription step still failed because the **`eventgrid_extension` system key never appeared**. That key only exists once the host loads an Event Grid-triggered function, so the real problem was: **the Function App was indexing zero functions.**

## Diagnosis (against the live app)

- Host **Running**, `DOTNET-ISOLATED|10.0` (a supported stack — ruled out .NET 10).
- `wwwroot` contained **only the default `host.json`** — none of the published output.
- The local `dotnet publish` artifact was complete and correct (`functions.metadata` listing both functions, app DLL, `worker.config.json`, etc.).

## Root cause

`WEBSITE_RUN_FROM_PACKAGE=1` makes `wwwroot` a **read-only mount** from the package. But `Azure/functions-action@v1` on a Linux **dedicated** plan deploys via **zip-deploy to `wwwroot`**. The deploy couldn't write the read-only mount, so the package contents never landed and the host had nothing to index.

## Fix

In `functions.bicep`, remove `WEBSITE_RUN_FROM_PACKAGE` and disable remote build (artifact is pre-published):

```
SCM_DO_BUILD_DURING_DEPLOYMENT: 'false'
ENABLE_ORYX_BUILD: 'false'
```

## Verified live (before opening this PR)

Applied the same settings to the prod app, restarted, and zip-deployed the published artifact:
- `wwwroot` is now fully populated (`.azurefunctions`, `functions.metadata`, all DLLs).
- Host admin API (`/admin/functions`) loads **both** functions.
- `eventgrid_extension` system key is generated.
- `puzzle-replenish-sub` WebHook subscription provisions with `provisioningState: Succeeded`.

So prod is already in a working state; this PR makes the IaC match it for future deploys.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other (please describe): Infrastructure-as-code / deployment

## Testing

- [x] `az bicep build --file infra/main.bicep` compiles cleanly
- [x] Validated end-to-end against the live Function App (see above)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)