### PR TITLE
Bump Aspire to 13.4.6, js-yaml to 4.2.0, and patch @babel/core

### DIFF
--- a/src/backend/Sudoku.Api/Sudoku.Api.csproj
+++ b/src/backend/Sudoku.Api/Sudoku.Api.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Azure.Security.KeyVault" Version="13.4.4" />
+    <PackageReference Include="Aspire.Azure.Security.KeyVault" Version="13.4.6" />
     <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.4.3" />
     <PackageReference Include="MediatR" Version="14.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />

--- a/src/backend/Sudoku.AppHost/Sudoku.AppHost.csproj
+++ b/src/backend/Sudoku.AppHost/Sudoku.AppHost.csproj
@@ -12,12 +12,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.4" />
-    <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" Version="13.4.4" />
-    <PackageReference Include="Aspire.Hosting.Azure.Functions" Version="13.4.4" />
-    <PackageReference Include="Aspire.Hosting.Azure.KeyVault" Version="13.4.4" />
-    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.4.4" />
-    <PackageReference Include="Aspire.Hosting.Azure.AppConfiguration" Version="13.4.4" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Azure.Functions" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Azure.KeyVault" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" Version="13.4.6" />
+    <PackageReference Include="Aspire.Hosting.Azure.AppConfiguration" Version="13.4.6" />
     <PackageReference Include="Aspire.Hosting.NodeJs" Version="9.5.2" />
   </ItemGroup>
 

--- a/src/frontend/Sudoku.React/package-lock.json
+++ b/src/frontend/Sudoku.React/package-lock.json
@@ -133,21 +133,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -442,14 +442,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -6533,10 +6533,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
## Description

Consolidates the six open Dependabot PRs (#331–#336) into a single change, plus an additional transitive security fix surfaced by `npm audit`. The four AppHost PRs (#333–#336) all edit the same `Sudoku.AppHost.csproj` ItemGroup and therefore conflict with one another, so they are merged together here. Dependabot will auto-close #331–#336 once these versions land on `main`.

## Type of Change

- [x] Other (please describe): Dependency and security updates

## Changes Made

- Bumped all `Aspire.Hosting.*` packages in `Sudoku.AppHost` from `13.4.4` → `13.4.6` (AppHost, Azure.CosmosDB, Azure.Functions, Azure.KeyVault, Azure.Storage, Azure.AppConfiguration) — supersedes #333, #334, #335, #336
- Bumped `Aspire.Azure.Security.KeyVault` in `Sudoku.Api` from `13.4.4` → `13.4.6` — supersedes #332
- Bumped `js-yaml` `4.1.1` → `4.2.0` (transitive security update) — supersedes #331
- Patched `@babel/core` `7.29.0` → `7.29.7` via `npm audit fix`, resolving GHSA-4x5r-pxfx-6jf8 (Arbitrary File Read via sourceMappingURL)

`npm audit` now reports **0 vulnerabilities**.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

Verified locally:
- `dotnet build` — 0 errors
- `dotnet test` — 626 passed
- `npm ci` — clean lockfile resolution
- `npm run test` — 151 passed
- `npm run build` — succeeds
- `npm audit` — 0 vulnerabilities

## Screenshots (if applicable)

N/A — dependency-only change.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)
