### PR TITLE
Automate role assignments as final deploy-infra step

### DIFF
--- a/.claude/rules/rbac-role-assignments.md
+++ b/.claude/rules/rbac-role-assignments.md
@@ -7,39 +7,48 @@ paths:
 
 # RBAC & Role Assignment Guidelines
 
-## Rule: role assignments live in `scripts/assign-roles.sh`, never in deployment code
+## Rule: role assignments live in `scripts/assign-roles.sh`, not in Bicep
 
-All Azure RBAC role assignments — managed identity grants to Key Vault, App
-Configuration, Cosmos DB, Storage, etc. — belong in `scripts/assign-roles.sh`.
-Do **not** declare `Microsoft.Authorization/roleAssignments` resources in Bicep
-(`infra/**`) or grant roles from CI/CD workflow steps.
+`scripts/assign-roles.sh` is the **single source of truth** for all Azure RBAC
+and Cosmos data-plane role assignments. Do **not** declare
+`Microsoft.Authorization/roleAssignments` (or `sqlRoleAssignments`) resources in
+Bicep (`infra/**`).
 
-### Why
-- **Recreate churn.** When a resource (storage account, identity, app) is torn
-  down and recreated, IaC role assignments referencing the old principal go
-  stale and must be cleaned up, then fail to re-grant cleanly — the root cause
-  of recurring `403 AuthorizationPermissionMismatch` failures and the
-  "clean up stale RBAC on recreate" work.
-- **Least privilege for deployments.** Keeping role assignments out of Bicep
-  means the deployment principal does not need `Owner` / `User Access
-  Administrator` on the resource group.
-- **One auditable place.** A single idempotent script is easy to review, re-run,
-  and reason about. It is safe to re-run — Azure skips assignments that already
-  exist.
+The script is **executed automatically** as the last step of the `deploy-infra`
+job in `.github/workflows/main.yml`, after Bicep has (re)created the managed
+identities. It can also be run manually. It is idempotent and exits non-zero on
+a genuine failure, so the deploy fails loudly if an assignment doesn't apply.
+
+### Why keep assignments out of Bicep (but still automated)
+- **Recreate churn.** When a resource (e.g. the Functions app) is deleted and
+  recreated, it gets a new managed-identity principal. Bicep `roleAssignments`
+  tied to the old principal go stale and fail with
+  `RoleAssignmentUpdateNotPermitted`. The script re-fetches principals at run
+  time, so it always assigns to the current identity. (The workflow's recreate
+  step cleans up the old principal's assignments before Bicep runs.)
+- **One auditable place.** A single idempotent script is easy to review and
+  re-run, and keeps every grant — across Key Vault, App Config, Storage, Cosmos
+  and monitoring — in one file.
 
 ### What this means in practice
-- Need a new permission? Add an `assign_role` (or `assign_cosmos_role`) line to
-  `scripts/assign-roles.sh` and re-run it. Do not add it to a `.bicep` module.
+- Need a new permission? Add an `assign_role` / `assign_cosmos_role` line to
+  `scripts/assign-roles.sh`. Do not add a `.bicep` `roleAssignments` resource.
 - Provisioning a new app/function that uses managed identity? Fetch its
   principal in the script (`az webapp identity show` / `az functionapp identity
   show`) and add its grants there.
-- Bicep should still **enable** the managed identity on a resource
+- Bicep should still **enable** the managed identity
   (`identity: { type: 'SystemAssigned' }`) and output its `principalId` — it
   just must not assign roles.
 
-### Migration note
-`infra/modules/functions.bicep` and `infra/modules/mcp.bicep` still contain
-`roleAssignments` resources. These should be removed and their grants moved into
-`scripts/assign-roles.sh`. (Watch for drift while migrating — e.g. the Key Vault
-Secrets User role ID in Bicep must match the canonical
-`4633458b-17de-408a-b874-0445c86b69e0` used in the script.)
+### Implementation notes
+- Assignments are created with `az rest` (direct ARM PUT), **not**
+  `az role assignment create`: the latter fails with `MissingSubscription` for
+  guest/B2B accounts (a known az CLI defect). `az rest` works for both guest
+  users (local runs) and the CI service principal.
+- The deploy service principal therefore needs permission to create role
+  assignments (Owner or User Access Administrator on the RG) — it already has
+  this, since the workflow's stale-RBAC cleanup deletes assignments too.
+- Built-in role definition IDs must match what Azure actually publishes. Verify
+  with `az role definition list --name "<Role Name>" --query "[0].name"`. Note
+  the Key Vault Secrets User ID is `4633458b-17de-408a-b874-0445c86b69e6`
+  (ends `e6`).

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -286,7 +286,16 @@ jobs:
           parameters: ./infra/params/prod.bicepparam
           scope: resourcegroup
           failOnStdErr: false
-          
+
+      # Role assignments are not declared in Bicep (they go stale on resource
+      # recreate). They live in scripts/assign-roles.sh — the single source of
+      # truth — and are applied here, after Bicep has (re)created the managed
+      # identities. The script is idempotent and exits non-zero on real failure.
+      # See .claude/rules/rbac-role-assignments.md.
+      - name: Assign managed identity roles
+        shell: bash
+        run: bash scripts/assign-roles.sh
+
       - name: DNS check (scm endpoint)
         shell: bash
         run: |

--- a/scripts/assign-roles.sh
+++ b/scripts/assign-roles.sh
@@ -2,10 +2,19 @@
 # =============================================================================
 # Azure RBAC Role Assignments – Sudoku Production
 # =============================================================================
-# Run this script once per environment to grant the app service managed
-# identities the permissions they need. It is safe to re-run — assignments that
-# already exist are detected and skipped. Genuine failures are printed and the
-# script exits non-zero.
+# Grants the app service / function managed identities the permissions they
+# need. This is the single source of truth for role assignments (they are NOT
+# declared in Bicep — see .claude/rules/rbac-role-assignments.md).
+#
+# It runs automatically as the last step of the `deploy-infra` job in
+# .github/workflows/main.yml, and can also be run manually. It is safe to
+# re-run — assignments that already exist are detected and skipped, and genuine
+# failures are printed and cause a non-zero exit.
+#
+# Assignments are created via `az rest` (a direct ARM call) rather than
+# `az role assignment create` on purpose: the latter fails with
+# `MissingSubscription` for guest/B2B accounts (a known az CLI defect), whereas
+# `az rest` works for both guest users and the CI service principal.
 #
 # Usage:
 #   chmod +x assign-roles.sh
@@ -14,6 +23,7 @@
 # Prerequisites:
 #   - Azure CLI installed and logged in (az login)
 #   - Owner or User Access Administrator role on the resource group
+#   - A GUID generator: uuidgen, /proc/sys/kernel/random/uuid, or python
 # =============================================================================
 
 # -u: fail on unset variables (catches typos / missing principals).
@@ -41,7 +51,7 @@ APP_CONFIG_NAME="appcs-xenobiasoft-prod"
 STORAGE_ACCOUNT_NAME="stxenobiasoftprod"
 
 # Built-in role definition IDs
-KEY_VAULT_SECRETS_USER="4633458b-17de-408a-b874-0445c86b69e0"       # Read secret values only
+KEY_VAULT_SECRETS_USER="4633458b-17de-408a-b874-0445c86b69e6"       # Read secret values only
 APP_CONFIG_DATA_READER="516239f1-63e1-4d78-a4de-a74fb236a071"       # Read App Configuration keys
 COSMOS_DATA_CONTRIBUTOR="00000000-0000-0000-0000-000000000002"      # Cosmos DB Built-in Data Contributor (SQL)
 STORAGE_BLOB_DATA_CONTRIBUTOR="ba92f5b4-2d11-453d-a403-e96b0029c9fe" # Read/write blob data
@@ -76,6 +86,30 @@ COSMOS_ID="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/provid
 STORAGE_ID="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP/providers/Microsoft.Storage/storageAccounts/$STORAGE_ACCOUNT_NAME"
 RESOURCE_GROUP_ID="/subscriptions/$SUBSCRIPTION_ID/resourceGroups/$RESOURCE_GROUP"
 
+ARM="https://management.azure.com"
+RBAC_API_VERSION="2022-04-01"
+COSMOS_API_VERSION="2024-05-15"
+
+# Generate a lowercase GUID for the role assignment name. Avoids python on
+# purpose: on Windows `python`/`python3` is often a Microsoft Store stub that
+# prints "Python was not found" and exits 0, which would poison the name. The
+# /dev/urandom fallback works in Git Bash and on CI runners with no extra tools.
+new_guid() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+  elif [[ -r /proc/sys/kernel/random/uuid ]]; then
+    cat /proc/sys/kernel/random/uuid
+  else
+    local hex
+    hex=$(head -c16 /dev/urandom | od -An -tx1 | tr -d ' \n')
+    printf '%s-%s-%s-%s-%s\n' "${hex:0:8}" "${hex:8:4}" "${hex:12:4}" "${hex:16:4}" "${hex:20:12}"
+  fi
+}
+
+# Azure RBAC assignment via a direct ARM PUT. ARM enforces uniqueness of
+# (principal, role, scope) regardless of the assignment name, so a fresh random
+# name re-creates idempotently — an existing assignment returns
+# RoleAssignmentExists, which we treat as a skip.
 assign_role() {
   local description=$1
   local assignee=$2
@@ -87,14 +121,21 @@ assign_role() {
     FAILED=1
     return
   fi
-  local output
-  if output=$(az role assignment create \
-    --assignee "$assignee" \
-    --role "$role" \
-    --scope "$scope" \
-    --output none 2>&1); then
+
+  # The developer is a User; the apps are managed identities (ServicePrincipal).
+  # Stating the type lets ARM skip the directory lookup, which also avoids
+  # replication-delay failures right after an identity is (re)created.
+  local principal_type="ServicePrincipal"
+  [[ "$assignee" == "$DEVELOPER_OID" ]] && principal_type="User"
+
+  local guid output
+  guid=$(new_guid) || { FAILED=1; return; }
+  local url="${ARM}${scope}/providers/Microsoft.Authorization/roleAssignments/${guid}?api-version=${RBAC_API_VERSION}"
+  local body="{\"properties\":{\"roleDefinitionId\":\"/subscriptions/${SUBSCRIPTION_ID}/providers/Microsoft.Authorization/roleDefinitions/${role}\",\"principalId\":\"${assignee}\",\"principalType\":\"${principal_type}\"}}"
+
+  if output=$(az rest --method put --url "$url" --body "$body" --output none 2>&1); then
     echo "  OK"
-  elif grep -qiE 'already exists|RoleAssignmentExists' <<<"$output"; then
+  elif grep -qiE 'RoleAssignmentExists' <<<"$output"; then
     echo "  Already exists — skipped"
   else
     echo "  FAILED:"
@@ -103,6 +144,9 @@ assign_role() {
   fi
 }
 
+# Cosmos DB data-plane (SQL) role assignment via ARM PUT. These are NOT Azure
+# RBAC and ARM does NOT enforce (principal, role, scope) uniqueness, so a blind
+# re-create would accumulate duplicates. Check for an existing assignment first.
 assign_cosmos_role() {
   local description=$1
   local assignee=$2
@@ -112,17 +156,24 @@ assign_cosmos_role() {
     FAILED=1
     return
   fi
-  local output
-  if output=$(az cosmosdb sql role assignment create \
-    --account-name "$COSMOS_ACCOUNT_NAME" \
-    --resource-group "$RESOURCE_GROUP" \
-    --role-definition-id "$COSMOS_DATA_CONTRIBUTOR" \
-    --principal-id "$assignee" \
-    --scope "/" \
-    --output none 2>&1); then
-    echo "  OK"
-  elif grep -qiE 'already exists|exists' <<<"$output"; then
+
+  local existing
+  existing=$(az rest --method get \
+    --url "${ARM}${COSMOS_ID}/sqlRoleAssignments?api-version=${COSMOS_API_VERSION}" \
+    --query "length(value[?properties.principalId=='${assignee}' && contains(properties.roleDefinitionId, '${COSMOS_DATA_CONTRIBUTOR}')])" \
+    -o tsv 2>/dev/null || echo 0)
+  if [[ "${existing:-0}" != "0" ]]; then
     echo "  Already exists — skipped"
+    return
+  fi
+
+  local guid output
+  guid=$(new_guid) || { FAILED=1; return; }
+  local url="${ARM}${COSMOS_ID}/sqlRoleAssignments/${guid}?api-version=${COSMOS_API_VERSION}"
+  local body="{\"properties\":{\"roleDefinitionId\":\"${COSMOS_ID}/sqlRoleDefinitions/${COSMOS_DATA_CONTRIBUTOR}\",\"principalId\":\"${assignee}\",\"scope\":\"${COSMOS_ID}\"}}"
+
+  if output=$(az rest --method put --url "$url" --body "$body" --output none 2>&1); then
+    echo "  OK"
   else
     echo "  FAILED:"
     sed 's/^/    /' <<<"$output"


### PR DESCRIPTION
## Description

You wanted role assignments created automatically at deploy time. This wires `scripts/assign-roles.sh` into the pipeline as the **last step of `deploy-infra`** (after Bicep creates/recreates the managed identities), and fixes two bugs that were making the script fail when run by hand.

### Root causes found while running it live against prod
1. **`az role assignment create` fails with `MissingSubscription` for guest/B2B accounts** (a known az CLI defect). The signed-in dev account is a guest (`...#EXT#@...onmicrosoft.com`), so *every* assignment failed. Switched to `az rest` (direct ARM PUT), which works for both guest users **and** the CI service principal — one code path everywhere.
2. **Wrong Key Vault Secrets User role id** — script had `...69e0`; the real id (per `az role definition list`) is `...69e6`. (I had this backwards in #319 — apologies; corrected here.)

All assignments are already applied in prod (I created them via `az rest` while diagnosing), so create-game and seeding are unblocked; this PR makes it repeatable and hands-off.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring
- [x] Documentation update

## Changes Made

- **`scripts/assign-roles.sh`**: create assignments via `az rest`; Azure RBAC treats `RoleAssignmentExists` as a skip, Cosmos data-plane checks for an existing assignment first (ARM doesn't dedupe those); portable GUID generation (`uuidgen` → `/proc` → `/dev/urandom`, no python); fixed Key Vault role id `...e0` → `...e6`. Still idempotent and exits non-zero on real failure.
- **`.github/workflows/main.yml`**: new `Assign managed identity roles` step in `deploy-infra`, right after the Bicep deploy. The deploy SP already has role-assignment permission (it runs the stale-RBAC cleanup), so no new secret/permission is needed.
- **`.claude/rules/rbac-role-assignments.md`**: updated — the script remains the single source of truth (still not Bicep `roleAssignments`), but is now executed automatically by the pipeline.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass

- Ran the rewritten script end-to-end against prod as the guest account: **exit 0**, every assignment reported `Already exists — skipped` (idempotent).
- Workflow YAML validated (parses; new step ordered correctly after the Bicep deploy).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation (if necessary)
