### PR TITLE
Deploy Functions on Flex Consumption (FC1) with fresh-app recreate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,6 +215,31 @@ jobs:
           az account list --output table
           az group show -n rg-xenobiasoft-sudoku-prod-westus2 --output table
 
+      # Flex Consumption does not support in-place migration of an existing
+      # Function App from another plan (Azure returns Conflict 59602). If the
+      # app currently lives on a non-Flex plan, delete it so the Bicep deploy
+      # can recreate it fresh on the FC1 plan. Idempotent: once the app is on
+      # FlexConsumption this is a no-op. Does not touch the shared B1 plan that
+      # hosts the API and MCP apps.
+      - name: Recreate Functions app on Flex (delete if on a non-Flex plan)
+        shell: bash
+        run: |
+          set -euo pipefail
+          RG="rg-xenobiasoft-sudoku-prod-westus2"
+          APP="${AZURE_FUNCTIONS_NAME}"
+          PLAN_ID=$(az functionapp show -n "$APP" -g "$RG" --query appServicePlanId -o tsv 2>/dev/null || true)
+          if [ -n "$PLAN_ID" ]; then
+            TIER=$(az appservice plan show --ids "$PLAN_ID" --query sku.tier -o tsv 2>/dev/null || true)
+            if [ "$TIER" != "FlexConsumption" ]; then
+              echo "Existing app is on '$TIER' (not Flex); deleting so Bicep can recreate it on FC1."
+              az functionapp delete -n "$APP" -g "$RG"
+            else
+              echo "App already on FlexConsumption; no recreate needed."
+            fi
+          else
+            echo "No existing Functions app; Bicep will create it fresh."
+          fi
+
       - name: Deploy Bicep template
         id: deploy
         uses: azure/arm-deploy@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -307,14 +307,15 @@ jobs:
           set -euo pipefail
           cd "${{ github.workspace }}/publish-functions"
           zip -r ../functions.zip .
-          # Use zipdeploy (not OneDeploy) so Oryx does not run against the
-          # pre-built publish output. azure/webapps-deploy uses OneDeploy for
-          # functionapp,linux which triggers Oryx and fails on compiled binaries.
-          az functionapp deployment source config-zip \
+          # Flex Consumption uses OneDeploy (the package is uploaded to the
+          # configured deployment blob container) — the legacy Kudu config-zip
+          # path does not apply. No Oryx build runs against this pre-built
+          # publish output.
+          az functionapp deploy \
             --name "${{ env.AZURE_FUNCTIONS_NAME }}" \
             --resource-group "rg-xenobiasoft-sudoku-prod-westus2" \
-            --src "${{ github.workspace }}/functions.zip" \
-            --timeout 600
+            --src-path "${{ github.workspace }}/functions.zip" \
+            --type zip
 
   deploy-event-grid:
     needs: deploy-apps

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -26,6 +26,9 @@ param mcpAppName string
 @description('Name of the Azure Functions app (puzzle-pool background jobs).')
 param functionAppName string
 
+@description('Name of the Flex Consumption plan that hosts the Azure Functions app.')
+param functionPlanName string
+
 @description('App Service Plan SKU.')
 param appServicePlanSku string = 'B1'
 
@@ -165,7 +168,7 @@ module functions 'modules/functions.bicep' = {
   params: {
     location: location
     environment: environment
-    appServicePlanName: appServicePlanName
+    functionPlanName: functionPlanName
     functionAppName: functionAppName
     storageAccountName: storage.outputs.storageAccountName
     keyVaultName: keyVaultName
@@ -174,9 +177,6 @@ module functions 'modules/functions.bicep' = {
     keyVaultUri: keyvault.outputs.keyVaultUri
     cosmosDbEndpoint: storage.outputs.cosmosDbEndpoint
   }
-  dependsOn: [
-    compute
-  ]
 }
 
 module staticwebapp 'modules/staticwebapp.bicep' = {

--- a/infra/modules/functions.bicep
+++ b/infra/modules/functions.bicep
@@ -1,29 +1,46 @@
 // ---------------------------------------------------------------------------
-// Azure Functions App
+// Azure Functions App — Flex Consumption (on-demand)
 //
 // Hosts the puzzle-pool background functions:
 //   PuzzlePoolSeedFunction   — TimerTrigger, nightly top-up of the pool
 //   PuzzleReplenishFunction  — EventGridTrigger, replenishes one puzzle each
 //                              time a puzzle blob is deleted from the pool
 //
-// Runs on the shared App Service Plan (B1, Linux) alongside the API and MCP
-// apps. Reuses the existing storage account for the Functions runtime
-// (AzureWebJobsStorage).
+// Hosting
+//   Runs on its OWN Flex Consumption plan (FC1, Linux) rather than the shared
+//   B1 App Service Plan. Flex Consumption supports the .NET 10 isolated runtime
+//   (the Linux Dedicated plan does not), and on-demand billing keeps this very
+//   low-volume workload (one daily timer + sporadic blob-delete events) inside
+//   the monthly free grant — effectively $0/month.
+//
+// Cost note
+//   scaleAndConcurrency.alwaysReady is intentionally EMPTY. Always-ready
+//   instances bill even while idle ($0.000004/GB-s, no free grant). This
+//   background workload tolerates cold starts, so we run purely on-demand.
+//
+// Runtime / deployment
+//   For Flex Consumption the runtime stack and worker are declared in
+//   functionAppConfig.runtime (NOT linuxFxVersion), and the deployment package
+//   is delivered to a blob container (functionAppConfig.deployment.storage)
+//   via OneDeploy — there is no Kudu/Oryx build, so SCM_DO_BUILD_DURING_*,
+//   ENABLE_ORYX_BUILD, WEBSITE_RUN_FROM_PACKAGE and FUNCTIONS_EXTENSION_VERSION
+//   are not used.
 //
 // Auth model
-//   Outbound — SystemAssigned Managed Identity → Key Vault / Cosmos / Blob.
-//   The identity must be granted the same data-plane roles as the API app
-//   (Key Vault Secrets User, Storage Blob Data Contributor, and the Cosmos
-//   SQL data role). Those grants are managed outside this template, matching
-//   the existing API setup.
+//   SystemAssigned Managed Identity for everything: host storage
+//   (AzureWebJobsStorage), the deployment container, Key Vault, Cosmos and
+//   puzzle blobs. The identity is granted the data-plane roles below.
 // ---------------------------------------------------------------------------
 
 param location string
 param environment string
-param appServicePlanName string
+
+@description('Name of the Flex Consumption plan to create for the Function App.')
+param functionPlanName string
+
 param functionAppName string
 
-@description('Name of the existing storage account reused for the Functions runtime and puzzle blobs.')
+@description('Name of the existing storage account reused for the Functions runtime, deployment package and puzzle blobs.')
 param storageAccountName string
 
 @description('Name of the existing Key Vault (for the Key Vault Secrets User role assignment).')
@@ -36,19 +53,30 @@ param appInsightsConnectionString string
 param keyVaultUri string
 param cosmosDbEndpoint string
 
+@description('Memory allocated per Flex Consumption instance, in MB. 2048 or 4096.')
+@allowed([
+  2048
+  4096
+])
+param instanceMemoryMB int = 2048
+
+@description('Maximum number of instances the app may scale out to (40–1000).')
+@minValue(40)
+@maxValue(1000)
+param maximumInstanceCount int = 40
+
 var tags = {
   environment: environment
   project: 'XenobiaSoftSudoku'
   component: 'functions'
 }
 
+// Blob container that holds the deployed function package (OneDeploy target).
+var deploymentContainerName = 'function-deployment'
+
 // ---------------------------------------------------------------------------
 // Reference shared / existing resources (read-only)
 // ---------------------------------------------------------------------------
-
-resource appServicePlan 'Microsoft.Web/serverfarms@2023-12-01' existing = {
-  name: appServicePlanName
-}
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
   name: storageAccountName
@@ -62,13 +90,43 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' exis
   name: cosmosDbAccountName
 }
 
-var storageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};AccountKey=${storageAccount.listKeys().keys[0].value};EndpointSuffix=${az.environment().suffixes.storage}'
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' existing = {
+  parent: storageAccount
+  name: 'default'
+}
+
+// Container for the deployment package.
+resource deploymentContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-01-01' = {
+  parent: blobService
+  name: deploymentContainerName
+  properties: {
+    publicAccess: 'None'
+  }
+}
 
 // ---------------------------------------------------------------------------
-// Function App
+// Flex Consumption plan (FC1, Linux)
 // ---------------------------------------------------------------------------
 
-resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
+resource flexPlan 'Microsoft.Web/serverfarms@2024-04-01' = {
+  name: functionPlanName
+  location: location
+  tags: tags
+  kind: 'functionapp'
+  sku: {
+    tier: 'FlexConsumption'
+    name: 'FC1'
+  }
+  properties: {
+    reserved: true // Linux
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Function App (Flex Consumption)
+// ---------------------------------------------------------------------------
+
+resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
   name: functionAppName
   location: location
   kind: 'functionapp,linux'
@@ -77,40 +135,44 @@ resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
     type: 'SystemAssigned'
   }
   properties: {
-    serverFarmId: appServicePlan.id
+    serverFarmId: flexPlan.id
     httpsOnly: true
-    clientAffinityEnabled: false
-    reserved: true
     keyVaultReferenceIdentity: 'SystemAssigned'
+    functionAppConfig: {
+      deployment: {
+        storage: {
+          type: 'blobContainer'
+          value: '${storageAccount.properties.primaryEndpoints.blob}${deploymentContainerName}'
+          authentication: {
+            type: 'SystemAssignedIdentity'
+          }
+        }
+      }
+      runtime: {
+        name: 'dotnet-isolated'
+        version: '10.0'
+      }
+      scaleAndConcurrency: {
+        // On-demand only — no always-ready instances, so the app bills nothing
+        // while idle and stays within the monthly free grant for this workload.
+        alwaysReady: []
+        maximumInstanceCount: maximumInstanceCount
+        instanceMemoryMB: instanceMemoryMB
+      }
+    }
     siteConfig: {
-      linuxFxVersion: 'DOTNET-ISOLATED|10.0'
-      alwaysOn: true
-      http20Enabled: true
       minTlsVersion: '1.2'
-      scmMinTlsVersion: '1.2'
       ftpsState: 'FtpsOnly'
-      numberOfWorkers: 1
-      use32BitWorkerProcess: false
     }
   }
 }
 
-resource functionAppSettings 'Microsoft.Web/sites/config@2023-12-01' = {
+resource functionAppSettings 'Microsoft.Web/sites/config@2024-04-01' = {
   parent: functionApp
   name: 'appsettings'
   properties: {
-    // Functions runtime
-    FUNCTIONS_EXTENSION_VERSION: '~4'
-    FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
-    AzureWebJobsStorage: storageConnectionString
-
-    // Deploy the pre-built publish artifact via zip-deploy to a writable
-    // wwwroot. WEBSITE_RUN_FROM_PACKAGE=1 must NOT be set: it makes wwwroot a
-    // read-only mount, so the Linux zip-deploy can't write the package and the
-    // host indexes zero functions. Disable Oryx/remote build since the artifact
-    // is already published.
-    SCM_DO_BUILD_DURING_DEPLOYMENT: 'false'
-    ENABLE_ORYX_BUILD: 'false'
+    // Host storage via managed identity (no account keys / connection strings).
+    AzureWebJobsStorage__accountName: storageAccount.name
 
     // Observability
     APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
@@ -123,33 +185,34 @@ resource functionAppSettings 'Microsoft.Web/sites/config@2023-12-01' = {
 }
 
 // NOTE: The Event Grid subscription (BlobDeleted → PuzzleReplenishFunction) is
-// NOT created here. Event Grid validates that the target function exists when
-// the subscription is created, but infra is deployed before the function code,
-// so on a fresh Function App the function doesn't exist yet and validation
-// fails with NotFound. The subscription is instead created in the deploy-apps
-// pipeline step, after the function package is published.
+// still created in the deploy pipeline after the package is published, because
+// the subscription's webhook target only resolves once the host has indexed
+// the Event Grid-triggered function.
 
 // ---------------------------------------------------------------------------
-// RBAC — grant the Function App's managed identity the same data-plane access
-// the API app uses.
+// RBAC — grant the Function App's managed identity the data-plane access it
+// needs.
 //
-//   Storage Blob Data Contributor  (ba92f5b4-2d11-453d-a403-e96b0029c9fe)
-//     Read/write puzzle blobs in the sudoku-puzzles container.
+//   Storage Blob Data Owner        (b7e6dc6d-f1e8-4753-8033-0f276bb0955b)
+//     Host storage (AzureWebJobsStorage), the deployment container, and
+//     read/write of puzzle blobs in the sudoku-puzzles container. Owner (vs
+//     Contributor) is used because the Flex host and timer-singleton leases
+//     need full blob data-plane access.
 //   Key Vault Secrets User         (4633458b-17de-408a-b874-0445c86b69e6)
 //     Resolve Key Vault references / configuration secrets.
 //   Cosmos DB Built-in Data Contributor (00000000-...-000000000002)
 //     Cosmos data-plane access (SQL role assignment, not Azure RBAC).
 // ---------------------------------------------------------------------------
 
-var storageBlobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
-var keyVaultSecretsUserRoleId        = '4633458b-17de-408a-b874-0445c86b69e6'
-var cosmosDataContributorRoleId      = '00000000-0000-0000-0000-000000000002'
+var storageBlobDataOwnerRoleId = 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b'
+var keyVaultSecretsUserRoleId  = '4633458b-17de-408a-b874-0445c86b69e6'
+var cosmosDataContributorRoleId = '00000000-0000-0000-0000-000000000002'
 
-resource blobDataContributorAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource blobDataOwnerAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   scope: storageAccount
-  name: guid(storageAccount.id, functionApp.id, storageBlobDataContributorRoleId)
+  name: guid(storageAccount.id, functionApp.id, storageBlobDataOwnerRoleId)
   properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributorRoleId)
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataOwnerRoleId)
     principalId: functionApp.identity.principalId
     principalType: 'ServicePrincipal'
   }

--- a/infra/params/prod.bicepparam
+++ b/infra/params/prod.bicepparam
@@ -9,6 +9,7 @@ param appServicePlanName = 'XenobiasoftServicePlan-prod'
 param apiAppName = 'XenobiasoftSudokuApi-prod'
 param mcpAppName = 'XenobiasoftSudokuMcp-prod'
 param functionAppName = 'XenobiasoftSudokuFunctions-prod'
+param functionPlanName = 'XenobiasoftFunctionsPlan-prod'
 param appServicePlanSku = 'B1'
 
 // Static Web App

--- a/infra/params/staging.bicepparam
+++ b/infra/params/staging.bicepparam
@@ -7,7 +7,9 @@ param environment = 'staging'
 // Compute
 param appServicePlanName = 'XenobiasoftServicePlan-staging'
 param apiAppName = 'XenobiasoftSudokuApi-staging'
+param mcpAppName = 'XenobiasoftSudokuMcp-staging'
 param functionAppName = 'XenobiasoftSudokuFunctions-staging'
+param functionPlanName = 'XenobiasoftFunctionsPlan-staging'
 param appServicePlanSku = 'B1'
 
 // Static Web App — uses the same prod SWA; staging environment slot uses


### PR DESCRIPTION
## Description

Gets the puzzle-pool Azure Functions app deploying and indexing on **.NET 10 isolated** in West US 2 by hosting it on a **Flex Consumption (FC1)** plan, and fixes the deployment failure that blocked the previous FC1 attempt.

This restores the reverted FC1 migration (#312) and adds the one missing piece that makes it actually deploy.

### Root cause (from CI logs)
- The previous **FC1 attempt failed at `deploy-infra`** with `Conflict 59602: Cannot change the site ... to the App Service Plan ... due to hosting constraints`. Azure does **not** support migrating an existing Function App onto a Flex Consumption plan in place — it was *not* a West US 2 / region-support issue. Flex is GA in West US 2 and supports .NET 8/9/10 isolated.
- The **reverted Dedicated B1 config also fails**: the host starts and creates the `eventgrid_extension` system key, but the webhook endpoint returns 404 and no functions appear — the .NET 10 isolated worker does not serve functions on the Linux Dedicated plan.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other (please describe): Infrastructure / CI-CD deployment fix

## Changes Made

- Re-applied the FC1 infrastructure migration (`infra/modules/functions.bicep`, `infra/main.bicep`, `infra/params/prod.bicepparam`, `infra/params/staging.bicepparam`, and the `az functionapp deploy --type zip` OneDeploy step in `main.yml`).
- Added a guarded, idempotent step to the `deploy-infra` job: if the Functions app exists on a **non-Flex** plan, delete it so Bicep recreates it fresh on FC1. No-op once the app is already on `FlexConsumption`. The shared B1 plan hosting the API and MCP apps is untouched.

## Testing

- [x] I have tested these changes locally — `az bicep build` (main.bicep) and `az bicep build-params` (prod + staging) all compile cleanly.
- [ ] All existing tests pass — N/A (infra/pipeline only)
- [ ] I have added new tests (if applicable) — N/A

### Post-merge verification
- `deploy-infra` succeeds with no `Conflict 59602`.
- `deploy-apps` deploys the package via OneDeploy.
- `deploy-event-grid` succeeds (system key appears, webhook returns non-404).
- `az functionapp show ... --query sku` → `FlexConsumption`; `az functionapp function list` shows `PuzzlePoolSeedFunction` and `PuzzleReplenishFunction`.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)