### PR TITLE
Deploy Functions to Flex via config-zip (fix HTTP 415)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -363,15 +363,15 @@ jobs:
           set -euo pipefail
           cd "${{ github.workspace }}/publish-functions"
           zip -r ../functions.zip .
-          # Flex Consumption uses OneDeploy (the package is uploaded to the
-          # configured deployment blob container) — the legacy Kudu config-zip
-          # path does not apply. No Oryx build runs against this pre-built
-          # publish output.
-          az functionapp deploy \
+          # Flex Consumption deploys the package to its configured deployment
+          # blob container via `az functionapp deployment source config-zip`
+          # (the documented Flex method). `az functionapp deploy --type zip`
+          # targets the OneDeploy endpoint and returns HTTP 415 on Flex apps.
+          # No --build-remote: the .NET isolated publish output is pre-built.
+          az functionapp deployment source config-zip \
             --name "${{ env.AZURE_FUNCTIONS_NAME }}" \
             --resource-group "rg-xenobiasoft-sudoku-prod-westus2" \
-            --src-path "${{ github.workspace }}/functions.zip" \
-            --type zip
+            --src "${{ github.workspace }}/functions.zip"
 
   deploy-event-grid:
     needs: deploy-apps


### PR DESCRIPTION
## Description

Follow-up to #315. With the RBAC blockers cleared, `deploy-infra` now **succeeds** and the function app runs on the FC1 plan. API and MCP also deploy. The only remaining failure is the **Deploy Functions** step:

> `ERROR: An error occurred during deployment. Status Code: 415` (Unsupported Media Type)

`az functionapp deploy --type zip` targets the OneDeploy endpoint, which **Flex Consumption rejects with 415**. The documented Flex deployment method is `az functionapp deployment source config-zip`, which uploads the package to the app's configured deployment blob container.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other (please describe): CI/CD deployment fix

## Changes Made

- Switched the Deploy Functions step from `az functionapp deploy --src-path … --type zip` to `az functionapp deployment source config-zip --src …`.
- No `--build-remote` flag: the .NET 10 isolated publish output is already built (no Oryx/remote build needed).

## Testing

- [ ] Verified in CI on merge (the deploy steps only run on `main`).

### Post-merge verification
- `deploy-apps` → Deploy Functions succeeds (no 415).
- `deploy-event-grid` succeeds: `eventgrid_extension` system key appears and the webhook validates.
- `az functionapp function list -n XenobiasoftSudokuFunctions-prod -g rg-xenobiasoft-sudoku-prod-westus2 -o table` lists `PuzzlePoolSeedFunction` and `PuzzleReplenishFunction`.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)