### PR TITLE
Configure app blob storage for Functions (fix worker crash-loop)

### DIFF
--- a/infra/modules/functions.bicep
+++ b/infra/modules/functions.bicep
@@ -181,6 +181,15 @@ resource functionAppSettings 'Microsoft.Web/sites/config@2024-04-01' = {
     ConnectionStrings__AzureKeyVault: keyVaultUri
     CosmosDb__UseManagedIdentity: 'true'
     CosmosDb__AccountEndpoint: cosmosDbEndpoint
+
+    // Application blob storage (Sudoku.Infrastructure AddBlobStorageClient).
+    // Distinct from AzureWebJobsStorage (the Functions host runtime store):
+    // the app's own BlobServiceClient binds the "AzureStorage" options section
+    // and connects to the puzzle-pool container via the managed identity
+    // (Storage Blob Data Owner is granted below). Without these the worker
+    // throws "Blob storage is not configured" at startup and crash-loops.
+    AzureStorage__UseManagedIdentity: 'true'
+    AzureStorage__AccountName: storageAccount.name
   }
 }
 


### PR DESCRIPTION
## Description

Follow-up to #317. The packaging fix worked — the deploy is accepted and the package is valid — but `deploy-apps` still failed at the post-deploy health check (`Failed to fetch host key`), and only the platform `WarmUp` function indexed. App Insights revealed the real cause: the **.NET isolated worker is crash-looping** (`dotnet exited with code 134`, 90+ times), so our functions never load.

The worker's startup exception:

> `System.InvalidOperationException: Blob storage is not configured. Provide one of: … AzureStorage:UseManagedIdentity + AzureStorage:AccountName, …`
> `at Sudoku.Infrastructure…AddBlobStorageClient` → `at Program.<Main>$`

The Functions bicep set only `AzureWebJobsStorage__accountName` (the Functions **host** runtime store). The **application's** `BlobServiceClient` (`Sudoku.Infrastructure.AddBlobStorageClient`) binds the `AzureStorage` options section, which was never configured — so DI throws and the worker aborts before any function indexes. (The API app gets these from App Configuration/Key Vault; the Functions app doesn't load those sources.)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other (please describe): Infrastructure configuration fix

## Changes Made

- Added `AzureStorage__UseManagedIdentity: 'true'` and `AzureStorage__AccountName: <storage>` to the Function App settings, mirroring the existing `CosmosDb__*` managed-identity pattern. The app's identity already holds **Storage Blob Data Owner**, so the managed-identity blob client works without keys.

## Testing

- [x] `az bicep build infra/main.bicep` compiles clean.
- [x] Root cause confirmed from App Insights worker traces (exit 134 → "Blob storage is not configured").

### Post-merge verification
- Worker no longer crash-loops; `az functionapp function list` shows `PuzzlePoolSeedFunction` and `PuzzleReplenishFunction` (not just `WarmUp`).
- `deploy-apps` Deploy Functions health check passes; `deploy-event-grid` registers the subscription.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)