### PR TITLE
Move all RBAC role assignments out of Bicep into assign-roles.sh

### DIFF
--- a/.claude/rules/rbac-role-assignments.md
+++ b/.claude/rules/rbac-role-assignments.md
@@ -1,0 +1,45 @@
+---
+paths:
+  - "infra/**/*.bicep"
+  - "scripts/assign-roles.sh"
+  - ".github/workflows/**"
+---
+
+# RBAC & Role Assignment Guidelines
+
+## Rule: role assignments live in `scripts/assign-roles.sh`, never in deployment code
+
+All Azure RBAC role assignments — managed identity grants to Key Vault, App
+Configuration, Cosmos DB, Storage, etc. — belong in `scripts/assign-roles.sh`.
+Do **not** declare `Microsoft.Authorization/roleAssignments` resources in Bicep
+(`infra/**`) or grant roles from CI/CD workflow steps.
+
+### Why
+- **Recreate churn.** When a resource (storage account, identity, app) is torn
+  down and recreated, IaC role assignments referencing the old principal go
+  stale and must be cleaned up, then fail to re-grant cleanly — the root cause
+  of recurring `403 AuthorizationPermissionMismatch` failures and the
+  "clean up stale RBAC on recreate" work.
+- **Least privilege for deployments.** Keeping role assignments out of Bicep
+  means the deployment principal does not need `Owner` / `User Access
+  Administrator` on the resource group.
+- **One auditable place.** A single idempotent script is easy to review, re-run,
+  and reason about. It is safe to re-run — Azure skips assignments that already
+  exist.
+
+### What this means in practice
+- Need a new permission? Add an `assign_role` (or `assign_cosmos_role`) line to
+  `scripts/assign-roles.sh` and re-run it. Do not add it to a `.bicep` module.
+- Provisioning a new app/function that uses managed identity? Fetch its
+  principal in the script (`az webapp identity show` / `az functionapp identity
+  show`) and add its grants there.
+- Bicep should still **enable** the managed identity on a resource
+  (`identity: { type: 'SystemAssigned' }`) and output its `principalId` — it
+  just must not assign roles.
+
+### Migration note
+`infra/modules/functions.bicep` and `infra/modules/mcp.bicep` still contain
+`roleAssignments` resources. These should be removed and their grants moved into
+`scripts/assign-roles.sh`. (Watch for drift while migrating — e.g. the Key Vault
+Secrets User role ID in Bicep must match the canonical
+`4633458b-17de-408a-b874-0445c86b69e0` used in the script.)

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -156,7 +156,6 @@ module mcp 'modules/mcp.bicep' = {
     environment: environment
     appServicePlanName: appServicePlanName
     mcpAppName: mcpAppName
-    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
     logAnalyticsWorkspaceCustomerId: monitoring.outputs.logAnalyticsWorkspaceCustomerId
     appInsightsConnectionString: monitoring.outputs.appInsightsConnectionString
     keyVaultUri: keyvault.outputs.keyVaultUri
@@ -171,8 +170,6 @@ module functions 'modules/functions.bicep' = {
     functionPlanName: functionPlanName
     functionAppName: functionAppName
     storageAccountName: storage.outputs.storageAccountName
-    keyVaultName: keyVaultName
-    cosmosDbAccountName: cosmosDbAccountName
     appInsightsConnectionString: monitoring.outputs.appInsightsConnectionString
     keyVaultUri: keyvault.outputs.keyVaultUri
     cosmosDbEndpoint: storage.outputs.cosmosDbEndpoint

--- a/infra/modules/functions.bicep
+++ b/infra/modules/functions.bicep
@@ -43,12 +43,6 @@ param functionAppName string
 @description('Name of the existing storage account reused for the Functions runtime, deployment package and puzzle blobs.')
 param storageAccountName string
 
-@description('Name of the existing Key Vault (for the Key Vault Secrets User role assignment).')
-param keyVaultName string
-
-@description('Name of the existing Cosmos DB account (for the SQL data-plane role assignment).')
-param cosmosDbAccountName string
-
 param appInsightsConnectionString string
 param keyVaultUri string
 param cosmosDbEndpoint string
@@ -80,14 +74,6 @@ var deploymentContainerName = 'function-deployment'
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' existing = {
   name: storageAccountName
-}
-
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
-  name: keyVaultName
-}
-
-resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' existing = {
-  name: cosmosDbAccountName
 }
 
 resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-01-01' existing = {
@@ -199,53 +185,11 @@ resource functionAppSettings 'Microsoft.Web/sites/config@2024-04-01' = {
 // the Event Grid-triggered function.
 
 // ---------------------------------------------------------------------------
-// RBAC — grant the Function App's managed identity the data-plane access it
-// needs.
-//
-//   Storage Blob Data Owner        (b7e6dc6d-f1e8-4753-8033-0f276bb0955b)
-//     Host storage (AzureWebJobsStorage), the deployment container, and
-//     read/write of puzzle blobs in the sudoku-puzzles container. Owner (vs
-//     Contributor) is used because the Flex host and timer-singleton leases
-//     need full blob data-plane access.
-//   Key Vault Secrets User         (4633458b-17de-408a-b874-0445c86b69e6)
-//     Resolve Key Vault references / configuration secrets.
-//   Cosmos DB Built-in Data Contributor (00000000-...-000000000002)
-//     Cosmos data-plane access (SQL role assignment, not Azure RBAC).
+// RBAC NOTE: This Function App's managed identity needs Storage Blob Data Owner,
+// Key Vault Secrets User, and Cosmos DB data-plane access. Those grants are NOT
+// declared here — all role assignments live in scripts/assign-roles.sh (see
+// .claude/rules/rbac-role-assignments.md). Run that script after deploying.
 // ---------------------------------------------------------------------------
-
-var storageBlobDataOwnerRoleId = 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b'
-var keyVaultSecretsUserRoleId  = '4633458b-17de-408a-b874-0445c86b69e6'
-var cosmosDataContributorRoleId = '00000000-0000-0000-0000-000000000002'
-
-resource blobDataOwnerAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: storageAccount
-  name: guid(storageAccount.id, functionApp.id, storageBlobDataOwnerRoleId)
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataOwnerRoleId)
-    principalId: functionApp.identity.principalId
-    principalType: 'ServicePrincipal'
-  }
-}
-
-resource keyVaultSecretsUserAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: keyVault
-  name: guid(keyVault.id, functionApp.id, keyVaultSecretsUserRoleId)
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
-    principalId: functionApp.identity.principalId
-    principalType: 'ServicePrincipal'
-  }
-}
-
-resource cosmosDataContributorAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-05-15' = {
-  parent: cosmosDbAccount
-  name: guid(cosmosDbAccount.id, functionApp.id, cosmosDataContributorRoleId)
-  properties: {
-    roleDefinitionId: '${cosmosDbAccount.id}/sqlRoleDefinitions/${cosmosDataContributorRoleId}'
-    principalId: functionApp.identity.principalId
-    scope: cosmosDbAccount.id
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Outputs

--- a/infra/modules/mcp.bicep
+++ b/infra/modules/mcp.bicep
@@ -15,9 +15,6 @@ param environment string
 param appServicePlanName string
 param mcpAppName string
 
-@description('Log Analytics workspace ARM resource ID (for the role assignment scope).')
-param logAnalyticsWorkspaceId string
-
 @description('Log Analytics workspace GUID (customerId) — passed to the app as AppInsights__WorkspaceId.')
 param logAnalyticsWorkspaceCustomerId string
 
@@ -104,38 +101,11 @@ resource mcpAppSettings 'Microsoft.Web/sites/config@2023-12-01' = {
 }
 
 // ---------------------------------------------------------------------------
-// RBAC — grant Managed Identity read access to Log Analytics
-//
-// Log Analytics Reader  (73c42c96-874c-492b-b04d-ab87d138a893)
-//   Allows QueryWorkspace calls against the workspace.
-//
-// Monitoring Reader     (43d0d8ad-25c7-4714-9337-8ba259a9fe05)
-//   Allows reading metrics from the Application Insights resource.
+// RBAC NOTE: This app's managed identity needs Log Analytics Reader and
+// Monitoring Reader (RG scope) to query Application Insights. Those grants are
+// NOT declared here — all role assignments live in scripts/assign-roles.sh
+// (see .claude/rules/rbac-role-assignments.md). Run that script after deploying.
 // ---------------------------------------------------------------------------
-
-var logAnalyticsReaderRoleId = '73c42c96-874c-492b-b04d-ab87d138a893'
-var monitoringReaderRoleId   = '43d0d8ad-25c7-4714-9337-8ba259a9fe05'
-
-resource logAnalyticsReaderAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  // Scope to the workspace so the identity can only query this workspace
-  scope: resourceGroup()
-  name: guid(logAnalyticsWorkspaceId, mcpApp.id, logAnalyticsReaderRoleId)
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', logAnalyticsReaderRoleId)
-    principalId: mcpApp.identity.principalId
-    principalType: 'ServicePrincipal'
-  }
-}
-
-resource monitoringReaderAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  scope: resourceGroup()
-  name: guid(logAnalyticsWorkspaceId, mcpApp.id, monitoringReaderRoleId)
-  properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', monitoringReaderRoleId)
-    principalId: mcpApp.identity.principalId
-    principalType: 'ServicePrincipal'
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Outputs

--- a/scripts/assign-roles.sh
+++ b/scripts/assign-roles.sh
@@ -21,6 +21,8 @@ RESOURCE_GROUP="rg-xenobiasoft-sudoku-prod-westus2"
 DEVELOPER_OID="79d81279-ad74-4496-a1bc-32636c40c0e3"
 
 API_APP_NAME="XenobiasoftSudokuApi-prod"
+FUNCTIONS_APP_NAME="xenobiasoftsudokufunctions-prod"
+MCP_APP_NAME="xenobiasoftsudokumcp-prod"
 
 KEY_VAULT_NAME="kv-xenobiasoft-prod"
 COSMOS_ACCOUNT_NAME="cosmos-sudoku-prod"
@@ -32,6 +34,9 @@ KEY_VAULT_SECRETS_USER="4633458b-17de-408a-b874-0445c86b69e0"       # Read secre
 APP_CONFIG_DATA_READER="516239f1-63e1-4d78-a4de-a74fb236a071"       # Read App Configuration keys
 COSMOS_DATA_CONTRIBUTOR="00000000-0000-0000-0000-000000000002"      # Cosmos DB Built-in Data Contributor (SQL)
 STORAGE_BLOB_DATA_CONTRIBUTOR="ba92f5b4-2d11-453d-a403-e96b0029c9fe" # Read/write blob data
+STORAGE_BLOB_DATA_OWNER="b7e6dc6d-f1e8-4753-8033-0f276bb0955b"      # Full blob data-plane (Functions host: AzureWebJobsStorage + leases)
+LOG_ANALYTICS_READER="73c42c96-874c-492b-b04d-ab87d138a893"        # Query Log Analytics workspace
+MONITORING_READER="43d0d8ad-25c7-4714-9337-8ba259a9fe05"          # Read Application Insights metrics
 
 echo "Fetching managed identity principal IDs..."
 API_APP_PRINCIPAL=$(az webapp identity show \
@@ -39,13 +44,26 @@ API_APP_PRINCIPAL=$(az webapp identity show \
   --resource-group "$RESOURCE_GROUP" \
   --query principalId --output tsv)
 
-echo "  API app principal:    $API_APP_PRINCIPAL"
+FUNCTIONS_APP_PRINCIPAL=$(az functionapp identity show \
+  --name "$FUNCTIONS_APP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --query principalId --output tsv)
+
+MCP_APP_PRINCIPAL=$(az webapp identity show \
+  --name "$MCP_APP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --query principalId --output tsv)
+
+echo "  API app principal:        $API_APP_PRINCIPAL"
+echo "  Functions app principal:  $FUNCTIONS_APP_PRINCIPAL"
+echo "  MCP app principal:        $MCP_APP_PRINCIPAL"
 echo ""
 
 KEY_VAULT_ID="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.KeyVault/vaults/$KEY_VAULT_NAME"
 APP_CONFIG_ID="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.AppConfiguration/configurationStores/$APP_CONFIG_NAME"
 COSMOS_ID="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.DocumentDB/databaseAccounts/$COSMOS_ACCOUNT_NAME"
 STORAGE_ID="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Storage/storageAccounts/$STORAGE_ACCOUNT_NAME"
+RESOURCE_GROUP_ID="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP"
 
 assign_role() {
   local description=$1
@@ -80,31 +98,43 @@ assign_cosmos_role() {
 echo "---------------------------------------------------------------------"
 echo "Key Vault — Secrets User (read-only)"
 echo "---------------------------------------------------------------------"
-assign_role "Blazor   → Key Vault" "$WEB_APP_PRINCIPAL" "$KEY_VAULT_SECRETS_USER" "$KEY_VAULT_ID"
-assign_role "API      → Key Vault" "$API_APP_PRINCIPAL" "$KEY_VAULT_SECRETS_USER" "$KEY_VAULT_ID"
-assign_role "DevEng	  → Key Vault" "$DEVELOPER_OID" "$KEY_VAULT_SECRETS_USER" "$KEY_VAULT_ID"
+assign_role "API       → Key Vault" "$API_APP_PRINCIPAL"       "$KEY_VAULT_SECRETS_USER" "$KEY_VAULT_ID"
+assign_role "Functions → Key Vault" "$FUNCTIONS_APP_PRINCIPAL" "$KEY_VAULT_SECRETS_USER" "$KEY_VAULT_ID"
+assign_role "DevEng    → Key Vault" "$DEVELOPER_OID"           "$KEY_VAULT_SECRETS_USER" "$KEY_VAULT_ID"
 
 echo ""
 echo "---------------------------------------------------------------------"
 echo "App Configuration — Data Reader"
 echo "---------------------------------------------------------------------"
-assign_role "Blazor   → App Config" "$WEB_APP_PRINCIPAL" "$APP_CONFIG_DATA_READER" "$APP_CONFIG_ID"
-assign_role "API      → App Config" "$API_APP_PRINCIPAL" "$APP_CONFIG_DATA_READER" "$APP_CONFIG_ID"
-assign_role "DevEng   → App Config" "$DEVELOPER_OID" "$APP_CONFIG_DATA_READER" "$APP_CONFIG_ID"
+assign_role "API       → App Config" "$API_APP_PRINCIPAL"       "$APP_CONFIG_DATA_READER" "$APP_CONFIG_ID"
+assign_role "Functions → App Config" "$FUNCTIONS_APP_PRINCIPAL" "$APP_CONFIG_DATA_READER" "$APP_CONFIG_ID"
+assign_role "DevEng    → App Config" "$DEVELOPER_OID"           "$APP_CONFIG_DATA_READER" "$APP_CONFIG_ID"
 
 echo ""
 echo "---------------------------------------------------------------------"
-echo "Cosmos DB — Built-in Data Contributor (API only)"
+echo "Cosmos DB — Built-in Data Contributor"
 echo "---------------------------------------------------------------------"
-assign_cosmos_role "API     → Cosmos DB" "$API_APP_PRINCIPAL"
-assign_cosmos_role "DevEng 	→ Cosmos DB" "$DEVELOPER_OID"
+assign_cosmos_role "API       → Cosmos DB" "$API_APP_PRINCIPAL"
+assign_cosmos_role "Functions → Cosmos DB" "$FUNCTIONS_APP_PRINCIPAL"
+assign_cosmos_role "DevEng    → Cosmos DB" "$DEVELOPER_OID"
 
 echo ""
 echo "---------------------------------------------------------------------"
-echo "Storage — Blob Data Contributor (read/write game and puzzle blobs)"
+echo "Storage — Blob Data (read/write game and puzzle blobs)"
 echo "---------------------------------------------------------------------"
-assign_role "API      → Storage Blob Data Contributor" "$API_APP_PRINCIPAL" "$STORAGE_BLOB_DATA_CONTRIBUTOR" "$STORAGE_ID"
-assign_role "DevEng   → Storage Blob Data Contributor" "$DEVELOPER_OID"    "$STORAGE_BLOB_DATA_CONTRIBUTOR" "$STORAGE_ID"
+# API reads/writes puzzle + game blobs → Contributor is sufficient.
+# Functions host needs Owner: AzureWebJobsStorage, deployment container, and
+# timer-singleton leases require full blob data-plane access on the Flex host.
+assign_role "API       → Storage Blob Data Contributor" "$API_APP_PRINCIPAL"       "$STORAGE_BLOB_DATA_CONTRIBUTOR" "$STORAGE_ID"
+assign_role "Functions → Storage Blob Data Owner"       "$FUNCTIONS_APP_PRINCIPAL" "$STORAGE_BLOB_DATA_OWNER"       "$STORAGE_ID"
+assign_role "DevEng    → Storage Blob Data Contributor" "$DEVELOPER_OID"           "$STORAGE_BLOB_DATA_CONTRIBUTOR" "$STORAGE_ID"
+
+echo ""
+echo "---------------------------------------------------------------------"
+echo "Monitoring — MCP server reads Log Analytics / App Insights (RG scope)"
+echo "---------------------------------------------------------------------"
+assign_role "MCP       → Log Analytics Reader" "$MCP_APP_PRINCIPAL" "$LOG_ANALYTICS_READER" "$RESOURCE_GROUP_ID"
+assign_role "MCP       → Monitoring Reader"    "$MCP_APP_PRINCIPAL" "$MONITORING_READER"    "$RESOURCE_GROUP_ID"
 
 echo ""
 echo "Done! All role assignments are in place for '$RESOURCE_GROUP'."


### PR DESCRIPTION
## Description

The Functions and MCP Bicep modules declared `Microsoft.Authorization/roleAssignments` inline. On resource recreate these go stale and fail to re-grant cleanly, producing recurring `403 AuthorizationPermissionMismatch` failures — the API's `CreateGame` could not list puzzle-pool blobs (no puzzle returned to players), and the seed function lacked storage access (ran to its 30-min timeout having seeded almost nothing). Diagnosed via Application Insights.

This PR makes `scripts/assign-roles.sh` the single, idempotent source of truth for all RBAC, and removes role assignments from deployment code entirely.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring
- [x] Documentation update

## Changes Made

- **`scripts/assign-roles.sh`** — added the MCP app (Log Analytics Reader + Monitoring Reader, RG scope), the Functions → Cosmos data-plane grant, Functions → Key Vault + App Config grants, and Functions → Storage Blob Data **Owner** (Flex host needs full data-plane for `AzureWebJobsStorage` + timer-singleton leases; API stays Contributor). Removed dead `Blazor` lines that referenced an undefined principal.
- **`infra/modules/functions.bicep`** — removed all 3 `roleAssignments` plus the now-dead `keyVault`/`cosmosDbAccount` existing-resource refs and `keyVaultName`/`cosmosDbAccountName` params. This also drops an invalid Key Vault Secrets User role-id typo (`...69e6`).
- **`infra/modules/mcp.bicep`** — removed both `roleAssignments` and the dead `logAnalyticsWorkspaceId` param.
- **`infra/main.bicep`** — dropped the three params no longer passed to the modules.
- **`.claude/rules/rbac-role-assignments.md`** — new rule: role/permission assignments belong in `scripts/assign-roles.sh`, never in deployment code.

Bicep now only enables managed identities and outputs their `principalId`.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

`az bicep build --file infra/main.bicep` compiles clean (exit 0, no warnings). No application code changed. After merge, run `./scripts/assign-roles.sh` once to apply the grants, then confirm `POST .../games/{difficulty}` returns 200 and the seed function populates the pool.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation (if necessary)
