### PR TITLE
Add HTTP-triggered puzzle pool seed function for on-demand seeding

### DIFF
--- a/src/backend/Sudoku.Functions/Functions/PuzzlePoolSeedFunction.cs
+++ b/src/backend/Sudoku.Functions/Functions/PuzzlePoolSeedFunction.cs
@@ -1,43 +1,16 @@
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
-using Sudoku.Application.Interfaces;
-using Sudoku.Domain.ValueObjects;
+using Sudoku.Functions.Services;
 
 namespace Sudoku.Functions.Functions;
 
-public class PuzzlePoolSeedFunction(IPuzzlePoolService puzzlePoolService, ILogger<PuzzlePoolSeedFunction> logger)
+public class PuzzlePoolSeedFunction(IPuzzlePoolSeeder seeder, ILogger<PuzzlePoolSeedFunction> logger)
 {
-    private const int TargetPoolSize = 10;
-
-    private static readonly GameDifficulty[] Difficulties =
-    [
-        GameDifficulty.Easy,
-        GameDifficulty.Medium,
-        GameDifficulty.Hard,
-        GameDifficulty.Expert
-    ];
-
     [Function("PuzzlePoolSeedFunction")]
     public async Task Run([TimerTrigger("0 0 2 * * *")] TimerInfo myTimer)
     {
         logger.LogInformation("Puzzle pool seed function triggered at {Time}", DateTime.UtcNow);
 
-        foreach (var difficulty in Difficulties)
-        {
-            var currentCount = await puzzlePoolService.GetAvailableCountAsync(difficulty);
-            var needed = TargetPoolSize - currentCount;
-
-            if (needed > 0)
-            {
-                logger.LogInformation("Seeding {Count} puzzles for {Difficulty} (current: {Current})",
-                    needed, difficulty.Name, currentCount);
-                await puzzlePoolService.SeedAsync(difficulty, needed);
-            }
-            else
-            {
-                logger.LogInformation("Pool full for {Difficulty} ({Count}/{Target})",
-                    difficulty.Name, currentCount, TargetPoolSize);
-            }
-        }
+        await seeder.SeedPoolAsync();
     }
 }

--- a/src/backend/Sudoku.Functions/Functions/PuzzlePoolSeedHttpFunction.cs
+++ b/src/backend/Sudoku.Functions/Functions/PuzzlePoolSeedHttpFunction.cs
@@ -1,0 +1,32 @@
+using System.Net;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using Sudoku.Functions.Services;
+
+namespace Sudoku.Functions.Functions;
+
+/// <summary>
+/// HTTP-triggered counterpart of <see cref="PuzzlePoolSeedFunction"/>. Performs the
+/// same pool top-up as the nightly timer, but can be invoked on demand for testing.
+/// Secured at <see cref="AuthorizationLevel.Function"/> — callers must supply the function key.
+/// </summary>
+public class PuzzlePoolSeedHttpFunction(IPuzzlePoolSeeder seeder, ILogger<PuzzlePoolSeedHttpFunction> logger)
+{
+    [Function("PuzzlePoolSeedHttpFunction")]
+    public async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "seed-puzzle-pool")] HttpRequestData request)
+    {
+        logger.LogInformation("Puzzle pool seed (HTTP) triggered at {Time}", DateTime.UtcNow);
+
+        var seeded = await seeder.SeedPoolAsync();
+
+        logger.LogInformation("Puzzle pool seed (HTTP) completed, seeded {Count} puzzles", seeded);
+
+        var response = request.CreateResponse(HttpStatusCode.OK);
+        response.Headers.Add("Content-Type", "application/json; charset=utf-8");
+        await response.WriteStringAsync($"{{\"seeded\":{seeded}}}");
+
+        return response;
+    }
+}

--- a/src/backend/Sudoku.Functions/Program.cs
+++ b/src/backend/Sudoku.Functions/Program.cs
@@ -1,7 +1,10 @@
 using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Sudoku.Functions.Services;
 using Sudoku.Infrastructure.Configuration;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 builder.Services.AddInfrastructureServices(builder.Configuration);
+builder.Services.AddScoped<IPuzzlePoolSeeder, PuzzlePoolSeeder>();
 builder.Build().Run();

--- a/src/backend/Sudoku.Functions/Services/IPuzzlePoolSeeder.cs
+++ b/src/backend/Sudoku.Functions/Services/IPuzzlePoolSeeder.cs
@@ -1,0 +1,10 @@
+namespace Sudoku.Functions.Services;
+
+public interface IPuzzlePoolSeeder
+{
+    /// <summary>
+    /// Tops every difficulty's pool back up to the target size.
+    /// Returns the total number of puzzles seeded across all difficulties.
+    /// </summary>
+    Task<int> SeedPoolAsync();
+}

--- a/src/backend/Sudoku.Functions/Services/PuzzlePoolSeeder.cs
+++ b/src/backend/Sudoku.Functions/Services/PuzzlePoolSeeder.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Logging;
+using Sudoku.Application.Interfaces;
+using Sudoku.Domain.ValueObjects;
+
+namespace Sudoku.Functions.Services;
+
+public class PuzzlePoolSeeder(IPuzzlePoolService puzzlePoolService, ILogger<PuzzlePoolSeeder> logger) : IPuzzlePoolSeeder
+{
+    public const int TargetPoolSize = 10;
+
+    private static readonly GameDifficulty[] Difficulties =
+    [
+        GameDifficulty.Easy,
+        GameDifficulty.Medium,
+        GameDifficulty.Hard,
+        GameDifficulty.Expert
+    ];
+
+    public async Task<int> SeedPoolAsync()
+    {
+        var totalSeeded = 0;
+
+        foreach (var difficulty in Difficulties)
+        {
+            var currentCount = await puzzlePoolService.GetAvailableCountAsync(difficulty);
+            var needed = TargetPoolSize - currentCount;
+
+            if (needed > 0)
+            {
+                logger.LogInformation("Seeding {Count} puzzles for {Difficulty} (current: {Current})",
+                    needed, difficulty.Name, currentCount);
+                await puzzlePoolService.SeedAsync(difficulty, needed);
+                totalSeeded += needed;
+            }
+            else
+            {
+                logger.LogInformation("Pool full for {Difficulty} ({Count}/{Target})",
+                    difficulty.Name, currentCount, TargetPoolSize);
+            }
+        }
+
+        return totalSeeded;
+    }
+}

--- a/src/backend/Sudoku.Functions/Sudoku.Functions.csproj
+++ b/src/backend/Sudoku.Functions/Sudoku.Functions.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventGrid" Version="3.4.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5">

--- a/src/backend/Tests/Functions/PuzzlePoolSeedFunctionTests.cs
+++ b/src/backend/Tests/Functions/PuzzlePoolSeedFunctionTests.cs
@@ -1,104 +1,43 @@
-using DepenMock.Attributes;
 using DepenMock.Moq;
 using Microsoft.Azure.Functions.Worker;
-using Sudoku.Application.Interfaces;
-using Sudoku.Domain.ValueObjects;
 using Sudoku.Functions.Functions;
+using Sudoku.Functions.Services;
 
 namespace UnitTests.Functions;
 
-[LogOutput(LogOutputTiming.Always)]
 public class PuzzlePoolSeedFunctionTests : MoqBaseTestByType<PuzzlePoolSeedFunction>
 {
-    private readonly Mock<IPuzzlePoolService> _mockPuzzlePoolService;
-    private const int TargetPoolSize = 10;
+    private readonly Mock<IPuzzlePoolSeeder> _mockSeeder;
 
     public PuzzlePoolSeedFunctionTests()
     {
-        _mockPuzzlePoolService = Container.ResolveMock<IPuzzlePoolService>().AsMoq();
+        _mockSeeder = Container.ResolveMock<IPuzzlePoolSeeder>().AsMoq();
     }
 
     [Fact]
-    public async Task Run_WhenPoolBelowTarget_SeedsMissingPuzzlesForEachDifficulty()
+    public async Task Run_InvokesSeederOnce()
     {
         // Arrange
-        var currentCount = 7;
-        var expectedSeedCount = TargetPoolSize - currentCount;
-
-        _mockPuzzlePoolService.SetupGetAvailableCountReturns(currentCount);
-
         var sut = ResolveSut();
 
         // Act
         await sut.Run(CreateTimerInfo());
 
         // Assert
-        _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Easy, expectedSeedCount);
-        _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Medium, expectedSeedCount);
-        _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Hard, expectedSeedCount);
-        _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Expert, expectedSeedCount);
+        _mockSeeder.VerifySeedPoolCalledOnce();
     }
 
     [Fact]
-    public async Task Run_WhenPoolAtTarget_DoesNotSeedAnyPuzzles()
+    public async Task Run_LogsTriggerInformation()
     {
         // Arrange
-        _mockPuzzlePoolService.SetupGetAvailableCountReturns(TargetPoolSize);
-
         var sut = ResolveSut();
 
         // Act
         await sut.Run(CreateTimerInfo());
 
         // Assert
-        _mockPuzzlePoolService.VerifySeedNeverCalled();
-    }
-
-    [Fact]
-    public async Task Run_ChecksEachDifficultyExactlyOnce()
-    {
-        // Arrange
-        _mockPuzzlePoolService.SetupGetAvailableCountReturns(TargetPoolSize);
-
-        var sut = ResolveSut();
-
-        // Act
-        await sut.Run(CreateTimerInfo());
-
-        // Assert
-        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(GameDifficulty.Easy);
-        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(GameDifficulty.Medium);
-        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(GameDifficulty.Hard);
-        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(GameDifficulty.Expert);
-    }
-
-    [Theory]
-    [InlineData(0, 10)]
-    [InlineData(5, 5)]
-    [InlineData(9, 1)]
-    [InlineData(10, 0)]
-    public async Task Run_SeedsExactlyTheNumberNeededToReachTarget(int currentCount, int expectedSeedCount)
-    {
-        // Arrange
-        _mockPuzzlePoolService.SetupGetAvailableCountReturns(currentCount);
-
-        var sut = ResolveSut();
-
-        // Act
-        await sut.Run(CreateTimerInfo());
-
-        // Assert
-        if (expectedSeedCount > 0)
-        {
-            _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Easy, expectedSeedCount);
-            _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Medium, expectedSeedCount);
-            _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Hard, expectedSeedCount);
-            _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Expert, expectedSeedCount);
-        }
-        else
-        {
-            _mockPuzzlePoolService.VerifySeedNeverCalled();
-        }
+        Logger.InformationLogs().ContainsMessage("Puzzle pool seed function triggered");
     }
 
     private static TimerInfo CreateTimerInfo() => new();

--- a/src/backend/Tests/Functions/PuzzlePoolSeedHttpFunctionTests.cs
+++ b/src/backend/Tests/Functions/PuzzlePoolSeedHttpFunctionTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using DepenMock.Moq;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Sudoku.Functions.Functions;
+using Sudoku.Functions.Services;
+
+namespace UnitTests.Functions;
+
+public class PuzzlePoolSeedHttpFunctionTests : MoqBaseTestByType<PuzzlePoolSeedHttpFunction>
+{
+    private readonly Mock<IPuzzlePoolSeeder> _mockSeeder;
+
+    public PuzzlePoolSeedHttpFunctionTests()
+    {
+        _mockSeeder = Container.ResolveMock<IPuzzlePoolSeeder>().AsMoq();
+    }
+
+    [Fact]
+    public async Task Run_InvokesSeederOnce()
+    {
+        // Arrange
+        var sut = ResolveSut();
+
+        // Act
+        await sut.Run(CreateHttpRequest());
+
+        // Assert
+        _mockSeeder.VerifySeedPoolCalledOnce();
+    }
+
+    [Fact]
+    public async Task Run_ReturnsOkStatus()
+    {
+        // Arrange
+        var sut = ResolveSut();
+
+        // Act
+        var response = await sut.Run(CreateHttpRequest());
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Run_WritesSeededCountToBody()
+    {
+        // Arrange
+        _mockSeeder.SetupSeedPoolReturns(5);
+        var sut = ResolveSut();
+
+        // Act
+        var response = await sut.Run(CreateHttpRequest());
+
+        // Assert
+        ReadBody(response).Should().Contain("\"seeded\":5");
+    }
+
+    private static HttpRequestData CreateHttpRequest()
+    {
+        var context = new Mock<FunctionContext>().Object;
+        var request = new Mock<HttpRequestData>(context);
+        var response = new Mock<HttpResponseData>(context);
+
+        response.SetupProperty(r => r.StatusCode);
+        response.Setup(r => r.Headers).Returns(new HttpHeadersCollection());
+        response.Setup(r => r.Body).Returns(new MemoryStream());
+        request.Setup(r => r.CreateResponse()).Returns(response.Object);
+
+        return request.Object;
+    }
+
+    private static string ReadBody(HttpResponseData response)
+    {
+        response.Body.Position = 0;
+        using var reader = new StreamReader(response.Body);
+        return reader.ReadToEnd();
+    }
+}

--- a/src/backend/Tests/Functions/PuzzlePoolSeederTests.cs
+++ b/src/backend/Tests/Functions/PuzzlePoolSeederTests.cs
@@ -1,0 +1,116 @@
+using DepenMock.Moq;
+using Sudoku.Application.Interfaces;
+using Sudoku.Domain.ValueObjects;
+using Sudoku.Functions.Services;
+
+namespace UnitTests.Functions;
+
+public class PuzzlePoolSeederTests : MoqBaseTestByAbstraction<PuzzlePoolSeeder, IPuzzlePoolSeeder>
+{
+    private readonly Mock<IPuzzlePoolService> _mockPuzzlePoolService;
+    private const int TargetPoolSize = PuzzlePoolSeeder.TargetPoolSize;
+
+    public PuzzlePoolSeederTests()
+    {
+        _mockPuzzlePoolService = Container.ResolveMock<IPuzzlePoolService>().AsMoq();
+    }
+
+    [Fact]
+    public async Task SeedPoolAsync_WhenPoolBelowTarget_SeedsMissingPuzzlesForEachDifficulty()
+    {
+        // Arrange
+        var currentCount = 7;
+        var expectedSeedCount = TargetPoolSize - currentCount;
+        _mockPuzzlePoolService.SetupGetAvailableCountReturns(currentCount);
+
+        var sut = ResolveSut();
+
+        // Act
+        await sut.SeedPoolAsync();
+
+        // Assert
+        _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Easy, expectedSeedCount);
+        _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Medium, expectedSeedCount);
+        _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Hard, expectedSeedCount);
+        _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Expert, expectedSeedCount);
+    }
+
+    [Fact]
+    public async Task SeedPoolAsync_WhenPoolAtTarget_DoesNotSeedAnyPuzzles()
+    {
+        // Arrange
+        _mockPuzzlePoolService.SetupGetAvailableCountReturns(TargetPoolSize);
+
+        var sut = ResolveSut();
+
+        // Act
+        await sut.SeedPoolAsync();
+
+        // Assert
+        _mockPuzzlePoolService.VerifySeedNeverCalled();
+    }
+
+    [Fact]
+    public async Task SeedPoolAsync_ChecksEachDifficultyExactlyOnce()
+    {
+        // Arrange
+        _mockPuzzlePoolService.SetupGetAvailableCountReturns(TargetPoolSize);
+
+        var sut = ResolveSut();
+
+        // Act
+        await sut.SeedPoolAsync();
+
+        // Assert
+        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(GameDifficulty.Easy);
+        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(GameDifficulty.Medium);
+        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(GameDifficulty.Hard);
+        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(GameDifficulty.Expert);
+    }
+
+    [Theory]
+    [InlineData(0, 10)]
+    [InlineData(5, 5)]
+    [InlineData(9, 1)]
+    [InlineData(10, 0)]
+    public async Task SeedPoolAsync_SeedsExactlyTheNumberNeededToReachTarget(int currentCount, int expectedSeedCount)
+    {
+        // Arrange
+        _mockPuzzlePoolService.SetupGetAvailableCountReturns(currentCount);
+
+        var sut = ResolveSut();
+
+        // Act
+        await sut.SeedPoolAsync();
+
+        // Assert
+        if (expectedSeedCount > 0)
+        {
+            _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Easy, expectedSeedCount);
+            _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Medium, expectedSeedCount);
+            _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Hard, expectedSeedCount);
+            _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Expert, expectedSeedCount);
+        }
+        else
+        {
+            _mockPuzzlePoolService.VerifySeedNeverCalled();
+        }
+    }
+
+    [Fact]
+    public async Task SeedPoolAsync_ReturnsTotalSeededAcrossAllDifficulties()
+    {
+        // Arrange
+        var currentCount = 7;
+        var expectedTotal = (TargetPoolSize - currentCount) * 4; // four difficulties
+        _mockPuzzlePoolService.SetupGetAvailableCountReturns(currentCount);
+
+        var sut = ResolveSut();
+
+        // Act
+        var totalSeeded = await sut.SeedPoolAsync();
+
+        // Assert
+        totalSeeded.Should().Be(expectedTotal);
+    }
+}

--- a/src/backend/Tests/Mocks/MockPuzzlePoolSeederExtensions.cs
+++ b/src/backend/Tests/Mocks/MockPuzzlePoolSeederExtensions.cs
@@ -1,0 +1,19 @@
+using Sudoku.Functions.Services;
+
+namespace UnitTests.Mocks;
+
+public static class MockPuzzlePoolSeederExtensions
+{
+    extension(Mock<IPuzzlePoolSeeder> mock)
+    {
+        public void SetupSeedPoolReturns(int seeded)
+        {
+            mock.Setup(x => x.SeedPoolAsync()).ReturnsAsync(seeded);
+        }
+
+        public void VerifySeedPoolCalledOnce()
+        {
+            mock.Verify(x => x.SeedPoolAsync(), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
## Description

The puzzle pool could only be seeded by the nightly `PuzzlePoolSeedFunction` timer (`0 0 2 * * *`), which made it hard to seed/verify on demand. This adds an HTTP-triggered function that performs the **same** pool top-up so it can be kicked off whenever needed (e.g. after a deploy, or while debugging the recent pool/RBAC issues).

To avoid duplicating the top-up logic, the shared loop is extracted into `IPuzzlePoolSeeder` / `PuzzlePoolSeeder`; both the timer and the HTTP trigger delegate to it.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring

## Changes Made

- **`IPuzzlePoolSeeder` / `PuzzlePoolSeeder`** (new) — the shared "top every difficulty back up to `TargetPoolSize`" loop, returning the total number of puzzles seeded.
- **`PuzzlePoolSeedFunction`** (timer) — now delegates to the seeder; behavior unchanged.
- **`PuzzlePoolSeedHttpFunction`** (new) — `POST /api/seed-puzzle-pool`, `AuthorizationLevel.Function` (requires the function key), returns `{"seeded":N}`.
- **DI / packaging** — registered `IPuzzlePoolSeeder` (scoped, matching `IPuzzlePoolService`) and added `Microsoft.Azure.Functions.Worker.Extensions.Http` 3.3.0.
- **Tests** — moved the pool top-up behavior tests onto `PuzzlePoolSeederTests`; the timer-function test now asserts delegation; added `PuzzlePoolSeedHttpFunctionTests` (status code + response body). Added a `MockPuzzlePoolSeederExtensions` DSL helper.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests

`dotnet test` → **626/626 passing** (21 in the Functions namespace).

## How to invoke once deployed

```
POST https://xenobiasoftsudokufunctions-prod.azurewebsites.net/api/seed-puzzle-pool?code=<function-key>
```

Returns `200 { "seeded": <count> }`.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation (if necessary)
