### PR TITLE
Use distinct trash-can icon for Reset button

### DIFF
--- a/src/frontend/Sudoku.React/src/components/GameControls.tsx
+++ b/src/frontend/Sudoku.React/src/components/GameControls.tsx
@@ -50,7 +50,7 @@ export default function GameControls({
           <i className="fa fa-undo" />
         </button>
         <button className={styles.btn} onClick={onReset} title="Reset">
-          <i className="fa fa-rotate-left" />
+          <i className="fa fa-trash-can" />
         </button>
         <button
           className={`${styles.btn} ${pencilMode ? '' : styles.btnOutline}`}


### PR DESCRIPTION
## Description

While playing the game, the **Undo** and **Reset** toolbar buttons rendered the same glyph, so players couldn't tell them apart. The cause: `fa-undo` (Undo) and `fa-rotate-left` (Reset) are aliases for the same counterclockwise-arrow icon in Font Awesome 6.5.0. Reset now uses `fa-trash-can` ("clear the board") so the two actions are visually distinct.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Changed the Reset button icon in `GameControls.tsx` from `fa-rotate-left` to `fa-trash-can`.
- Left the Undo button as `fa-undo` (the conventional single curved-back arrow), now visually distinct from Reset.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

`GameControls.test.tsx` selects buttons by their `title` ("Undo" / "Reset"), not by icon class, so no test changes were needed. All 10 `GameControls` tests pass.

## Screenshots (if applicable)

Undo → ↶ (curved-back arrow) · Reset → 🗑 (trash can)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)