### PR TITLE
Fast bitmask solver + unique-solution generator with A/B benchmarks

### DIFF
--- a/Sudoku.sln
+++ b/Sudoku.sln
@@ -57,6 +57,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "params", "params", "{0B6998
 		infra\params\staging.bicepparam = infra\params\staging.bicepparam
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "backend", "backend", "{FE360695-3F2B-1049-3887-35FBB5135923}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sudoku.Benchmarks", "src\backend\Sudoku.Benchmarks\Sudoku.Benchmarks.csproj", "{3C73669A-2EED-471C-ACF3-E66F1A95A6FC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -175,6 +181,18 @@ Global
 		{D3B1C2A4-F5E6-7890-BCDE-F01234567891}.Release|x64.Build.0 = Release|Any CPU
 		{D3B1C2A4-F5E6-7890-BCDE-F01234567891}.Release|x86.ActiveCfg = Release|Any CPU
 		{D3B1C2A4-F5E6-7890-BCDE-F01234567891}.Release|x86.Build.0 = Release|Any CPU
+		{3C73669A-2EED-471C-ACF3-E66F1A95A6FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C73669A-2EED-471C-ACF3-E66F1A95A6FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C73669A-2EED-471C-ACF3-E66F1A95A6FC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3C73669A-2EED-471C-ACF3-E66F1A95A6FC}.Debug|x64.Build.0 = Debug|Any CPU
+		{3C73669A-2EED-471C-ACF3-E66F1A95A6FC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3C73669A-2EED-471C-ACF3-E66F1A95A6FC}.Debug|x86.Build.0 = Debug|Any CPU
+		{3C73669A-2EED-471C-ACF3-E66F1A95A6FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C73669A-2EED-471C-ACF3-E66F1A95A6FC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C73669A-2EED-471C-ACF3-E66F1A95A6FC}.Release|x64.ActiveCfg = Release|Any CPU
+		{3C73669A-2EED-471C-ACF3-E66F1A95A6FC}.Release|x64.Build.0 = Release|Any CPU
+		{3C73669A-2EED-471C-ACF3-E66F1A95A6FC}.Release|x86.ActiveCfg = Release|Any CPU
+		{3C73669A-2EED-471C-ACF3-E66F1A95A6FC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -182,6 +200,8 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{F2DFCC82-9530-4EB9-9237-377038CC4FCA} = {9A29756C-E327-47DF-B5A2-BF6956C21A74}
 		{0B69982A-788E-4277-A168-A9EA56E58EA9} = {9A29756C-E327-47DF-B5A2-BF6956C21A74}
+		{FE360695-3F2B-1049-3887-35FBB5135923} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{3C73669A-2EED-471C-ACF3-E66F1A95A6FC} = {FE360695-3F2B-1049-3887-35FBB5135923}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B3A3B7C7-B547-499D-8BB0-DFBB021089C3}

--- a/src/backend/Sudoku.Benchmarks/AlgorithmFactory.cs
+++ b/src/backend/Sudoku.Benchmarks/AlgorithmFactory.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Sudoku.Application.Interfaces;
+using Sudoku.Infrastructure.Repositories;
+using Sudoku.Infrastructure.Services;
+using Sudoku.Infrastructure.Services.Strategies;
+
+namespace Sudoku.Benchmarks;
+
+/// <summary>
+/// Constructs the old and new algorithm implementations without the full Azure DI graph.
+/// The legacy solver's collaborators (strategy pipeline, in-memory repository, logger) are
+/// wired up directly, exactly as the production container would.
+/// </summary>
+public static class AlgorithmFactory
+{
+    public static IPuzzleSolver CreateOldSolver()
+    {
+        var strategies = typeof(SolverStrategy).Assembly
+            .GetTypes()
+            .Where(t => t.IsSubclassOf(typeof(SolverStrategy)) && !t.IsAbstract)
+            .Select(t => (SolverStrategy)Activator.CreateInstance(t)!)
+            .ToList();
+
+        return new StrategyBasedPuzzleSolver(
+            strategies,
+            new InMemoryPuzzleRepository(),
+            NullLogger<StrategyBasedPuzzleSolver>.Instance);
+    }
+
+    public static IPuzzleSolver CreateNewSolver() => new BitwiseBacktrackingPuzzleSolver();
+
+    public static IPuzzleGenerator CreateOldGenerator() => new PuzzleGenerator(CreateOldSolver());
+
+    public static IPuzzleGenerator CreateNewGenerator() => new UniqueSolutionPuzzleGenerator();
+}

--- a/src/backend/Sudoku.Benchmarks/GeneratorBenchmarks.cs
+++ b/src/backend/Sudoku.Benchmarks/GeneratorBenchmarks.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+using Sudoku.Application.Interfaces;
+using Sudoku.Domain.Entities;
+using Sudoku.Domain.ValueObjects;
+
+namespace Sudoku.Benchmarks;
+
+/// <summary>
+/// Head-to-head generation speed/allocations: legacy <c>PuzzleGenerator</c> (baseline) vs
+/// the uniqueness-guaranteeing <c>UniqueSolutionPuzzleGenerator</c>, across all difficulties.
+/// </summary>
+[MemoryDiagnoser]
+public class GeneratorBenchmarks
+{
+    private IPuzzleGenerator _oldGenerator = null!;
+    private IPuzzleGenerator _newGenerator = null!;
+
+    [Params("Easy", "Medium", "Hard", "Expert")]
+    public string Difficulty { get; set; } = "Easy";
+
+    private GameDifficulty SelectedDifficulty => GameDifficulty.FromName(Difficulty);
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _oldGenerator = AlgorithmFactory.CreateOldGenerator();
+        _newGenerator = AlgorithmFactory.CreateNewGenerator();
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task<SudokuPuzzle> OldGenerator() => _oldGenerator.GeneratePuzzleAsync(SelectedDifficulty);
+
+    [Benchmark]
+    public Task<SudokuPuzzle> NewGenerator() => _newGenerator.GeneratePuzzleAsync(SelectedDifficulty);
+}

--- a/src/backend/Sudoku.Benchmarks/Program.cs
+++ b/src/backend/Sudoku.Benchmarks/Program.cs
@@ -1,0 +1,22 @@
+using System.Reflection;
+using BenchmarkDotNet.Running;
+using Sudoku.Benchmarks;
+
+// `--validate` runs the correctness/quality report (unique-solution rate, clue distribution).
+// Anything else is forwarded to BenchmarkDotNet's switcher, e.g.:
+//   dotnet run -c Release -- --filter *GeneratorBenchmarks*
+//   dotnet run -c Release -- --filter *SolverBenchmarks*
+if (args.Contains("--validate"))
+{
+    var samples = 30;
+    var index = Array.IndexOf(args, "--samples");
+    if (index >= 0 && index + 1 < args.Length && int.TryParse(args[index + 1], out var parsed))
+    {
+        samples = parsed;
+    }
+
+    QualityReport.Run(samples);
+    return;
+}
+
+BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);

--- a/src/backend/Sudoku.Benchmarks/PuzzleParser.cs
+++ b/src/backend/Sudoku.Benchmarks/PuzzleParser.cs
@@ -1,0 +1,33 @@
+using Sudoku.Domain.Entities;
+using Sudoku.Domain.ValueObjects;
+
+namespace Sudoku.Benchmarks;
+
+/// <summary>
+/// Parses an 81-character board string into a <see cref="SudokuPuzzle"/> of fixed clues.
+/// Digits 1-9 are clues; '0' or '.' are blanks.
+/// </summary>
+public static class PuzzleParser
+{
+    public static SudokuPuzzle Parse(string board, GameDifficulty difficulty)
+    {
+        if (board.Length != 81)
+        {
+            throw new ArgumentException($"Board must be 81 characters, got {board.Length}.", nameof(board));
+        }
+
+        var cells = new List<Cell>(81);
+
+        for (var i = 0; i < 81; i++)
+        {
+            int row = i / 9, column = i % 9;
+            var ch = board[i];
+
+            cells.Add(ch is >= '1' and <= '9'
+                ? Cell.CreateFixed(row, column, ch - '0')
+                : Cell.CreateEmpty(row, column));
+        }
+
+        return SudokuPuzzle.Create(GameId.New(), difficulty, cells);
+    }
+}

--- a/src/backend/Sudoku.Benchmarks/QualityReport.cs
+++ b/src/backend/Sudoku.Benchmarks/QualityReport.cs
@@ -1,0 +1,61 @@
+using Sudoku.Application.Interfaces;
+using Sudoku.Domain.Entities;
+using Sudoku.Domain.ValueObjects;
+using Sudoku.Infrastructure.Services.Solvers;
+
+namespace Sudoku.Benchmarks;
+
+/// <summary>
+/// "Other stuff" beyond raw timing: generates many puzzles with each algorithm and reports
+/// the metrics that prove correctness rather than speed — most importantly the
+/// <b>unique-solution rate</b>, plus the clue-count distribution.
+/// </summary>
+public static class QualityReport
+{
+    public static void Run(int samplesPerDifficulty)
+    {
+        var oldGenerator = AlgorithmFactory.CreateOldGenerator();
+        var newGenerator = AlgorithmFactory.CreateNewGenerator();
+        var difficulties = new[] { GameDifficulty.Easy, GameDifficulty.Medium, GameDifficulty.Hard, GameDifficulty.Expert };
+
+        Console.WriteLine();
+        Console.WriteLine($"Quality comparison ({samplesPerDifficulty} puzzles per difficulty)");
+        Console.WriteLine(new string('-', 86));
+        Console.WriteLine($"{"Generator",-32} {"Difficulty",-10} {"Unique%",8} {"AvgClues",9} {"MinClues",9} {"MaxClues",9}");
+        Console.WriteLine(new string('-', 86));
+
+        foreach (var difficulty in difficulties)
+        {
+            ReportRow("Legacy PuzzleGenerator", oldGenerator, difficulty, samplesPerDifficulty);
+            ReportRow("UniqueSolutionPuzzleGenerator", newGenerator, difficulty, samplesPerDifficulty);
+        }
+
+        Console.WriteLine(new string('-', 86));
+        Console.WriteLine("Unique% = share of generated puzzles with exactly one solution (the correctness win).");
+    }
+
+    private static void ReportRow(string name, IPuzzleGenerator generator, GameDifficulty difficulty, int samples)
+    {
+        var uniqueCount = 0;
+        var clueCounts = new List<int>(samples);
+
+        for (var i = 0; i < samples; i++)
+        {
+            var puzzle = generator.GeneratePuzzleAsync(difficulty).GetAwaiter().GetResult();
+            var grid = BitwiseSolverGridMapper.ToGrid(puzzle);
+
+            if (BitwiseSolverEngine.CountSolutions(grid, cap: 2) == 1)
+            {
+                uniqueCount++;
+            }
+
+            clueCounts.Add(CountClues(puzzle));
+        }
+
+        var uniquePct = 100.0 * uniqueCount / samples;
+        Console.WriteLine(
+            $"{name,-32} {difficulty.Name,-10} {uniquePct,7:0.0}% {clueCounts.Average(),9:0.0} {clueCounts.Min(),9} {clueCounts.Max(),9}");
+    }
+
+    private static int CountClues(SudokuPuzzle puzzle) => puzzle.Cells.Count(c => c.HasValue);
+}

--- a/src/backend/Sudoku.Benchmarks/README.md
+++ b/src/backend/Sudoku.Benchmarks/README.md
@@ -1,0 +1,97 @@
+# Sudoku.Benchmarks
+
+A/B harness for comparing the **legacy** Sudoku algorithms against the **new** fast
+implementations — both for raw speed (via [BenchmarkDotNet](https://benchmarkdotnet.org/))
+and for correctness quality (a unique-solution validation report).
+
+| Concern | Legacy (baseline) | New |
+| --- | --- | --- |
+| Solve | `StrategyBasedPuzzleSolver` | `BitwiseBacktrackingPuzzleSolver` |
+| Generate | `PuzzleGenerator` | `UniqueSolutionPuzzleGenerator` |
+
+The new solver is a bitmask + MRV backtracking engine (`BitwiseSolverEngine`); the new
+generator uses that engine to **guarantee every puzzle has exactly one solution** — something
+the legacy generator never verifies.
+
+## Prerequisites
+
+- .NET 10 SDK
+- Run in **Release** — BenchmarkDotNet refuses to measure a Debug build.
+
+## Speed benchmarks (BenchmarkDotNet)
+
+Run from the repo root. Pass a filter so you don't run every benchmark at once:
+
+```bash
+# Generator: legacy vs new, across Easy/Medium/Hard/Expert
+dotnet run -c Release --project src/backend/Sudoku.Benchmarks -- --filter *GeneratorBenchmarks*
+
+# Solver: legacy vs new, over fixed seed puzzles (Easy, Medium)
+dotnet run -c Release --project src/backend/Sudoku.Benchmarks -- --filter *SolverBenchmarks*
+
+# Everything
+dotnet run -c Release --project src/backend/Sudoku.Benchmarks -- --filter *
+```
+
+Useful flags (forwarded straight to BenchmarkDotNet):
+
+- `--job short` — fewer warmup/iteration cycles for a quick (noisier) read.
+- `--list flat` — list available benchmarks without running them.
+
+Each run prints a summary table (Mean, Error, StdDev, allocations) with the legacy method
+marked as the baseline and a `Ratio` column showing the new method's relative speed. Full
+reports are written to `BenchmarkDotNet.Artifacts/`.
+
+### What's measured
+
+- **`GeneratorBenchmarks`** — `[Params]` over the four difficulties; `OldGenerator` (baseline)
+  vs `NewGenerator`. `[MemoryDiagnoser]` reports allocations.
+- **`SolverBenchmarks`** — `[ParamsSource]` over the head-to-head seed puzzles in
+  `SeedPuzzles.HeadToHead`; `OldSolver` (baseline) vs `NewSolver`. A fresh puzzle is parsed per
+  invocation (the legacy solver mutates its input), so the parse cost is shared and fair.
+
+## Quality / correctness report (`--validate`)
+
+Raw timing can't show the new generator's real win — **guaranteed uniqueness**. The validate
+mode generates many puzzles with each generator and reports the unique-solution rate plus the
+clue-count distribution:
+
+```bash
+# Default: 30 puzzles per difficulty per generator
+dotnet run -c Release --project src/backend/Sudoku.Benchmarks -- --validate
+
+# Custom sample size
+dotnet run -c Release --project src/backend/Sudoku.Benchmarks -- --validate --samples 50
+```
+
+Example shape of the output:
+
+```
+Generator                        Difficulty    Unique%  AvgClues  MinClues  MaxClues
+--------------------------------------------------------------------------------------
+Legacy PuzzleGenerator           Easy            ...%      ...       ...       ...
+UniqueSolutionPuzzleGenerator    Easy          100.0%      ...       ...       ...
+...
+```
+
+`Unique%` is the share of generated puzzles with exactly one solution (verified with
+`BitwiseSolverEngine.CountSolutions`). The new generator should report **100%**.
+
+> Tip: don't run `--validate` and the speed benchmarks at the same time — CPU contention
+> makes the BenchmarkDotNet numbers unreliable.
+
+## Adding a new algorithm to the comparison
+
+1. Implement `IPuzzleSolver` / `IPuzzleGenerator` (or a new engine) in `Sudoku.Infrastructure`.
+2. Add a factory method in `AlgorithmFactory`.
+3. Add a `[Benchmark]` method to the relevant benchmark class (keep the legacy one as
+   `Baseline = true`), and/or a row in `QualityReport`.
+
+## Files
+
+- `Program.cs` — entry point; routes `--validate` to the quality report, everything else to
+  BenchmarkDotNet's `BenchmarkSwitcher`.
+- `AlgorithmFactory.cs` — constructs legacy and new implementations without the Azure DI graph.
+- `GeneratorBenchmarks.cs` / `SolverBenchmarks.cs` — the head-to-head speed benchmarks.
+- `QualityReport.cs` — the `--validate` correctness report.
+- `SeedPuzzles.cs` / `PuzzleParser.cs` — fixed input puzzles and an 81-char board parser.

--- a/src/backend/Sudoku.Benchmarks/SeedPuzzles.cs
+++ b/src/backend/Sudoku.Benchmarks/SeedPuzzles.cs
@@ -1,0 +1,27 @@
+namespace Sudoku.Benchmarks;
+
+/// <summary>
+/// Fixed, well-known unique puzzles so old and new solvers run against identical input.
+/// '0' denotes a blank cell.
+/// </summary>
+public static class SeedPuzzles
+{
+    // Canonical Wikipedia example puzzle.
+    public const string Easy =
+        "530070000600195000098000060800060003400803001700020006060000280000419005000080079";
+
+    // A unique medium-difficulty puzzle requiring some guessing.
+    public const string Medium =
+        "000260701680070090190004500820100040004602900050003028009300074040050036703018000";
+
+    // Arto Inkala's "world's hardest" puzzle — unique, brutal for naive strategies.
+    public const string Hardest =
+        "800000000003600000070090200050007000000045700000100030001000068008500010090000400";
+
+    /// <summary>Puzzles used for the old-vs-new head-to-head (both solvers handle these).</summary>
+    public static readonly IReadOnlyDictionary<string, string> HeadToHead = new Dictionary<string, string>
+    {
+        ["Easy"] = Easy,
+        ["Medium"] = Medium,
+    };
+}

--- a/src/backend/Sudoku.Benchmarks/SolverBenchmarks.cs
+++ b/src/backend/Sudoku.Benchmarks/SolverBenchmarks.cs
@@ -1,0 +1,41 @@
+using BenchmarkDotNet.Attributes;
+using Sudoku.Application.Interfaces;
+using Sudoku.Domain.Entities;
+using Sudoku.Domain.ValueObjects;
+
+namespace Sudoku.Benchmarks;
+
+/// <summary>
+/// Head-to-head solve speed/allocations: legacy <c>StrategyBasedPuzzleSolver</c> (baseline)
+/// vs the <c>BitwiseBacktrackingPuzzleSolver</c>, over identical seed puzzles. Each benchmark
+/// parses a fresh puzzle per invocation (the legacy solver mutates its input), so the parse
+/// cost is shared and the comparison stays fair.
+/// </summary>
+[MemoryDiagnoser]
+public class SolverBenchmarks
+{
+    private IPuzzleSolver _oldSolver = null!;
+    private IPuzzleSolver _newSolver = null!;
+    private string _board = SeedPuzzles.Easy;
+
+    [ParamsSource(nameof(PuzzleNames))]
+    public string Puzzle { get; set; } = "Easy";
+
+    public IEnumerable<string> PuzzleNames => SeedPuzzles.HeadToHead.Keys;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _oldSolver = AlgorithmFactory.CreateOldSolver();
+        _newSolver = AlgorithmFactory.CreateNewSolver();
+        _board = SeedPuzzles.HeadToHead[Puzzle];
+    }
+
+    [Benchmark(Baseline = true)]
+    public Task<SudokuPuzzle> OldSolver() =>
+        _oldSolver.SolvePuzzle(PuzzleParser.Parse(_board, GameDifficulty.Hard));
+
+    [Benchmark]
+    public Task<SudokuPuzzle> NewSolver() =>
+        _newSolver.SolvePuzzle(PuzzleParser.Parse(_board, GameDifficulty.Hard));
+}

--- a/src/backend/Sudoku.Benchmarks/Sudoku.Benchmarks.csproj
+++ b/src/backend/Sudoku.Benchmarks/Sudoku.Benchmarks.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <RootNamespace>$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Sudoku.Domain\Sudoku.Domain.csproj" />
+    <ProjectReference Include="..\Sudoku.Application\Sudoku.Application.csproj" />
+    <ProjectReference Include="..\Sudoku.Infrastructure\Sudoku.Infrastructure.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
+
+</Project>

--- a/src/backend/Sudoku.Infrastructure/Services/BitwiseBacktrackingPuzzleSolver.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/BitwiseBacktrackingPuzzleSolver.cs
@@ -1,0 +1,22 @@
+using Sudoku.Application.Interfaces;
+using Sudoku.Domain.Entities;
+using Sudoku.Infrastructure.Services.Solvers;
+
+namespace Sudoku.Infrastructure.Services;
+
+/// <summary>
+/// An <see cref="IPuzzleSolver"/> backed by the fast <see cref="BitwiseSolverEngine"/>.
+/// Drop-in alternative to <see cref="StrategyBasedPuzzleSolver"/> with no repository,
+/// async round-trips, or random guessing in the solve path.
+/// </summary>
+public class BitwiseBacktrackingPuzzleSolver : IPuzzleSolver
+{
+    public Task<SudokuPuzzle> SolvePuzzle(SudokuPuzzle puzzle)
+    {
+        var grid = BitwiseSolverGridMapper.ToGrid(puzzle);
+
+        BitwiseSolverEngine.Solve(grid);
+
+        return Task.FromResult(BitwiseSolverGridMapper.ApplyTo(puzzle, grid));
+    }
+}

--- a/src/backend/Sudoku.Infrastructure/Services/Solvers/BitwiseSolverEngine.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/Solvers/BitwiseSolverEngine.cs
@@ -1,0 +1,202 @@
+using System.Numerics;
+
+namespace Sudoku.Infrastructure.Services.Solvers;
+
+/// <summary>
+/// A fast, allocation-light Sudoku engine operating on a flat <c>int[81]</c> grid
+/// (0 = empty, 1-9 = value). Uses per row/column/box candidate bitmasks (bits 1-9)
+/// with minimum-remaining-values (MRV) cell selection and backtracking.
+///
+/// This is intentionally free of domain types, DI, async, and randomness so it can be
+/// reused as both a solver and a uniqueness checker, and is trivially benchmarkable.
+/// </summary>
+public static class BitwiseSolverEngine
+{
+    // Bits 1..9 set (bit 0 is unused so a value maps directly to its bit index).
+    private const int FullMask = 0b11_1111_1110;
+
+    /// <summary>
+    /// Solves the grid in place, returning <c>true</c> if a solution was found.
+    /// Returns the first solution discovered (MRV order). If the grid is already
+    /// inconsistent (contains a duplicate), returns <c>false</c> and leaves it untouched.
+    /// </summary>
+    public static bool Solve(int[] grid)
+    {
+        var rows = new int[9];
+        var cols = new int[9];
+        var boxes = new int[9];
+
+        return BuildMasks(grid, rows, cols, boxes) && SolveRecursive(grid, rows, cols, boxes);
+    }
+
+    /// <summary>
+    /// Counts the number of distinct solutions, stopping as soon as <paramref name="cap"/>
+    /// is reached. Uniqueness checks only need to distinguish "exactly one" from "more than
+    /// one", so the default cap of 2 keeps the search cheap. The input grid is not mutated.
+    /// </summary>
+    public static int CountSolutions(int[] grid, int cap = 2)
+    {
+        var working = (int[])grid.Clone();
+        var rows = new int[9];
+        var cols = new int[9];
+        var boxes = new int[9];
+
+        if (!BuildMasks(working, rows, cols, boxes))
+        {
+            return 0;
+        }
+
+        var count = 0;
+        CountRecursive(working, rows, cols, boxes, cap, ref count);
+
+        return count;
+    }
+
+    private static bool BuildMasks(int[] grid, int[] rows, int[] cols, int[] boxes)
+    {
+        for (var i = 0; i < 81; i++)
+        {
+            var value = grid[i];
+            if (value == 0)
+            {
+                continue;
+            }
+
+            var bit = 1 << value;
+            int r = i / 9, c = i % 9, b = (r / 3) * 3 + c / 3;
+
+            // A bit already set in any unit means a duplicate -> inconsistent grid.
+            if (((rows[r] | cols[c] | boxes[b]) & bit) != 0)
+            {
+                return false;
+            }
+
+            rows[r] |= bit;
+            cols[c] |= bit;
+            boxes[b] |= bit;
+        }
+
+        return true;
+    }
+
+    private static bool SolveRecursive(int[] grid, int[] rows, int[] cols, int[] boxes)
+    {
+        var (index, candidates) = SelectMostConstrainedCell(grid, rows, cols, boxes);
+
+        if (index == -1)
+        {
+            return true; // No empty cells remain -> solved.
+        }
+
+        if (candidates == 0)
+        {
+            return false; // A cell has no candidates -> dead end.
+        }
+
+        int r = index / 9, c = index % 9, b = (r / 3) * 3 + c / 3;
+
+        while (candidates != 0)
+        {
+            var bit = candidates & -candidates; // lowest set bit
+            candidates &= candidates - 1;
+            var value = BitOperations.TrailingZeroCount(bit);
+
+            grid[index] = value;
+            rows[r] |= bit;
+            cols[c] |= bit;
+            boxes[b] |= bit;
+
+            if (SolveRecursive(grid, rows, cols, boxes))
+            {
+                return true;
+            }
+
+            grid[index] = 0;
+            rows[r] &= ~bit;
+            cols[c] &= ~bit;
+            boxes[b] &= ~bit;
+        }
+
+        return false;
+    }
+
+    private static void CountRecursive(int[] grid, int[] rows, int[] cols, int[] boxes, int cap, ref int count)
+    {
+        if (count >= cap)
+        {
+            return;
+        }
+
+        var (index, candidates) = SelectMostConstrainedCell(grid, rows, cols, boxes);
+
+        if (index == -1)
+        {
+            count++;
+            return;
+        }
+
+        if (candidates == 0)
+        {
+            return; // dead end
+        }
+
+        int r = index / 9, c = index % 9, b = (r / 3) * 3 + c / 3;
+
+        while (candidates != 0 && count < cap)
+        {
+            var bit = candidates & -candidates;
+            candidates &= candidates - 1;
+            var value = BitOperations.TrailingZeroCount(bit);
+
+            grid[index] = value;
+            rows[r] |= bit;
+            cols[c] |= bit;
+            boxes[b] |= bit;
+
+            CountRecursive(grid, rows, cols, boxes, cap, ref count);
+
+            grid[index] = 0;
+            rows[r] &= ~bit;
+            cols[c] &= ~bit;
+            boxes[b] &= ~bit;
+        }
+    }
+
+    /// <summary>
+    /// Finds the empty cell with the fewest candidates (MRV). Returns its index and the
+    /// candidate bitmask, or (-1, 0) when the grid is full. A returned mask of 0 signals a
+    /// dead end (an empty cell with no legal value).
+    /// </summary>
+    private static (int Index, int Candidates) SelectMostConstrainedCell(int[] grid, int[] rows, int[] cols, int[] boxes)
+    {
+        var bestIndex = -1;
+        var bestCandidates = 0;
+        var bestCount = int.MaxValue;
+
+        for (var i = 0; i < 81; i++)
+        {
+            if (grid[i] != 0)
+            {
+                continue;
+            }
+
+            int r = i / 9, c = i % 9, b = (r / 3) * 3 + c / 3;
+            var candidates = FullMask & ~(rows[r] | cols[c] | boxes[b]);
+            var count = BitOperations.PopCount((uint)candidates);
+
+            if (count < bestCount)
+            {
+                bestCount = count;
+                bestIndex = i;
+                bestCandidates = candidates;
+
+                if (count <= 1)
+                {
+                    break; // Can't do better than 0 or 1 candidate.
+                }
+            }
+        }
+
+        return (bestIndex, bestCandidates);
+    }
+}

--- a/src/backend/Sudoku.Infrastructure/Services/Solvers/BitwiseSolverGridMapper.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/Solvers/BitwiseSolverGridMapper.cs
@@ -1,0 +1,38 @@
+using Sudoku.Domain.Entities;
+using Sudoku.Domain.ValueObjects;
+
+namespace Sudoku.Infrastructure.Services.Solvers;
+
+/// <summary>
+/// Converts between the domain <see cref="SudokuPuzzle"/> and the flat <c>int[81]</c> grid
+/// used by <see cref="BitwiseSolverEngine"/> (row-major, 0 = empty, 1-9 = value).
+/// </summary>
+public static class BitwiseSolverGridMapper
+{
+    public static int[] ToGrid(SudokuPuzzle puzzle)
+    {
+        var grid = new int[81];
+
+        foreach (var cell in puzzle.Cells)
+        {
+            grid[cell.Row * 9 + cell.Column] = cell.Value ?? 0;
+        }
+
+        return grid;
+    }
+
+    /// <summary>
+    /// Projects a solved/partial grid back onto a new puzzle, preserving each cell's
+    /// fixed status and difficulty. Empty grid positions (0) become empty cells.
+    /// </summary>
+    public static SudokuPuzzle ApplyTo(SudokuPuzzle puzzle, int[] grid)
+    {
+        var cells = puzzle.Cells.Select(cell =>
+        {
+            var value = grid[cell.Row * 9 + cell.Column];
+            return Cell.Create(cell.Row, cell.Column, value == 0 ? null : value, cell.IsFixed);
+        }).ToList();
+
+        return SudokuPuzzle.Create(puzzle.PuzzleId, puzzle.Difficulty, cells);
+    }
+}

--- a/src/backend/Sudoku.Infrastructure/Services/Strategies/ColumnRowMiniGridEliminationStrategy.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/Strategies/ColumnRowMiniGridEliminationStrategy.cs
@@ -13,7 +13,6 @@ public class ColumnRowMiniGridEliminationStrategy : SolverStrategy
 			if (cell.Value.HasValue || cell.PossibleValues.Count != 1) continue;
 
 			var cellValue = cell.PossibleValues.First();
-			Console.WriteLine($"Setting cell:{cell.Row}:{cell.Column} to value {cellValue}");
 			cell.SetValue(cellValue);
 			cell.PossibleValues.Clear();
             changesMade = true;

--- a/src/backend/Sudoku.Infrastructure/Services/Strategies/SinglesInColumnsStrategy.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/Strategies/SinglesInColumnsStrategy.cs
@@ -34,7 +34,6 @@ public class SinglesInColumnsStrategy : SolverStrategy
 				if (occurrence != 1) continue;
 
 				var loneRangerCell = puzzle.GetCell(rowPos, colPos);
-				Console.WriteLine($"Setting cell:{loneRangerCell.Row}:{loneRangerCell.Column} to value {number}");
 				loneRangerCell.SetValue(number);
 				loneRangerCell.PossibleValues.Clear();
 				changesMade = true;

--- a/src/backend/Sudoku.Infrastructure/Services/Strategies/SinglesInMiniGridsStrategy.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/Strategies/SinglesInMiniGridsStrategy.cs
@@ -33,7 +33,6 @@ public class SinglesInMiniGridsStrategy : SolverStrategy
 					if (occurrence != 1) continue;
 
 					var loneRangerCell = puzzle.GetCell(rowPos, colPos);
-					Console.WriteLine($"Setting cell:{loneRangerCell.Row}:{loneRangerCell.Column} to value {number}");
 					loneRangerCell.SetValue(number);
 					loneRangerCell.PossibleValues.Clear();
                     changesMade = true;

--- a/src/backend/Sudoku.Infrastructure/Services/Strategies/SinglesInRowsStrategy.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/Strategies/SinglesInRowsStrategy.cs
@@ -34,7 +34,6 @@ public class SinglesInRowsStrategy : SolverStrategy
 				if (occurrence != 1) continue;
 
 				var loneRangerCell = puzzle.GetCell(rowPos, colPos);
-				Console.WriteLine($"Setting cell:{loneRangerCell.Row}:{loneRangerCell.Column} to value {number}");
 				loneRangerCell.SetValue(number);
 				loneRangerCell.PossibleValues.Clear();
 				changesMade = true;

--- a/src/backend/Sudoku.Infrastructure/Services/UniqueSolutionPuzzleGenerator.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/UniqueSolutionPuzzleGenerator.cs
@@ -1,0 +1,159 @@
+using Sudoku.Application.Interfaces;
+using Sudoku.Domain.Entities;
+using Sudoku.Domain.ValueObjects;
+using Sudoku.Infrastructure.Services.Solvers;
+using Sudoku.Infrastructure.Utilities;
+
+namespace Sudoku.Infrastructure.Services;
+
+/// <summary>
+/// An <see cref="IPuzzleGenerator"/> that guarantees every generated puzzle has exactly
+/// one solution. It builds a complete grid with <see cref="BitwiseSolverEngine"/>, then
+/// digs holes symmetrically, keeping a removal only while the puzzle still has a unique
+/// solution (verified via <see cref="BitwiseSolverEngine.CountSolutions"/>).
+///
+/// Empty-cell targets per difficulty mirror the legacy <see cref="PuzzleGenerator"/> so the
+/// two are directly comparable. The target is a ceiling: if uniqueness can't be preserved
+/// all the way to it, generation stops at the last unique state.
+/// </summary>
+public class UniqueSolutionPuzzleGenerator : IPuzzleGenerator
+{
+    private const int EASY_EMPTY_MIN = 40;
+    private const int EASY_EMPTY_MAX = 45;
+    private const int MEDIUM_EMPTY_MIN = 46;
+    private const int MEDIUM_EMPTY_MAX = 49;
+    private const int HARD_EMPTY_MIN = 50;
+    private const int HARD_EMPTY_MAX = 53;
+    private const int EXPERT_EMPTY_MIN = 54;
+    private const int EXPERT_EMPTY_MAX = 58;
+
+    public Task<SudokuPuzzle> GeneratePuzzleAsync(GameDifficulty difficulty)
+    {
+        var grid = GenerateFullSolution();
+        var targetEmpty = GetTargetEmptyCount(difficulty);
+
+        DigHoles(grid, targetEmpty);
+
+        return Task.FromResult(BuildPuzzle(grid, difficulty));
+    }
+
+    private static int[] GenerateFullSolution()
+    {
+        var grid = new int[81];
+
+        // Seeding the three diagonal boxes is always conflict-free (they share no row,
+        // column, or box), and the random fill is what gives each generated puzzle a
+        // different solution once the solver completes the rest.
+        for (var box = 0; box < 3; box++)
+        {
+            var values = ShuffledOneToNine();
+            var k = 0;
+
+            for (var r = box * 3; r < box * 3 + 3; r++)
+            {
+                for (var c = box * 3; c < box * 3 + 3; c++)
+                {
+                    grid[r * 9 + c] = values[k++];
+                }
+            }
+        }
+
+        BitwiseSolverEngine.Solve(grid);
+
+        return grid;
+    }
+
+    private static void DigHoles(int[] grid, int targetEmpty)
+    {
+        var positions = ShuffledPositions();
+        var removed = 0;
+
+        foreach (var index in positions)
+        {
+            var remaining = targetEmpty - removed;
+            if (remaining <= 0)
+            {
+                break;
+            }
+
+            if (grid[index] == 0)
+            {
+                continue; // already cleared (e.g. as a mirror)
+            }
+
+            var mirror = 80 - index;
+
+            // Remove a symmetric pair when there's room for two; otherwise a single cell.
+            // Bounding the group by 'remaining' guarantees we never exceed the target.
+            var group = (index == mirror || grid[mirror] == 0 || remaining < 2)
+                ? new[] { index }
+                : new[] { index, mirror };
+
+            var saved = group.Select(i => grid[i]).ToArray();
+
+            foreach (var i in group)
+            {
+                grid[i] = 0;
+            }
+
+            if (BitwiseSolverEngine.CountSolutions(grid, cap: 2) == 1)
+            {
+                removed += group.Length;
+            }
+            else
+            {
+                for (var i = 0; i < group.Length; i++)
+                {
+                    grid[group[i]] = saved[i];
+                }
+            }
+        }
+    }
+
+    private static SudokuPuzzle BuildPuzzle(int[] grid, GameDifficulty difficulty)
+    {
+        var cells = Enumerable.Range(0, 81)
+            .Select(i =>
+            {
+                int row = i / 9, column = i % 9;
+                return grid[i] == 0
+                    ? Cell.CreateEmpty(row, column)
+                    : Cell.CreateFixed(row, column, grid[i]);
+            })
+            .ToList();
+
+        return SudokuPuzzle.Create(GameId.New(), difficulty, cells);
+    }
+
+    private static int GetTargetEmptyCount(GameDifficulty difficulty) => difficulty.Name switch
+    {
+        "Easy" => RandomGenerator.RandomNumber(EASY_EMPTY_MIN, EASY_EMPTY_MAX),
+        "Medium" => RandomGenerator.RandomNumber(MEDIUM_EMPTY_MIN, MEDIUM_EMPTY_MAX),
+        "Hard" => RandomGenerator.RandomNumber(HARD_EMPTY_MIN, HARD_EMPTY_MAX),
+        "Expert" => RandomGenerator.RandomNumber(EXPERT_EMPTY_MIN, EXPERT_EMPTY_MAX),
+        _ => 0
+    };
+
+    private static int[] ShuffledOneToNine()
+    {
+        var values = Enumerable.Range(1, 9).ToArray();
+        Shuffle(values);
+        return values;
+    }
+
+    private static int[] ShuffledPositions()
+    {
+        var positions = Enumerable.Range(0, 81).ToArray();
+        Shuffle(positions);
+        return positions;
+    }
+
+    private static void Shuffle(int[] array)
+    {
+        for (var i = array.Length - 1; i > 0; i--)
+        {
+            var j = RandomGenerator.RandomNumber(0, i + 1);
+            (array[i], array[j]) = (array[j], array[i]);
+        }
+    }
+}

--- a/src/backend/Tests/Infrastructure/Services/BitwiseSolverEngineTests.cs
+++ b/src/backend/Tests/Infrastructure/Services/BitwiseSolverEngineTests.cs
@@ -1,0 +1,132 @@
+using Sudoku.Infrastructure.Services.Solvers;
+
+namespace UnitTests.Infrastructure.Services;
+
+public class BitwiseSolverEngineTests
+{
+    // Canonical Wikipedia example puzzle (unique solution).
+    private const string UniquePuzzle =
+        "530070000600195000098000060800060003400803001700020006060000280000419005000080079";
+
+    [Fact]
+    public void Solve_KnownUniquePuzzle_FillsEveryCellWithAValidCompleteGrid()
+    {
+        var grid = ToGrid(UniquePuzzle);
+
+        var solved = BitwiseSolverEngine.Solve(grid);
+
+        solved.Should().BeTrue();
+        grid.Should().OnlyContain(v => v >= 1 && v <= 9);
+        IsCompleteValidGrid(grid).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Solve_GivenClues_KeepsThoseCluesInTheSolution()
+    {
+        var clues = ToGrid(UniquePuzzle);
+        var grid = (int[])clues.Clone();
+
+        BitwiseSolverEngine.Solve(grid);
+
+        for (var i = 0; i < 81; i++)
+        {
+            if (clues[i] != 0)
+            {
+                grid[i].Should().Be(clues[i]);
+            }
+        }
+    }
+
+    [Fact]
+    public void Solve_InconsistentGrid_ReturnsFalse()
+    {
+        var grid = new int[81];
+        grid[0] = 5;
+        grid[1] = 5; // duplicate in the same row/box
+
+        BitwiseSolverEngine.Solve(grid).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CountSolutions_UniquePuzzle_ReturnsOne()
+    {
+        var grid = ToGrid(UniquePuzzle);
+
+        BitwiseSolverEngine.CountSolutions(grid, cap: 2).Should().Be(1);
+    }
+
+    [Fact]
+    public void CountSolutions_EmptyGrid_StopsAtCap()
+    {
+        var grid = new int[81]; // wide-open, astronomically many solutions
+
+        BitwiseSolverEngine.CountSolutions(grid, cap: 2).Should().Be(2);
+    }
+
+    [Fact]
+    public void CountSolutions_UnderConstrainedPuzzle_ReturnsMoreThanOne()
+    {
+        // The unique puzzle with several clues removed admits multiple solutions.
+        var grid = ToGrid(UniquePuzzle);
+        grid[2] = 0;
+        grid[3] = 0;
+        grid[20] = 0;
+        grid[40] = 0;
+        grid[60] = 0;
+
+        BitwiseSolverEngine.CountSolutions(grid, cap: 2).Should().BeGreaterThan(1);
+    }
+
+    [Fact]
+    public void CountSolutions_DoesNotMutateInputGrid()
+    {
+        var grid = ToGrid(UniquePuzzle);
+        var snapshot = (int[])grid.Clone();
+
+        BitwiseSolverEngine.CountSolutions(grid, cap: 2);
+
+        grid.Should().Equal(snapshot);
+    }
+
+    private static int[] ToGrid(string board)
+    {
+        var grid = new int[81];
+        for (var i = 0; i < 81; i++)
+        {
+            grid[i] = board[i] is >= '1' and <= '9' ? board[i] - '0' : 0;
+        }
+        return grid;
+    }
+
+    private static bool IsCompleteValidGrid(int[] grid)
+    {
+        for (var unit = 0; unit < 9; unit++)
+        {
+            var rowSeen = new HashSet<int>();
+            var colSeen = new HashSet<int>();
+            var boxSeen = new HashSet<int>();
+
+            for (var k = 0; k < 9; k++)
+            {
+                if (!rowSeen.Add(grid[unit * 9 + k]))
+                {
+                    return false;
+                }
+
+                if (!colSeen.Add(grid[k * 9 + unit]))
+                {
+                    return false;
+                }
+
+                var boxRow = (unit / 3) * 3 + k / 3;
+                var boxCol = (unit % 3) * 3 + k % 3;
+                if (!boxSeen.Add(grid[boxRow * 9 + boxCol]))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/backend/Tests/Infrastructure/Services/UniqueSolutionPuzzleGeneratorTests.cs
+++ b/src/backend/Tests/Infrastructure/Services/UniqueSolutionPuzzleGeneratorTests.cs
@@ -1,0 +1,83 @@
+using Sudoku.Application.Interfaces;
+using Sudoku.Domain.ValueObjects;
+using Sudoku.Infrastructure.Services;
+using Sudoku.Infrastructure.Services.Solvers;
+
+namespace UnitTests.Infrastructure.Services;
+
+public class UniqueSolutionPuzzleGeneratorTests : MoqBaseTestByAbstraction<UniqueSolutionPuzzleGenerator, IPuzzleGenerator>
+{
+    public static IEnumerable<object[]> Difficulties =>
+    [
+        [GameDifficulty.Easy],
+        [GameDifficulty.Medium],
+        [GameDifficulty.Hard],
+        [GameDifficulty.Expert],
+    ];
+
+    [Theory]
+    [MemberData(nameof(Difficulties))]
+    public async Task GeneratePuzzleAsync_ForAnyDifficulty_ProducesAValidPuzzle(GameDifficulty difficulty)
+    {
+        var sut = ResolveSut();
+
+        var puzzle = await sut.GeneratePuzzleAsync(difficulty);
+
+        puzzle.Should().NotBeNull();
+        puzzle.IsValid().Should().BeTrue();
+        puzzle.Difficulty.Should().Be(difficulty);
+    }
+
+    [Theory]
+    [MemberData(nameof(Difficulties))]
+    public async Task GeneratePuzzleAsync_ForAnyDifficulty_ProducesExactlyOneSolution(GameDifficulty difficulty)
+    {
+        var sut = ResolveSut();
+
+        var puzzle = await sut.GeneratePuzzleAsync(difficulty);
+
+        var grid = BitwiseSolverGridMapper.ToGrid(puzzle);
+        BitwiseSolverEngine.CountSolutions(grid, cap: 2).Should().Be(1);
+    }
+
+    [Theory]
+    [MemberData(nameof(Difficulties))]
+    public async Task GeneratePuzzleAsync_RemainingCluesAreFixed(GameDifficulty difficulty)
+    {
+        var sut = ResolveSut();
+
+        var puzzle = await sut.GeneratePuzzleAsync(difficulty);
+
+        puzzle.Cells.Where(c => c.HasValue).Should().OnlyContain(c => c.IsFixed);
+        puzzle.Cells.Where(c => !c.HasValue).Should().OnlyContain(c => !c.IsFixed);
+    }
+
+    [Theory]
+    [MemberData(nameof(Difficulties))]
+    public async Task GeneratePuzzleAsync_ClueCountStaysWithinDifficultyBand(GameDifficulty difficulty)
+    {
+        var sut = ResolveSut();
+
+        var puzzle = await sut.GeneratePuzzleAsync(difficulty);
+
+        var emptyCells = puzzle.GetEmptyCellCount();
+        var (min, max) = ExpectedEmptyBand(difficulty);
+
+        // Target is a ceiling; uniqueness may stop digging early, so allow a lower-bound margin.
+        emptyCells.Should().BeLessThanOrEqualTo(max);
+        emptyCells.Should().BeGreaterThanOrEqualTo(min - LowerBandMargin);
+    }
+
+    // Uniqueness can occasionally halt digging a few cells short of the target; this margin
+    // keeps the band assertion stable without weakening the uniqueness guarantee above.
+    private const int LowerBandMargin = 6;
+
+    private static (int Min, int Max) ExpectedEmptyBand(GameDifficulty difficulty) => difficulty.Name switch
+    {
+        "Easy" => (40, 45),
+        "Medium" => (46, 49),
+        "Hard" => (50, 53),
+        "Expert" => (54, 58),
+        _ => (0, 81)
+    };
+}


### PR DESCRIPTION
## Description

Explores faster, higher-quality algorithms for **solving** and **generating** Sudoku puzzles, and adds a BenchmarkDotNet harness to compare the new implementations against the legacy ones side by side (speed + correctness). New implementations drop in behind the existing `IPuzzleSolver` / `IPuzzleGenerator` seams, so production wiring is unchanged.

Motivation — two concrete gaps in the current code:
- The legacy `PuzzleGenerator` removes cells by **count only** and never verifies uniqueness (`SudokuPuzzle.HasUniqueSolution()` is a `>= 17 clues` stub), so generated puzzles can have multiple solutions.
- The legacy `StrategyBasedPuzzleSolver` falls back to a **random** guess every loop and persists/rolls back through an `IPuzzleRepository` (async memento round-trips) — slow, and unusable as a uniqueness checker.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Performance improvement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Changes Made

- **`BitwiseSolverEngine`** — bitmask + MRV backtracking over a flat `int[81]`; `Solve` (first solution) and `CountSolutions(grid, cap)` that early-exits at the cap for cheap "exactly one vs more than one" uniqueness checks. Pure, synchronous, no DI.
- **`BitwiseBacktrackingPuzzleSolver`** — `IPuzzleSolver` wrapping the engine (+ `BitwiseSolverGridMapper` for `SudokuPuzzle` ⇄ grid).
- **`UniqueSolutionPuzzleGenerator`** — `IPuzzleGenerator` that builds a full solution then digs holes symmetrically, **keeping a removal only while the puzzle still has exactly one solution**. Reuses the legacy per-difficulty empty-cell bands so old/new stay comparable.
- **`Sudoku.Benchmarks`** project — BenchmarkDotNet `GeneratorBenchmarks` / `SolverBenchmarks` (legacy = baseline, `[MemoryDiagnoser]`), plus a `--validate` quality report (unique-solution rate + clue distribution) and a README.
- Unit tests for the engine and the generator.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

Full suite: **649 passed, 0 failed**. New tests: **23 passed** (`BitwiseSolverEngineTests`, `UniqueSolutionPuzzleGeneratorTests`) — including assertions that every generated puzzle (all four difficulties) has exactly one solution.

Run the comparisons:
```bash
dotnet run -c Release --project src/backend/Sudoku.Benchmarks -- --filter *GeneratorBenchmarks*
dotnet run -c Release --project src/backend/Sudoku.Benchmarks -- --filter *SolverBenchmarks*
dotnet run -c Release --project src/backend/Sudoku.Benchmarks -- --validate
```

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
