### PR TITLE
Fix Functions Flex plan detection + stale RBAC cleanup on recreate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -228,23 +228,47 @@ jobs:
           RG="rg-xenobiasoft-sudoku-prod-westus2"
           APP="${AZURE_FUNCTIONS_NAME}"
           FLEX_PLAN="XenobiasoftFunctionsPlan-prod"
+          COSMOS="cosmos-sudoku-prod"
 
-          # Detect via an RG-scoped list + client-side filter rather than
-          # `az functionapp show -n <app>`: the latter intermittently returned an
-          # empty appServicePlanId in CI, which silently routed an existing app
-          # down the "create fresh" path and let Bicep hit Conflict 59602 again.
-          # The list query returns an empty string (exit 0) when the app is
-          # absent, so `set -e` only trips on a genuine CLI/auth failure.
+          # Existence via an RG-scoped list + client-side filter (returns an
+          # empty string / exit 0 when absent, so `set -e` only trips on a real
+          # CLI/auth failure). The plan is then read from properties.serverFarmId
+          # via `az resource show`: `az functionapp [show|list] --query
+          # appServicePlanId` returns null for Flex Consumption apps (and was
+          # empty in CI for the B1 app too), which previously mis-routed an
+          # existing app down the delete-or-create-fresh paths.
           APP_ID=$(az functionapp list -g "$RG" --query "[?name=='$APP'].id | [0]" -o tsv)
-          PLAN_ID=$(az functionapp list -g "$RG" --query "[?name=='$APP'].appServicePlanId | [0]" -o tsv)
 
           if [ -z "$APP_ID" ]; then
             echo "No existing Functions app; Bicep will create it fresh on FC1."
-          elif [[ "$PLAN_ID" == */"$FLEX_PLAN" ]]; then
-            echo "App already on Flex plan ($FLEX_PLAN); no recreate needed."
           else
-            echo "Existing app is on a non-Flex plan ($PLAN_ID); deleting so Bicep can recreate it on FC1."
-            az functionapp delete --ids "$APP_ID"
+            PLAN_ID=$(az resource show --ids "$APP_ID" --query "properties.serverFarmId" -o tsv)
+            if [[ "$PLAN_ID" == */"$FLEX_PLAN" ]]; then
+              echo "App already on Flex plan ($FLEX_PLAN); no recreate needed."
+            else
+              echo "Existing app is on a non-Flex plan ($PLAN_ID); deleting so Bicep can recreate it on FC1."
+              # The recreated app gets a NEW system-assigned principal. Azure
+              # forbids updating an existing role assignment's principalId, so the
+              # assignments tied to the old principal must be removed first or
+              # Bicep fails with RoleAssignmentUpdateNotPermitted. Capture the old
+              # principal's assignment ids while it still resolves, then delete.
+              OLD_PRINCIPAL=$(az functionapp show --ids "$APP_ID" --query identity.principalId -o tsv 2>/dev/null || true)
+              STALE_RBAC=""
+              STALE_COSMOS=""
+              if [ -n "$OLD_PRINCIPAL" ] && [ "$OLD_PRINCIPAL" != "null" ]; then
+                STALE_RBAC=$(az role assignment list --all --assignee "$OLD_PRINCIPAL" --query "[].id" -o tsv 2>/dev/null || true)
+                STALE_COSMOS=$(az cosmosdb sql role assignment list --account-name "$COSMOS" -g "$RG" --query "[?principalId=='$OLD_PRINCIPAL'].id" -o tsv 2>/dev/null || true)
+              fi
+              az functionapp delete --ids "$APP_ID"
+              for id in $STALE_RBAC; do
+                echo "Removing stale Azure RBAC assignment $id"
+                az role assignment delete --ids "$id" 2>/dev/null || true
+              done
+              for raid in $STALE_COSMOS; do
+                echo "Removing stale Cosmos SQL role assignment $raid"
+                az cosmosdb sql role assignment delete --account-name "$COSMOS" -g "$RG" --role-assignment-id "$raid" --yes 2>/dev/null || true
+              done
+            fi
           fi
 
       - name: Deploy Bicep template


### PR DESCRIPTION
## Description

Follow-up to #313/#314. The second FC1 deploy made real progress — the recreate step deleted the B1 app and **Bicep successfully created the app fresh on the FC1 plan** (verified live: app is on `XenobiasoftFunctionsPlan-prod`, tier `FlexConsumption`). It then failed on **RBAC**:

- `RoleAssignmentUpdateNotPermitted` (Key Vault)
- `Updating SQL Role Assignment Principal ID is not permitted. Existing: [93408941…] Updated: [8d15ee12…]` (Cosmos)

The recreated app has a **new** system-assigned principal, but the role assignments have deterministic names, so Bicep tried to *update* their principalId — which Azure forbids.

Also discovered: `az functionapp [show|list] --query appServicePlanId` returns **null for Flex Consumption apps** (and was empty in CI for the B1 app), so the previous detection would have deleted the FC1 app on every run.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other (please describe): CI/CD deployment fix

## Changes Made

- **Detection** now reads the plan from `az resource show --ids <app> --query properties.serverFarmId` instead of `appServicePlanId`. Reliable for Flex; once on FC1 the recreate step is a true no-op.
- **Stale RBAC cleanup**: when the recreate step deletes a non-Flex app, it captures that principal's Azure RBAC + Cosmos SQL role-assignment ids *before* deletion (while the principal still resolves), then removes them after. Targeted at the old principal only — API/MCP assignments are untouched. This makes any future forced recreate self-healing.

## Testing

- [x] `az bicep build infra/main.bicep` compiles clean.
- [x] Verified live that `properties.serverFarmId` returns the FC1 plan id where `appServicePlanId` returns null.

> ⚠️ **One-time manual prerequisite before this deploy can go green:** the *current* orphaned assignments from the already-deleted principal `93408941…` must be removed once (the automated cleanup only fires on future deletes, and that principal is already gone). See the PR discussion / commands provided separately. After that, this deploy creates the Key Vault + Cosmos assignments fresh for the live principal.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)