### PR TITLE
Switch puzzle generation to UniqueSolutionPuzzleGenerator

### DIFF
--- a/src/backend/Sudoku.Infrastructure/Configuration/InfrastructureServiceCollectionExtensions.cs
+++ b/src/backend/Sudoku.Infrastructure/Configuration/InfrastructureServiceCollectionExtensions.cs
@@ -81,7 +81,7 @@ public static class InfrastructureServiceCollectionExtensions
 
         private IServiceCollection AddPuzzleServices()
         {
-            services.AddScoped<IPuzzleGenerator, PuzzleGenerator>();
+            services.AddScoped<IPuzzleGenerator, UniqueSolutionPuzzleGenerator>();
             services.AddScoped<IPuzzleSolver, StrategyBasedPuzzleSolver>();
 
             typeof(SolverStrategy).Assembly


### PR DESCRIPTION
## Description

Wires the `IPuzzleGenerator` DI registration to the new `UniqueSolutionPuzzleGenerator` (added in #338) so production puzzle generation now guarantees every puzzle has exactly one solution. Previously the container still resolved the legacy `PuzzleGenerator`, which could produce puzzles with multiple valid solutions.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Changed `AddPuzzleServices` to register `IPuzzleGenerator` → `UniqueSolutionPuzzleGenerator` instead of `PuzzleGenerator`.
- Both consumers (`CreateGameCommandHandler`, `AzureBlobPuzzleRepository`) depend on the `IPuzzleGenerator` interface, so they pick up the new implementation automatically.
- Retained the legacy `PuzzleGenerator` (and its tests) as the A/B benchmark baseline; nothing in production references it now.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

Build verified locally; `UniqueSolutionPuzzleGenerator` already ships with unit-test coverage from #338. No DI tests assert the concrete type — they only check `IPuzzleGenerator` resolves to non-null.

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)