### PR TITLE
Fix Functions Flex recreate detection (RG-scoped list)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,17 +227,24 @@ jobs:
           set -euo pipefail
           RG="rg-xenobiasoft-sudoku-prod-westus2"
           APP="${AZURE_FUNCTIONS_NAME}"
-          PLAN_ID=$(az functionapp show -n "$APP" -g "$RG" --query appServicePlanId -o tsv 2>/dev/null || true)
-          if [ -n "$PLAN_ID" ]; then
-            TIER=$(az appservice plan show --ids "$PLAN_ID" --query sku.tier -o tsv 2>/dev/null || true)
-            if [ "$TIER" != "FlexConsumption" ]; then
-              echo "Existing app is on '$TIER' (not Flex); deleting so Bicep can recreate it on FC1."
-              az functionapp delete -n "$APP" -g "$RG"
-            else
-              echo "App already on FlexConsumption; no recreate needed."
-            fi
+          FLEX_PLAN="XenobiasoftFunctionsPlan-prod"
+
+          # Detect via an RG-scoped list + client-side filter rather than
+          # `az functionapp show -n <app>`: the latter intermittently returned an
+          # empty appServicePlanId in CI, which silently routed an existing app
+          # down the "create fresh" path and let Bicep hit Conflict 59602 again.
+          # The list query returns an empty string (exit 0) when the app is
+          # absent, so `set -e` only trips on a genuine CLI/auth failure.
+          APP_ID=$(az functionapp list -g "$RG" --query "[?name=='$APP'].id | [0]" -o tsv)
+          PLAN_ID=$(az functionapp list -g "$RG" --query "[?name=='$APP'].appServicePlanId | [0]" -o tsv)
+
+          if [ -z "$APP_ID" ]; then
+            echo "No existing Functions app; Bicep will create it fresh on FC1."
+          elif [[ "$PLAN_ID" == */"$FLEX_PLAN" ]]; then
+            echo "App already on Flex plan ($FLEX_PLAN); no recreate needed."
           else
-            echo "No existing Functions app; Bicep will create it fresh."
+            echo "Existing app is on a non-Flex plan ($PLAN_ID); deleting so Bicep can recreate it on FC1."
+            az functionapp delete --ids "$APP_ID"
           fi
 
       - name: Deploy Bicep template


### PR DESCRIPTION
## Description

Follow-up to #313. The first FC1 deploy on `main` failed at `deploy-infra` with the same `Conflict 59602` it was meant to prevent.

**Root cause:** the recreate step logged *"No existing Functions app; Bicep will create it fresh"* and Bicep then tried the unsupported in-place migration anyway. `az functionapp show -n <app> --query appServicePlanId -o tsv` returned **empty in CI** even though the app exists on the B1 plan (verified live). The `2>/dev/null || true` swallowed whatever went wrong and silently routed the still-existing app down the create-fresh branch.

**Fix:** detect with an RG-scoped `az functionapp list` + client-side `[?name=='...']` filter, which reliably returns both the app id and its `appServicePlanId` in one call. The app is treated as absent only when the filtered list is genuinely empty (empty string, exit 0), so `set -e` trips only on a real CLI/auth failure rather than mis-routing.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other (please describe): CI/CD deployment fix

## Changes Made

- Replaced `az functionapp show -n <app>` detection with `az functionapp list -g <rg> --query "[?name=='<app>']..."` for both the app id and plan id.
- Idempotency now keys off the FC1 plan name (`*/XenobiasoftFunctionsPlan-prod`): no-op once migrated, delete otherwise, create-fresh only when truly absent.
- Removed the blanket stderr/`|| true` suppression that masked the failure.

## Testing

- [x] I have tested these changes locally — confirmed against live Azure that `az functionapp list ... --query "[?name=='XenobiasoftSudokuFunctions-prod'].id|[0]"` returns the app id and `.appServicePlanId|[0]` returns the B1 plan (the case `functionapp show` returned empty for in CI).
- [ ] All existing tests pass — N/A (CI pipeline only)
- [ ] I have added new tests (if applicable) — N/A

### Post-merge verification
- `deploy-infra` recreate step logs *"deleting so Bicep can recreate it on FC1"* (not "create fresh"), then Bicep succeeds with no `Conflict 59602`.
- `deploy-apps` and `deploy-event-grid` go green; `az functionapp show ... --query sku` → `FlexConsumption`; both functions index.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)