### PR TITLE
Include hidden files in publish-functions artifact (.azurefunctions)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,6 +94,12 @@ jobs:
         with:
           name: publish-functions
           path: ${{ github.workspace }}/publish-functions
+          # The .NET isolated publish output includes a hidden `.azurefunctions`
+          # directory with the worker metadata. upload-artifact@v4 excludes
+          # hidden files by default, which drops it from the package and makes
+          # Flex Consumption reject the deploy ("Cannot find required
+          # .azurefunctions directory at root level in the .zip package").
+          include-hidden-files: true
 
   build-frontend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Follow-up to #316. With `config-zip` in place the HTTP 415 is gone, but Flex now rejects the package at content-validation:

> `InvalidPackageContentException: Cannot find required .azurefunctions directory at root level in the .zip package.`

**Root cause:** the .NET 10 isolated publish output includes a **hidden** `.azurefunctions` directory (worker metadata the host needs to launch the isolated worker). `actions/upload-artifact@v4` **excludes hidden files by default**, so `.azurefunctions` was stripped when the build job uploaded `publish-functions`; deploy-apps then zipped an incomplete package. Verified locally that `dotnet publish` (with or without `--no-build`) does produce `.azurefunctions` — so the loss was at the artifact boundary, not the build.

This very likely also contributed to the earlier **B1** symptom (host started, system key appeared, but no functions served / webhook 404): without `.azurefunctions`, the isolated worker has no function metadata to load.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other (please describe): CI/CD packaging fix

## Changes Made

- Added `include-hidden-files: true` to the **Upload publish-functions artifact** step so `.azurefunctions` survives the artifact round-trip and ends up in the deployed zip.

## Testing

- [x] Verified locally that the publish output contains `.azurefunctions` (so the only loss was the artifact's default hidden-file exclusion).
- [ ] Verified in CI on merge.

### Post-merge verification
- `deploy-apps` → Deploy Functions succeeds (no package-validation error).
- `deploy-event-grid` succeeds.
- `az functionapp function list -n XenobiasoftSudokuFunctions-prod -g rg-xenobiasoft-sudoku-prod-westus2 -o table` lists `PuzzlePoolSeedFunction` and `PuzzleReplenishFunction`.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)