### PR TITLE
Add Serilog structured logging to Sudoku.Api

### DIFF
--- a/src/backend/Sudoku.Api/Program.cs
+++ b/src/backend/Sudoku.Api/Program.cs
@@ -13,7 +13,8 @@ builder.Host.UseSerilog((context, services, config) =>
         .Enrich.FromLogContext()
         .Enrich.WithMachineName()
         .Enrich.WithThreadId()
-        .Enrich.WithEnvironmentName());
+        .Enrich.WithEnvironmentName(),
+    writeToProviders: true);
 
 builder.AddServiceDefaults();
 

--- a/src/backend/Sudoku.Api/Program.cs
+++ b/src/backend/Sudoku.Api/Program.cs
@@ -1,10 +1,19 @@
 using Azure.Identity;
-using Microsoft.AspNetCore.HttpLogging;
 using Microsoft.OpenApi;
+using Serilog;
 using Sudoku.Api;
 using System.Reflection;
 
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseSerilog((context, services, config) =>
+    config
+        .ReadFrom.Configuration(context.Configuration)
+        .ReadFrom.Services(services)
+        .Enrich.FromLogContext()
+        .Enrich.WithMachineName()
+        .Enrich.WithThreadId()
+        .Enrich.WithEnvironmentName());
 
 builder.AddServiceDefaults();
 
@@ -26,11 +35,6 @@ if (!builder.Environment.IsDevelopment())
 builder.AddAzureCosmosClient("CosmosDb");
 
 builder.Services.AddApiDefaults(builder.Configuration, builder.Environment);
-
-builder.Services.AddHttpLogging(logging =>
-{
-    logging.LoggingFields = HttpLoggingFields.All;
-});
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
@@ -61,6 +65,8 @@ if (app.Environment.IsDevelopment() || app.Configuration.GetValue<bool>("EnableS
     });
 }
 
+app.UseSerilogRequestLogging();
+
 app.UseHttpsRedirection();
 
 app.UseCors("AllowAll");
@@ -68,8 +74,6 @@ app.UseCors("AllowAll");
 app.UseAuthorization();
 
 app.MapControllers();
-
-app.UseHttpLogging();
 
 app.MapHealthChecks("/health-check");
 

--- a/src/backend/Sudoku.Api/Sudoku.Api.csproj
+++ b/src/backend/Sudoku.Api/Sudoku.Api.csproj
@@ -14,6 +14,10 @@
     <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.3.5" />
     <PackageReference Include="MediatR" Version="14.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
   </ItemGroup>
 

--- a/src/backend/Sudoku.Api/appsettings.Development.json
+++ b/src/backend/Sudoku.Api/appsettings.Development.json
@@ -1,9 +1,19 @@
 {
-    "Logging": {
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft.AspNetCore": "Warning"
-        }
+    "Serilog": {
+        "MinimumLevel": {
+            "Default": "Debug",
+            "Override": {
+                "Microsoft.AspNetCore": "Information"
+            }
+        },
+        "WriteTo": [
+            {
+                "Name": "Console",
+                "Args": {
+                    "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {SourceContext}: {Message:lj}{NewLine}{Exception}"
+                }
+            }
+        ]
     },
     "ConnectionStrings": {
         "CosmosDb": "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==;"

--- a/src/backend/Sudoku.Api/appsettings.Production.json
+++ b/src/backend/Sudoku.Api/appsettings.Production.json
@@ -1,10 +1,4 @@
 {
-    "Logging": {
-        "LogLevel": {
-            "Default": "Information",
-            "Microsoft.AspNetCore": "Warning"
-        }
-    },
     "appconfig": {
         "Endpoint": "https://appcs-xenobiasoft-prod.azconfig.io",
         "ManagedIdentityEnabled": true

--- a/src/backend/Sudoku.Api/appsettings.json
+++ b/src/backend/Sudoku.Api/appsettings.json
@@ -1,10 +1,28 @@
 {
-    "Logging": {
-        "LogLevel": {
-            "Default": "Information"
-        }
-    },
     "AllowedHosts": "*",
+    "Serilog": {
+        "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.OpenTelemetry" ],
+        "MinimumLevel": {
+            "Default": "Information",
+            "Override": {
+                "Microsoft": "Warning",
+                "Microsoft.AspNetCore": "Warning",
+                "System": "Warning"
+            }
+        },
+        "WriteTo": [
+            {
+                "Name": "Console",
+                "Args": {
+                    "formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
+                }
+            },
+            {
+                "Name": "OpenTelemetry"
+            }
+        ],
+        "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId", "WithEnvironmentName" ]
+    },
     "AzureAppConfiguration": {
         "KeyFilter": "*",
         "RefreshInterval": 30,

--- a/src/backend/Sudoku.Infrastructure/Services/StrategyBasedPuzzleSolver.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/StrategyBasedPuzzleSolver.cs
@@ -58,13 +58,13 @@ public class StrategyBasedPuzzleSolver(IEnumerable<SolverStrategy> strategies, I
 
         foreach (var strategy in strategies.OrderBy(x => x.Order))
         {
-            logger.LogDebug($"Solving with {strategy.GetType().Name}");
+            logger.LogDebug("Solving with {StrategyName}", strategy.GetType().Name);
 
             changesMade = changesMade || strategy.SolvePuzzle(_puzzle);
 
             if (!_puzzle.IsValid())
             {
-                logger.LogWarning($"Failure in solving puzzle using {strategy.GetType().Name} strategy");
+                logger.LogWarning("Failure in solving puzzle using {StrategyName} strategy", strategy.GetType().Name);
                 await UndoAsync();
             }
 
@@ -101,7 +101,7 @@ public class StrategyBasedPuzzleSolver(IEnumerable<SolverStrategy> strategies, I
         }
 
         var value = cell.PossibleValues.ElementAt(rnd.Next(cell.PossibleValues.Count));
-        logger.LogDebug($"Setting cell at ({cell.Row}, {cell.Column}) to {value}");
+        logger.LogDebug("Setting cell at ({Row}, {Column}) to {Value}", cell.Row, cell.Column, value);
         cell.SetValue(value);
     }
 


### PR DESCRIPTION
## Description

Adds Serilog as the structured logging backend for `Sudoku.Api`, replacing the default .NET console provider. Serilog integrates via MEL's `ILoggerProvider`, so all existing `ILogger<T>` call sites are unchanged. The existing OpenTelemetry → Azure Monitor pipeline is preserved by bridging Serilog through the `OpenTelemetry` sink.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Added `Serilog.AspNetCore`, `Serilog.Enrichers.Environment`, `Serilog.Enrichers.Thread`, and `Serilog.Sinks.OpenTelemetry` packages to `Sudoku.Api`
- Wired `builder.Host.UseSerilog()` in `Program.cs` with `FromLogContext`, `WithMachineName`, `WithThreadId`, and `WithEnvironmentName` enrichers
- Replaced `UseHttpLogging` / `AddHttpLogging` with `UseSerilogRequestLogging` (single structured line per request)
- Configured `appsettings.json` with Console (compact JSON) + OpenTelemetry sinks; `appsettings.Development.json` overrides to human-readable console output at Debug level
- Removed redundant `Logging` sections from all three appsettings files (Serilog `MinimumLevel` takes over)
- Fixed 3 string-interpolated log calls in `StrategyBasedPuzzleSolver.cs` that were defeating structured logging

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation (if necessary)