### PR TITLE
Switch puzzle generation to UniqueSolutionPuzzleGenerator

### DIFF
--- a/src/backend/Sudoku.Infrastructure/Configuration/InfrastructureServiceCollectionExtensions.cs
+++ b/src/backend/Sudoku.Infrastructure/Configuration/InfrastructureServiceCollectionExtensions.cs
@@ -81,7 +81,7 @@ public static class InfrastructureServiceCollectionExtensions
 
         private IServiceCollection AddPuzzleServices()
         {
-            services.AddScoped<IPuzzleGenerator, PuzzleGenerator>();
+            services.AddScoped<IPuzzleGenerator, UniqueSolutionPuzzleGenerator>();
             services.AddScoped<IPuzzleSolver, StrategyBasedPuzzleSolver>();
 
             typeof(SolverStrategy).Assembly


### PR DESCRIPTION
## Description

Switches runtime puzzle generation to `UniqueSolutionPuzzleGenerator` so every generated puzzle is verified to have exactly one solution. The legacy `PuzzleGenerator` is retained as the A/B benchmark baseline.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Wire `IPuzzleGenerator` DI registration to `UniqueSolutionPuzzleGenerator` instead of `PuzzleGenerator` in `InfrastructureServiceCollectionExtensions`
- Keep legacy `PuzzleGenerator` available as the A/B benchmark baseline

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

Ran `dotnet build` (succeeds, pre-existing warnings only) and the puzzle-generation test suite: 23 passed, 0 failed.

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)
