### PR TITLE
Add Hint System (#218)

### DIFF
--- a/src/backend/Sudoku.Api/Controllers/GameActionsController.cs
+++ b/src/backend/Sudoku.Api/Controllers/GameActionsController.cs
@@ -66,5 +66,25 @@ namespace Sudoku.Api.Controllers
             var result = await Mediator.Send(new UndoLastMoveCommand(gameId));
             return HandleUnitResult(result);
         }
+
+        /// <summary>
+        /// Reveals a hint by filling one correct cell (subject to the per-game hint limit)
+        /// </summary>
+        /// <param name="profileId">The player's profile ID</param>
+        /// <param name="gameId">The game id</param>
+        /// <param name="request">Optional play duration to record with the hint</param>
+        /// <returns>No content if successful</returns>
+        [HttpPost("hint")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<ActionResult> RequestHintAsync(string profileId, string gameId, [FromBody] HintRequest? request)
+        {
+            var (_, error) = await GetAuthorizedGameAsync(profileId, gameId);
+            if (error != null) return error;
+
+            var result = await Mediator.Send(new RequestHintCommand(gameId, request?.PlayDuration ?? TimeSpan.Zero));
+            return HandleUnitResult(result);
+        }
     }
 }

--- a/src/backend/Sudoku.Api/Models/HintRequest.cs
+++ b/src/backend/Sudoku.Api/Models/HintRequest.cs
@@ -1,0 +1,3 @@
+namespace Sudoku.Api.Models;
+
+public record HintRequest(TimeSpan PlayDuration);

--- a/src/backend/Sudoku.Application/Commands/RequestHintCommand.cs
+++ b/src/backend/Sudoku.Application/Commands/RequestHintCommand.cs
@@ -1,0 +1,5 @@
+using Sudoku.Application.Common;
+
+namespace Sudoku.Application.Commands;
+
+public record RequestHintCommand(string GameId, TimeSpan PlayDuration) : ICommand;

--- a/src/backend/Sudoku.Application/DTOs/GameDto.cs
+++ b/src/backend/Sudoku.Application/DTOs/GameDto.cs
@@ -40,6 +40,8 @@ public record GameStatisticsDto(
     int TotalMoves,
     int ValidMoves,
     int InvalidMoves,
+    int HintsUsed,
+    int HintsRemaining,
     TimeSpan PlayDuration,
     double AccuracyPercentage)
 {
@@ -49,6 +51,8 @@ public record GameStatisticsDto(
             statistics.TotalMoves,
             statistics.ValidMoves,
             statistics.InvalidMoves,
+            statistics.HintsUsed,
+            statistics.HintsRemaining,
             statistics.PlayDuration,
             statistics.AccuracyPercentage
         );
@@ -60,6 +64,7 @@ public record CellDto(
     int Column,
     int? Value,
     bool IsFixed,
+    bool IsHint,
     bool HasValue,
     List<int> PossibleValues)
 {
@@ -70,6 +75,7 @@ public record CellDto(
             cell.Column,
             cell.Value,
             cell.IsFixed,
+            cell.IsHint,
             cell.HasValue,
             cell.PossibleValues.ToList()
         );

--- a/src/backend/Sudoku.Application/Handlers/RequestHintCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/RequestHintCommandHandler.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Logging;
+using Sudoku.Application.Commands;
+using Sudoku.Application.Common;
+using Sudoku.Application.Interfaces;
+using Sudoku.Domain.Entities;
+using Sudoku.Domain.Exceptions;
+using Sudoku.Domain.ValueObjects;
+
+namespace Sudoku.Application.Handlers;
+
+public class RequestHintCommandHandler(
+    IGameRepository gameRepository,
+    IPuzzleSolver puzzleSolver,
+    ILogger<RequestHintCommandHandler> logger) : ICommandHandler<RequestHintCommand>
+{
+    public async Task<Result> Handle(RequestHintCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var gameId = GameId.Create(request.GameId);
+            var game = await gameRepository.GetByIdAsync(gameId);
+
+            if (game == null)
+            {
+                return Result.Failure($"Game not found with ID: {request.GameId}");
+            }
+
+            // Solve from the fixed clues (and any previously revealed hints) only, so a wrong
+            // player entry can never make the board unsolvable or yield the wrong hint value.
+            var solvedPuzzle = await puzzleSolver.SolvePuzzle(BuildPuzzleFromClues(game));
+
+            var (row, column, value) = game.RevealHint(solvedPuzzle);
+            game.UpdatePlayDuration(request.PlayDuration);
+
+            await gameRepository.SaveAsync(game);
+
+            logger.LogInformation("Revealed hint for game {GameId} at [{Row},{Column}] with value {Value}",
+                gameId.Value, row, column, value);
+            return Result.Success();
+        }
+        catch (DomainException ex)
+        {
+            logger.LogWarning("Failed to reveal hint for game {GameId}: {Error}", request.GameId, ex.Message);
+            return Result.Failure(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An unexpected error occurred revealing hint for game {GameId}", request.GameId);
+            return Result.Failure($"An unexpected error occurred: {ex.Message}");
+        }
+    }
+
+    private static SudokuPuzzle BuildPuzzleFromClues(SudokuGame game)
+    {
+        var cells = game.GetCells()
+            .Select(c => c.IsLocked
+                ? Cell.CreateFixed(c.Row, c.Column, c.Value!.Value)
+                : Cell.CreateEmpty(c.Row, c.Column))
+            .ToList();
+
+        return SudokuPuzzle.Create(game.Id.Value.ToString(), game.Difficulty, cells);
+    }
+}

--- a/src/backend/Sudoku.Domain/Entities/SudokuGame.cs
+++ b/src/backend/Sudoku.Domain/Entities/SudokuGame.cs
@@ -97,7 +97,7 @@ public class SudokuGame : AggregateRoot
         }
 
         var cell = GetCell(row, column);
-        if (cell.IsFixed)
+        if (cell.IsLocked)
         {
             throw new CellIsFixedException($"Cannot modify fixed cell at position ({row}, {column})");
         }
@@ -118,6 +118,49 @@ public class SudokuGame : AggregateRoot
         {
             CompleteGame();
         }
+    }
+
+    /// <summary>
+    /// Reveals the correct value for a randomly chosen empty cell, locking it in place.
+    /// The caller supplies the solved puzzle (computed from the fixed clues), so the domain
+    /// stays free of any solver dependency. Hints do not enter the move history, so they are
+    /// unaffected by <see cref="UndoLastMove"/>.
+    /// </summary>
+    public (int Row, int Column, int Value) RevealHint(SudokuPuzzle solvedPuzzle)
+    {
+        if (Status != GameStatusEnum.InProgress)
+        {
+            throw new GameNotInProgressException($"Cannot reveal a hint in {Status} state");
+        }
+
+        if (Statistics.HintsUsed >= GameStatistics.MaxHints)
+        {
+            throw new HintLimitReachedException();
+        }
+
+        var emptyCells = _cells.Where(c => !c.IsLocked && !c.HasValue).ToList();
+        if (emptyCells.Count == 0)
+        {
+            throw new NoAvailableCellsForHintException();
+        }
+
+        var target = emptyCells[Random.Shared.Next(emptyCells.Count)];
+        var correctValue = solvedPuzzle.GetCell(target.Row, target.Column).Value
+            ?? throw new NoAvailableCellsForHintException();
+
+        var index = _cells.FindIndex(c => c.Row == target.Row && c.Column == target.Column);
+        _cells[index] = Cell.CreateHint(target.Row, target.Column, correctValue);
+
+        Statistics.RecordHint();
+
+        AddDomainEvent(new HintRevealedEvent(Id, target.Row, target.Column, correctValue, Statistics));
+
+        if (IsGameComplete())
+        {
+            CompleteGame();
+        }
+
+        return (target.Row, target.Column, correctValue);
     }
 
     public void AddPossibleValue(int row, int column, int value)
@@ -207,11 +250,24 @@ public class SudokuGame : AggregateRoot
             throw new GameNotInStartStateException("Game is already in its initial state");
         }
 
-        // Reset all non-fixed cells
-        foreach (var cell in _cells.Where(c => !c.IsFixed))
+        // Reset all non-fixed cells; hint-revealed cells are locked, so rebuild them as empty
+        for (var i = 0; i < _cells.Count; i++)
         {
-            cell.SetValue(null);
-            cell.ClearPossibleValues();
+            var cell = _cells[i];
+            if (cell.IsFixed)
+            {
+                continue;
+            }
+
+            if (cell.IsHint)
+            {
+                _cells[i] = Cell.CreateEmpty(cell.Row, cell.Column);
+            }
+            else
+            {
+                cell.SetValue(null);
+                cell.ClearPossibleValues();
+            }
         }
 
         // Clear move history

--- a/src/backend/Sudoku.Domain/Events/GameEvents.cs
+++ b/src/backend/Sudoku.Domain/Events/GameEvents.cs
@@ -23,3 +23,5 @@ public record PossibleValueAddedEvent(GameId GameId, int Row, int Column, int Va
 public record PossibleValueRemovedEvent(GameId GameId, int Row, int Column, int Value) : DomainEvent;
 
 public record PossibleValuesClearedEvent(GameId GameId, int Row, int Column) : DomainEvent;
+
+public record HintRevealedEvent(GameId GameId, int Row, int Column, int Value, GameStatistics Statistics) : DomainEvent;

--- a/src/backend/Sudoku.Domain/Exceptions/HintLimitReachedException.cs
+++ b/src/backend/Sudoku.Domain/Exceptions/HintLimitReachedException.cs
@@ -1,0 +1,3 @@
+namespace Sudoku.Domain.Exceptions;
+
+public class HintLimitReachedException() : DomainException("No hints remaining for this game");

--- a/src/backend/Sudoku.Domain/Exceptions/NoAvailableCellsForHintException.cs
+++ b/src/backend/Sudoku.Domain/Exceptions/NoAvailableCellsForHintException.cs
@@ -1,0 +1,3 @@
+namespace Sudoku.Domain.Exceptions;
+
+public class NoAvailableCellsForHintException() : DomainException("No empty cells available to reveal a hint");

--- a/src/backend/Sudoku.Domain/ValueObjects/Cell.cs
+++ b/src/backend/Sudoku.Domain/ValueObjects/Cell.cs
@@ -8,10 +8,17 @@ public record Cell
     public int Column { get; }
     public int? Value { get; private set; }
     public bool IsFixed { get; }
+    public bool IsHint { get; }
     public bool HasValue => Value.HasValue;
+
+    /// <summary>
+    /// A cell is locked when it cannot be modified by the player: original clues (<see cref="IsFixed"/>)
+    /// and cells revealed by a hint (<see cref="IsHint"/>).
+    /// </summary>
+    public bool IsLocked => IsFixed || IsHint;
     public HashSet<int> PossibleValues { get; private set; } = new();
 
-    private Cell(int row, int column, int? value, bool isFixed)
+    private Cell(int row, int column, int? value, bool isFixed, bool isHint = false)
     {
         if (row < 0 || row > 8)
         {
@@ -32,11 +39,12 @@ public record Cell
         Column = column;
         Value = value;
         IsFixed = isFixed;
+        IsHint = isHint;
     }
 
-    public static Cell Create(int row, int column, int? value = null, bool isFixed = false)
+    public static Cell Create(int row, int column, int? value = null, bool isFixed = false, bool isHint = false)
     {
-        return new Cell(row, column, value, isFixed);
+        return new Cell(row, column, value, isFixed, isHint);
     }
 
     public static Cell CreateFixed(int row, int column, int value)
@@ -49,9 +57,18 @@ public record Cell
         return new Cell(row, column, null, false);
     }
 
+    /// <summary>
+    /// Creates a cell revealed by a hint: it holds the correct value and is locked so the player
+    /// cannot change it, but it is distinct from an original clue (<see cref="IsFixed"/> stays false).
+    /// </summary>
+    public static Cell CreateHint(int row, int column, int value)
+    {
+        return new Cell(row, column, value, isFixed: false, isHint: true);
+    }
+
     public void SetValue(int value)
     {
-        if (IsFixed)
+        if (IsLocked)
         {
             throw new CellIsFixedException($"Cannot modify fixed cell at position ({Row}, {Column})");
         }
@@ -67,7 +84,7 @@ public record Cell
 
     public void SetValue(int? value)
     {
-        if (IsFixed)
+        if (IsLocked)
         {
             throw new CellIsFixedException($"Cannot modify fixed cell at position ({Row}, {Column})");
         }
@@ -90,7 +107,7 @@ public record Cell
 
     public void ClearValue()
     {
-        if (IsFixed)
+        if (IsLocked)
         {
             throw new CellIsFixedException($"Cannot modify fixed cell at position ({Row}, {Column})");
         }
@@ -100,7 +117,7 @@ public record Cell
 
     public void AddPossibleValue(int value)
     {
-        if (IsFixed)
+        if (IsLocked)
         {
             throw new CellIsFixedException($"Cannot modify fixed cell at position ({Row}, {Column})");
         }
@@ -123,7 +140,7 @@ public record Cell
 
     public void RemovePossibleValue(int value)
     {
-        if (IsFixed)
+        if (IsLocked)
         {
             throw new CellIsFixedException($"Cannot modify fixed cell at position ({Row}, {Column})");
         }
@@ -138,7 +155,7 @@ public record Cell
 
     public void ClearPossibleValues()
     {
-        if (IsFixed)
+        if (IsLocked)
         {
             throw new CellIsFixedException($"Cannot modify fixed cell at position ({Row}, {Column})");
         }
@@ -153,7 +170,7 @@ public record Cell
 
     public Cell DeepCopy()
     {
-        var clonedCell = new Cell(Row, Column, Value, IsFixed);
+        var clonedCell = new Cell(Row, Column, Value, IsFixed, IsHint);
 
         foreach (var possibleValue in PossibleValues)
         {

--- a/src/backend/Sudoku.Domain/ValueObjects/GameStatistics.cs
+++ b/src/backend/Sudoku.Domain/ValueObjects/GameStatistics.cs
@@ -2,9 +2,13 @@ namespace Sudoku.Domain.ValueObjects;
 
 public record GameStatistics
 {
+    /// <summary>Maximum number of hints a player may use per game (all difficulties).</summary>
+    public const int MaxHints = 3;
+
     public int TotalMoves { get; private set; }
     public int ValidMoves { get; private set; }
     public int InvalidMoves { get; private set; }
+    public int HintsUsed { get; private set; }
     public TimeSpan PlayDuration { get; private set; }
     public DateTime? LastMoveAt { get; private set; }
 
@@ -13,6 +17,7 @@ public record GameStatistics
         TotalMoves = 0;
         ValidMoves = 0;
         InvalidMoves = 0;
+        HintsUsed = 0;
         PlayDuration = TimeSpan.Zero;
         LastMoveAt = null;
     }
@@ -42,12 +47,19 @@ public record GameStatistics
         ValidMoves--;
     }
 
+    public void RecordHint()
+    {
+        HintsUsed++;
+    }
+
     public void UpdatePlayDuration(TimeSpan duration)
     {
         PlayDuration = duration;
     }
 
     public double AccuracyPercentage => TotalMoves > 0 ? (double)ValidMoves / TotalMoves * 100 : 0;
+
+    public int HintsRemaining => Math.Max(0, MaxHints - HintsUsed);
 
     public bool HasMoves => TotalMoves > 0;
 }

--- a/src/backend/Sudoku.Infrastructure/Mappers/SudokuGameMapper.cs
+++ b/src/backend/Sudoku.Infrastructure/Mappers/SudokuGameMapper.cs
@@ -70,6 +70,7 @@ public static class SudokuGameMapper
             Column = cell.Column,
             Value = cell.Value,
             IsFixed = cell.IsFixed,
+            IsHint = cell.IsHint,
             PossibleValues = cell.PossibleValues.ToHashSet()
         };
         return cellDocument;
@@ -77,7 +78,7 @@ public static class SudokuGameMapper
 
     private static Cell ToDomain(this CellDocument document)
     {
-        var cell = Cell.Create(document.Row, document.Column, document.Value, document.IsFixed);
+        var cell = Cell.Create(document.Row, document.Column, document.Value, document.IsFixed, document.IsHint);
 
         // Set possible values using reflection since there's no public setter
         var cellType = typeof(Cell);
@@ -94,6 +95,7 @@ public static class SudokuGameMapper
             TotalMoves = statistics.TotalMoves,
             ValidMoves = statistics.ValidMoves,
             InvalidMoves = statistics.InvalidMoves,
+            HintsUsed = statistics.HintsUsed,
             PlayDuration = statistics.PlayDuration,
             LastMoveAt = statistics.LastMoveAt
         };
@@ -115,6 +117,9 @@ public static class SudokuGameMapper
 
         var invalidMovesField = statsType.GetField("<InvalidMoves>k__BackingField", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         invalidMovesField?.SetValue(statistics, document.InvalidMoves);
+
+        var hintsUsedField = statsType.GetField("<HintsUsed>k__BackingField", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        hintsUsedField?.SetValue(statistics, document.HintsUsed);
 
         var playDurationField = statsType.GetField("<PlayDuration>k__BackingField", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         playDurationField?.SetValue(statistics, document.PlayDuration);

--- a/src/backend/Sudoku.Infrastructure/Models/SudokuGameDocument.cs
+++ b/src/backend/Sudoku.Infrastructure/Models/SudokuGameDocument.cs
@@ -60,6 +60,9 @@ public class CellDocument
     [JsonProperty("isFixed")]
     public bool IsFixed { get; set; }
 
+    [JsonProperty("isHint")]
+    public bool IsHint { get; set; }
+
     [JsonProperty("possibleValues")]
     public HashSet<int> PossibleValues { get; set; } = [];
 }
@@ -74,6 +77,9 @@ public class GameStatisticsDocument
 
     [JsonProperty("invalidMoves")]
     public int InvalidMoves { get; set; }
+
+    [JsonProperty("hintsUsed")]
+    public int HintsUsed { get; set; }
 
     [JsonProperty("playDuration")]
     public TimeSpan PlayDuration { get; set; }

--- a/src/backend/Tests/API/BaseGameControllerTests.cs
+++ b/src/backend/Tests/API/BaseGameControllerTests.cs
@@ -1,6 +1,7 @@
 using DepenMock.Moq;
 using MediatR;
 using Sudoku.Application.DTOs;
+using Sudoku.Domain.ValueObjects;
 
 namespace UnitTests.API;
 
@@ -23,7 +24,7 @@ public abstract class BaseGameControllerTests<TControllerType> : MoqBaseTestByTy
             "TestPlayer",
             difficulty,
             "NotStarted",
-            new GameStatisticsDto(0, 0, 0, TimeSpan.Zero, 0.0),
+            new GameStatisticsDto(0, 0, 0, 0, GameStatistics.MaxHints, TimeSpan.Zero, 0.0),
             DateTime.UtcNow,
             null,
             null,

--- a/src/backend/Tests/Application/DTOs/GameDtoTests.cs
+++ b/src/backend/Tests/Application/DTOs/GameDtoTests.cs
@@ -99,6 +99,7 @@ public class GameDtoTests : MoqBaseTestByType<GameDto>
             dtoCell.Column.Should().Be(originalCell.Column);
             dtoCell.Value.Should().Be(originalCell.Value);
             dtoCell.IsFixed.Should().Be(originalCell.IsFixed);
+            dtoCell.IsHint.Should().Be(originalCell.IsHint);
             dtoCell.HasValue.Should().Be(originalCell.HasValue);
         }
     }
@@ -134,6 +135,8 @@ public class GameDtoTests : MoqBaseTestByType<GameDto>
         dto.Statistics.TotalMoves.Should().Be(game.Statistics.TotalMoves);
         dto.Statistics.ValidMoves.Should().Be(game.Statistics.ValidMoves);
         dto.Statistics.InvalidMoves.Should().Be(game.Statistics.InvalidMoves);
+        dto.Statistics.HintsUsed.Should().Be(game.Statistics.HintsUsed);
+        dto.Statistics.HintsRemaining.Should().Be(game.Statistics.HintsRemaining);
         dto.Statistics.PlayDuration.Should().Be(game.Statistics.PlayDuration);
         dto.Statistics.AccuracyPercentage.Should().Be(game.Statistics.AccuracyPercentage);
     }
@@ -147,7 +150,7 @@ public class GameDtoTests : MoqBaseTestByType<GameDto>
         var displayName = "TestPlayer";
         var difficulty = "Medium";
         var status = "InProgress";
-        var statistics = new GameStatisticsDto(10, 8, 2, TimeSpan.FromMinutes(5), 80.0);
+        var statistics = new GameStatisticsDto(10, 8, 2, 1, 2, TimeSpan.FromMinutes(5), 80.0);
         var createdAt = DateTime.UtcNow.AddMinutes(-10);
         var startedAt = DateTime.UtcNow.AddMinutes(-5);
         var completedAt = (DateTime?)null;

--- a/src/backend/Tests/Application/Handlers/RequestHintCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/RequestHintCommandHandlerTests.cs
@@ -1,0 +1,108 @@
+using DepenMock.Attributes;
+using DepenMock.Moq;
+using Sudoku.Application.Commands;
+using Sudoku.Application.Common;
+using Sudoku.Application.Handlers;
+using Sudoku.Application.Interfaces;
+using Sudoku.Domain.Entities;
+using Sudoku.Domain.ValueObjects;
+using UnitTests.Helpers.Factories;
+
+namespace UnitTests.Application.Handlers;
+
+[LogOutput(LogOutputTiming.Always)]
+public class RequestHintCommandHandlerTests : MoqBaseTestByAbstraction<RequestHintCommandHandler, ICommandHandler<RequestHintCommand>>
+{
+    private readonly Mock<IGameRepository> _mockGameRepository;
+    private readonly Mock<IPuzzleSolver> _mockPuzzleSolver;
+
+    public RequestHintCommandHandlerTests()
+    {
+        _mockGameRepository = Container.ResolveMock<IGameRepository>().AsMoq();
+        _mockPuzzleSolver = Container.ResolveMock<IPuzzleSolver>().AsMoq();
+
+        _mockPuzzleSolver
+            .Setup(x => x.SolvePuzzle(It.IsAny<SudokuPuzzle>()))
+            .ReturnsAsync(PuzzleFactory.GetSolvedPuzzle());
+    }
+
+    [Fact]
+    public async Task Handle_WithHintsAvailable_ReturnsSuccessAndSavesGame()
+    {
+        // Arrange
+        var game = GameFactory.CreateGameInProgress();
+        var command = new RequestHintCommand(game.Id.Value.ToString(), TimeSpan.FromSeconds(30));
+
+        _mockGameRepository.Setup(x => x.GetByIdAsync(It.IsAny<GameId>())).ReturnsAsync(game);
+        _mockGameRepository.Setup(x => x.SaveAsync(It.IsAny<SudokuGame>())).Returns(Task.CompletedTask);
+
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _mockPuzzleSolver.Verify(x => x.SolvePuzzle(It.IsAny<SudokuPuzzle>()), Times.Once);
+        _mockGameRepository.Verify(x => x.SaveAsync(It.IsAny<SudokuGame>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenGameNotFound_ReturnsFailureAndDoesNotSolve()
+    {
+        // Arrange
+        var command = new RequestHintCommand(Guid.NewGuid().ToString(), TimeSpan.Zero);
+        _mockGameRepository.Setup(x => x.GetByIdAsync(It.IsAny<GameId>())).ReturnsAsync((SudokuGame?)null);
+
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be($"Game not found with ID: {command.GameId}");
+        _mockPuzzleSolver.Verify(x => x.SolvePuzzle(It.IsAny<SudokuPuzzle>()), Times.Never);
+        _mockGameRepository.Verify(x => x.SaveAsync(It.IsAny<SudokuGame>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoEmptyCells_ReturnsFailureAndDoesNotSave()
+    {
+        // Arrange - a fully solved board has no cells to reveal
+        var game = GameFactory.CreateGameWithCells(CellsFactory.CreateCompletedCells());
+        game.StartGame();
+        var command = new RequestHintCommand(game.Id.Value.ToString(), TimeSpan.Zero);
+
+        _mockGameRepository.Setup(x => x.GetByIdAsync(It.IsAny<GameId>())).ReturnsAsync(game);
+
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        _mockGameRepository.Verify(x => x.SaveAsync(It.IsAny<SudokuGame>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRepositoryThrows_ReturnsFailureResult()
+    {
+        // Arrange
+        var game = GameFactory.CreateGameInProgress();
+        var command = new RequestHintCommand(game.Id.Value.ToString(), TimeSpan.Zero);
+
+        _mockGameRepository.Setup(x => x.GetByIdAsync(It.IsAny<GameId>())).ReturnsAsync(game);
+        _mockGameRepository.Setup(x => x.SaveAsync(It.IsAny<SudokuGame>())).ThrowsAsync(new Exception("Database error"));
+
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be("An unexpected error occurred: Database error");
+    }
+}

--- a/src/backend/Tests/Domain/CellTests.cs
+++ b/src/backend/Tests/Domain/CellTests.cs
@@ -583,4 +583,45 @@ public class CellTests : MoqBaseTestByType<Cell>
         clonedCell.Value.Should().Be(5);
         clonedCell.PossibleValues.Should().BeEmpty();
     }
+
+    [Fact]
+    public void CreateHint_CreatesLockedCellWithValue()
+    {
+        // Act
+        var cell = Cell.CreateHint(3, 4, 7);
+
+        // Assert
+        cell.Value.Should().Be(7);
+        cell.HasValue.Should().BeTrue();
+        cell.IsHint.Should().BeTrue();
+        cell.IsFixed.Should().BeFalse();
+        cell.IsLocked.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SetValue_OnHintCell_ThrowsCellIsFixedException()
+    {
+        // Arrange
+        var cell = Cell.CreateHint(3, 4, 7);
+
+        // Act
+        Action act = () => cell.SetValue(9);
+
+        // Assert
+        act.Should().Throw<CellIsFixedException>();
+    }
+
+    [Fact]
+    public void DeepCopy_PreservesIsHint()
+    {
+        // Arrange
+        var cell = Cell.CreateHint(3, 4, 7);
+
+        // Act
+        var clone = cell.DeepCopy();
+
+        // Assert
+        clone.IsHint.Should().BeTrue();
+        clone.Value.Should().Be(7);
+    }
 }

--- a/src/backend/Tests/Domain/GameStatisticsTests.cs
+++ b/src/backend/Tests/Domain/GameStatisticsTests.cs
@@ -15,10 +15,43 @@ public class GameStatisticsTests : MoqBaseTestByType<GameStatistics>
         statistics.TotalMoves.Should().Be(0);
         statistics.ValidMoves.Should().Be(0);
         statistics.InvalidMoves.Should().Be(0);
+        statistics.HintsUsed.Should().Be(0);
+        statistics.HintsRemaining.Should().Be(GameStatistics.MaxHints);
         statistics.PlayDuration.Should().Be(TimeSpan.Zero);
         statistics.LastMoveAt.Should().BeNull();
         statistics.AccuracyPercentage.Should().Be(0);
         statistics.HasMoves.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RecordHint_IncrementsHintsUsedAndDecrementsHintsRemaining()
+    {
+        // Arrange
+        var statistics = GameStatistics.Create();
+
+        // Act
+        statistics.RecordHint();
+
+        // Assert
+        statistics.HintsUsed.Should().Be(1);
+        statistics.HintsRemaining.Should().Be(GameStatistics.MaxHints - 1);
+    }
+
+    [Fact]
+    public void RecordHint_WhenAllHintsUsed_HintsRemainingIsZero()
+    {
+        // Arrange
+        var statistics = GameStatistics.Create();
+
+        // Act
+        for (var i = 0; i < GameStatistics.MaxHints; i++)
+        {
+            statistics.RecordHint();
+        }
+
+        // Assert
+        statistics.HintsUsed.Should().Be(GameStatistics.MaxHints);
+        statistics.HintsRemaining.Should().Be(0);
     }
 
     [Fact]

--- a/src/backend/Tests/Domain/SudokuGameHintTests.cs
+++ b/src/backend/Tests/Domain/SudokuGameHintTests.cs
@@ -1,0 +1,185 @@
+using Sudoku.Domain.Entities;
+using Sudoku.Domain.Enums;
+using Sudoku.Domain.Events;
+using Sudoku.Domain.Exceptions;
+using Sudoku.Domain.ValueObjects;
+using UnitTests.Helpers.Factories;
+
+namespace UnitTests.Domain;
+
+public class SudokuGameHintTests : MoqBaseTestByType<SudokuGame>
+{
+    private static readonly SudokuPuzzle Solution = PuzzleFactory.GetSolvedPuzzle();
+
+    [Fact]
+    public void RevealHint_WithEmptyCells_FillsACellWithTheSolvedValue()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+
+        // Act
+        var (row, column, value) = sut.RevealHint(Solution);
+
+        // Assert
+        var cell = sut.GetCell(row, column);
+        cell.Value.Should().Be(value);
+        cell.Value.Should().Be(Solution.GetCell(row, column).Value);
+    }
+
+    [Fact]
+    public void RevealHint_MarksTheRevealedCellAsHint()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+
+        // Act
+        var (row, column, _) = sut.RevealHint(Solution);
+
+        // Assert
+        sut.GetCell(row, column).IsHint.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RevealHint_IncrementsHintsUsed()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+
+        // Act
+        sut.RevealHint(Solution);
+
+        // Assert
+        sut.Statistics.HintsUsed.Should().Be(1);
+        sut.Statistics.HintsRemaining.Should().Be(GameStatistics.MaxHints - 1);
+    }
+
+    [Fact]
+    public void RevealHint_RaisesHintRevealedEvent()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+
+        // Act
+        sut.RevealHint(Solution);
+
+        // Assert
+        sut.DomainEvents.Should().Contain(e => e is HintRevealedEvent);
+    }
+
+    [Fact]
+    public void RevealHint_LocksTheRevealedCell_SoMakeMoveThrows()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        var (row, column, _) = sut.RevealHint(Solution);
+
+        // Act
+        Action act = () => sut.MakeMove(row, column, 1);
+
+        // Assert
+        act.Should().Throw<CellIsFixedException>();
+    }
+
+    [Fact]
+    public void RevealHint_DoesNotAddToMoveHistory()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+
+        // Act
+        sut.RevealHint(Solution);
+
+        // Assert
+        sut.MoveHistory.Should().BeEmpty();
+        Action undo = () => sut.UndoLastMove();
+        undo.Should().Throw<NoMoveHistoryException>();
+    }
+
+    [Fact]
+    public void RevealHint_WhenHintLimitReached_ThrowsHintLimitReachedException()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        for (var i = 0; i < GameStatistics.MaxHints; i++)
+        {
+            sut.RevealHint(Solution);
+        }
+
+        // Act
+        Action act = () => sut.RevealHint(Solution);
+
+        // Assert
+        act.Should().Throw<HintLimitReachedException>();
+    }
+
+    [Fact]
+    public void RevealHint_WhenGameNotInProgress_ThrowsGameNotInProgressException()
+    {
+        // Arrange
+        var sut = GameFactory.CreateGameWithCells(CellsFactory.CreateEmptyCells());
+
+        // Act
+        Action act = () => sut.RevealHint(Solution);
+
+        // Assert
+        act.Should().Throw<GameNotInProgressException>();
+    }
+
+    [Fact]
+    public void RevealHint_WhenNoEmptyCells_ThrowsNoAvailableCellsForHintException()
+    {
+        // Arrange - all cells are fixed clues, leaving nothing to reveal
+        var sut = GameFactory.CreateGameWithCells(CellsFactory.CreateCompletedCells());
+        sut.StartGame();
+
+        // Act
+        Action act = () => sut.RevealHint(Solution);
+
+        // Assert
+        act.Should().Throw<NoAvailableCellsForHintException>();
+    }
+
+    [Fact]
+    public void ResetGame_AfterHint_ClearsRevealedCellAndResetsHintsUsed()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        var (row, column, _) = sut.RevealHint(Solution);
+
+        // Act
+        sut.ResetGame();
+
+        // Assert
+        var cell = sut.GetCell(row, column);
+        cell.IsHint.Should().BeFalse();
+        cell.HasValue.Should().BeFalse();
+        sut.Statistics.HintsUsed.Should().Be(0);
+    }
+
+    [Fact]
+    public void RevealHint_CompletingTheBoard_CompletesTheGame()
+    {
+        // Arrange - a board with a single empty cell and a matching solution
+        var completed = CellsFactory.CreateCompletedCells().ToList();
+        var cells = completed
+            .Select(c => c.Row == 0 && c.Column == 0 ? Cell.CreateEmpty(0, 0) : c)
+            .ToList();
+        var sut = GameFactory.CreateGameWithCells(cells);
+        sut.StartGame();
+        var solution = SudokuPuzzle.Create("solution", GameDifficulty.Easy, CellsFactory.CreateCompletedCells().ToList());
+
+        // Act
+        sut.RevealHint(solution);
+
+        // Assert
+        sut.Status.Should().Be(GameStatusEnum.Completed);
+        sut.DomainEvents.Should().Contain(e => e is GameCompletedEvent);
+    }
+
+    private static SudokuGame CreateStartedEmptyGame()
+    {
+        var game = GameFactory.CreateGameWithCells(CellsFactory.CreateEmptyCells());
+        game.StartGame();
+        return game;
+    }
+}

--- a/src/backend/Tests/Infrastructure/Mappers/SudokuGameMapperTests.cs
+++ b/src/backend/Tests/Infrastructure/Mappers/SudokuGameMapperTests.cs
@@ -1,0 +1,26 @@
+using Sudoku.Infrastructure.Mappers;
+using Sudoku.Infrastructure.Models;
+using UnitTests.Helpers.Factories;
+
+namespace UnitTests.Infrastructure.Mappers;
+
+public class SudokuGameMapperTests : MoqBaseTestByType<SudokuGameDocument>
+{
+    [Fact]
+    public void RoundTrip_PreservesHintCellsAndHintsUsed()
+    {
+        // Arrange - reveal a hint so the game has a hint cell and a non-zero HintsUsed
+        var game = GameFactory.CreateGameWithCells(CellsFactory.CreateEmptyCells());
+        game.StartGame();
+        var (row, column, _) = game.RevealHint(PuzzleFactory.GetSolvedPuzzle());
+
+        // Act
+        var document = SudokuGameMapper.ToDocument(game);
+        var restored = SudokuGameMapper.ToDomain(document);
+
+        // Assert
+        restored.GetCell(row, column).IsHint.Should().BeTrue();
+        restored.Statistics.HintsUsed.Should().Be(1);
+        restored.Statistics.HintsRemaining.Should().Be(game.Statistics.HintsRemaining);
+    }
+}

--- a/src/frontend/Sudoku.React/src/api/apiClient.ts
+++ b/src/frontend/Sudoku.React/src/api/apiClient.ts
@@ -96,6 +96,14 @@ export const apiClient = {
     return request(`/api/players/${profileId}/games/${gameId}`);
   },
 
+  getHint: async (profileId: string, gameId: string, playDuration: string): Promise<GameModel> => {
+    await request(`/api/players/${profileId}/games/${gameId}/actions/hint`, {
+      method: 'POST',
+      body: JSON.stringify({ playDuration }),
+    });
+    return request(`/api/players/${profileId}/games/${gameId}`);
+  },
+
   pauseGame: (profileId: string, gameId: string): Promise<void> =>
     request(`/api/players/${profileId}/games/${gameId}/status/pause`, { method: 'POST' }),
 

--- a/src/frontend/Sudoku.React/src/components/CellInput.module.css
+++ b/src/frontend/Sudoku.React/src/components/CellInput.module.css
@@ -66,6 +66,11 @@
   font-weight: 500;
 }
 
+.hint {
+  color: var(--accent);
+  font-weight: 600;
+}
+
 .invalidDigit {
   color: var(--error);
   font-weight: 600;

--- a/src/frontend/Sudoku.React/src/components/CellInput.tsx
+++ b/src/frontend/Sudoku.React/src/components/CellInput.tsx
@@ -40,7 +40,9 @@ export default function CellInput({
     ? styles.invalidDigit
     : cell.isFixed
       ? styles.given
-      : styles.entry;
+      : cell.isHint
+        ? styles.hint
+        : styles.entry;
 
   const showPencil = cell.possibleValues.length > 0 && !cell.hasValue;
 

--- a/src/frontend/Sudoku.React/src/components/GameControls.module.css
+++ b/src/frontend/Sudoku.React/src/components/GameControls.module.css
@@ -55,6 +55,7 @@
 }
 
 .actionBtn {
+  position: relative;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -69,6 +70,20 @@
   cursor: pointer;
   font-size: 17px;
   transition: background-color 0.15s ease, color 0.15s ease, opacity 0.15s ease;
+}
+
+.hintBadge {
+  position: absolute;
+  top: 3px;
+  right: 5px;
+  min-width: 15px;
+  padding: 0 4px;
+  font-size: 10px;
+  line-height: 15px;
+  text-align: center;
+  border-radius: 8px;
+  background-color: var(--accent);
+  color: var(--accent-ink);
 }
 
 .actionBtn:hover:not(:disabled) {

--- a/src/frontend/Sudoku.React/src/components/GameControls.test.tsx
+++ b/src/frontend/Sudoku.React/src/components/GameControls.test.tsx
@@ -9,9 +9,11 @@ function renderControls(overrides: Partial<React.ComponentProps<typeof GameContr
     cells: make81Cells(),
     pencilMode: false,
     canUndo: true,
+    hintsRemaining: 3,
     onNumberClick: vi.fn(),
     onErase: vi.fn(),
     onUndo: vi.fn(),
+    onHint: vi.fn(),
     onReset: vi.fn(),
     onTogglePencil: vi.fn(),
   };
@@ -34,9 +36,24 @@ describe('GameControls', () => {
     expect(screen.getByRole('button', { name: /pencil/i })).toBeInTheDocument();
   });
 
-  it('renders a disabled Hint button', () => {
-    renderControls();
+  it('renders an enabled Hint button showing remaining hints', () => {
+    renderControls({ hintsRemaining: 3 });
+    const hintButton = screen.getByRole('button', { name: /hint/i });
+    expect(hintButton).toBeEnabled();
+    expect(hintButton).toHaveTextContent('3');
+  });
+
+  it('disables the Hint button when no hints remain', () => {
+    renderControls({ hintsRemaining: 0 });
     expect(screen.getByRole('button', { name: /hint/i })).toBeDisabled();
+  });
+
+  it('calls onHint when the hint button is clicked', async () => {
+    const user = userEvent.setup();
+    const onHint = vi.fn();
+    renderControls({ onHint, hintsRemaining: 2 });
+    await user.click(screen.getByRole('button', { name: /hint/i }));
+    expect(onHint).toHaveBeenCalledOnce();
   });
 
   it('calls onNumberClick with the correct number', async () => {

--- a/src/frontend/Sudoku.React/src/components/GameControls.tsx
+++ b/src/frontend/Sudoku.React/src/components/GameControls.tsx
@@ -5,9 +5,11 @@ interface GameControlsProps {
   cells: CellModel[];
   pencilMode: boolean;
   canUndo: boolean;
+  hintsRemaining: number;
   onNumberClick: (value: number) => void;
   onErase: () => void;
   onUndo: () => void;
+  onHint: () => void;
   onReset: () => void;
   onTogglePencil: () => void;
 }
@@ -16,9 +18,11 @@ export default function GameControls({
   cells,
   pencilMode,
   canUndo,
+  hintsRemaining,
   onNumberClick,
   onErase,
   onUndo,
+  onHint,
   onReset,
   onTogglePencil,
 }: GameControlsProps) {
@@ -66,9 +70,16 @@ export default function GameControls({
           <i className="fa fa-pencil" />
           <span className={styles.actionLabel}>Pencil</span>
         </button>
-        <button type="button" className={styles.actionBtn} disabled title="Hints coming soon">
+        <button
+          type="button"
+          className={styles.actionBtn}
+          onClick={onHint}
+          disabled={hintsRemaining <= 0}
+          title={hintsRemaining > 0 ? `Reveal a cell (${hintsRemaining} left)` : 'No hints remaining'}
+        >
           <i className="fa fa-lightbulb" />
           <span className={styles.actionLabel}>Hint</span>
+          <span className={`${styles.hintBadge} tnum`}>{hintsRemaining}</span>
         </button>
         <button type="button" className={styles.actionBtn} onClick={onReset}>
           <i className="fa fa-trash-can" />

--- a/src/frontend/Sudoku.React/src/hooks/useGameService.test.ts
+++ b/src/frontend/Sudoku.React/src/hooks/useGameService.test.ts
@@ -9,6 +9,7 @@ vi.mock('../api/apiClient', () => ({
   apiClient: {
     getGames: vi.fn(),
     deleteGame: vi.fn(),
+    getHint: vi.fn(),
   },
 }));
 
@@ -43,6 +44,8 @@ const mockGames: GameModel[] = [
     statistics: {
       totalMoves: 5,
       invalidMoves: 0,
+      hintsUsed: 0,
+      hintsRemaining: 3,
       playDuration: '00:05:00',
     },
   },
@@ -61,6 +64,8 @@ const mockGames: GameModel[] = [
     statistics: {
       totalMoves: 15,
       invalidMoves: 2,
+      hintsUsed: 1,
+      hintsRemaining: 2,
       playDuration: '00:15:00',
     },
   },
@@ -79,6 +84,8 @@ const mockGames: GameModel[] = [
     statistics: {
       totalMoves: 25,
       invalidMoves: 5,
+      hintsUsed: 3,
+      hintsRemaining: 0,
       playDuration: '00:20:00',
     },
   },
@@ -325,6 +332,39 @@ describe('useGameService', () => {
 
       expect(apiClient.getGames).toHaveBeenCalledWith('test-player');
       expect(result.current.savedGames).toEqual([mockGames[0]]);
+    });
+  });
+
+  describe('requestHint', () => {
+    it('should call apiClient.getHint and set the current game', async () => {
+      const hintedGame = mockGames[0];
+      vi.mocked(apiClient.getHint).mockResolvedValue(hintedGame);
+
+      const { result } = renderHook(() => useGameService());
+
+      await act(async () => {
+        await result.current.requestHint('test-player', 'game-1', '00:01:00');
+      });
+
+      expect(apiClient.getHint).toHaveBeenCalledWith('test-player', 'game-1', '00:01:00');
+      expect(result.current.currentGame).toEqual(hintedGame);
+    });
+
+    it('should set gameError when the hint request fails', async () => {
+      vi.mocked(apiClient.getHint).mockRejectedValue(new Error('No hints remaining for this game'));
+
+      const { result } = renderHook(() => useGameService());
+
+      await act(async () => {
+        try {
+          await result.current.requestHint('test-player', 'game-1', '00:01:00');
+        } catch {
+          // expected
+        }
+      });
+
+      expect(result.current.gameError).toBe('No hints remaining for this game');
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to get hint:', expect.any(Error));
     });
   });
 

--- a/src/frontend/Sudoku.React/src/hooks/useGameService.ts
+++ b/src/frontend/Sudoku.React/src/hooks/useGameService.ts
@@ -23,6 +23,7 @@ export interface UseGameServiceReturn {
   resumeGame: (profileId: string, gameId: string) => Promise<void>;
   makeMove: (profileId: string, gameId: string, row: number, column: number, value: number | null, duration: string) => Promise<GameModel>;
   undoMove: (profileId: string, gameId: string) => Promise<GameModel>;
+  requestHint: (profileId: string, gameId: string, duration: string) => Promise<GameModel>;
   resetGame: (profileId: string, gameId: string) => Promise<GameModel>;
   addPossibleValue: (profileId: string, gameId: string, row: number, column: number, value: number) => Promise<GameModel>;
   removePossibleValue: (profileId: string, gameId: string, row: number, column: number, value: number) => Promise<GameModel>;
@@ -267,6 +268,25 @@ export function useGameService(): UseGameServiceReturn {
     }
   }, []);
 
+  const requestHint = useCallback(async (profileId: string, gameId: string, duration: string): Promise<GameModel> => {
+    if (!profileId || !gameId) {
+      throw new Error('Profile ID and game ID are required');
+    }
+
+    setGameError(null);
+
+    try {
+      const updatedGame = await apiClient.getHint(profileId, gameId, duration);
+      setCurrentGame(updatedGame);
+      return updatedGame;
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to get hint';
+      setGameError(errorMessage);
+      console.error('Failed to get hint:', err);
+      throw err;
+    }
+  }, []);
+
   const resetGame = useCallback(async (profileId: string, gameId: string): Promise<GameModel> => {
     if (!profileId || !gameId) {
       throw new Error('Profile ID and game ID are required');
@@ -364,6 +384,7 @@ export function useGameService(): UseGameServiceReturn {
     resumeGame,
     makeMove,
     undoMove,
+    requestHint,
     resetGame,
     addPossibleValue,
     removePossibleValue,

--- a/src/frontend/Sudoku.React/src/pages/GamePage.integration.test.tsx
+++ b/src/frontend/Sudoku.React/src/pages/GamePage.integration.test.tsx
@@ -72,7 +72,7 @@ beforeEach(() => {
     pauseGame: vi.fn().mockResolvedValue(undefined),
     resumeGame: vi.fn().mockResolvedValue(undefined),
     makeMove: vi.fn(),
-    undoMove: vi.fn(),
+    undoMove: vi.fn(), requestHint: vi.fn(),
     resetGame: vi.fn(),
     addPossibleValue: vi.fn(),
     removePossibleValue: vi.fn(),
@@ -106,7 +106,7 @@ describe('GamePage - New Architecture', () => {
       currentGame: null,
       isGameLoading: true,
       gameError: null,
-      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     
@@ -121,7 +121,7 @@ describe('GamePage - New Architecture', () => {
       currentGame: null,
       isGameLoading: false,
       gameError: 'Failed to load game',
-      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     
@@ -136,7 +136,7 @@ describe('GamePage - New Architecture', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: null, isGameLoading: false, gameError: null,
-      getGame: mockGetGame, pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: mockGetGame, pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     
@@ -164,7 +164,7 @@ describe('GamePage - New Architecture', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: null, isGameLoading: false, gameError: null,
-      getGame: mockGetGame, pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: mockGetGame, pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     

--- a/src/frontend/Sudoku.React/src/pages/GamePage.test.tsx
+++ b/src/frontend/Sudoku.React/src/pages/GamePage.test.tsx
@@ -13,7 +13,7 @@ vi.mock('../api/apiClient', () => ({
     deleteGame: vi.fn(),
     makeMove: vi.fn(),
     resetGame: vi.fn(),
-    undoMove: vi.fn(),
+    undoMove: vi.fn(), requestHint: vi.fn(),
     pauseGame: vi.fn(),
     resumeGame: vi.fn(),
     addPossibleValue: vi.fn(),
@@ -90,7 +90,7 @@ beforeEach(() => {
     pauseGame: vi.fn().mockResolvedValue(undefined),
     resumeGame: vi.fn().mockResolvedValue(undefined),
     makeMove: vi.fn(),
-    undoMove: vi.fn(),
+    undoMove: vi.fn(), requestHint: vi.fn(),
     resetGame: vi.fn(),
     addPossibleValue: vi.fn(),
     removePossibleValue: vi.fn(),
@@ -127,7 +127,7 @@ describe('GamePage - loading', () => {
       isGameLoading: false,
       gameError: null,
       getGame: vi.fn().mockResolvedValue(makeGame()),
-      pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), resetGame: vi.fn(),
+      pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     renderGamePage();
@@ -188,7 +188,7 @@ describe('GamePage - loading', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: null, isGameLoading: false, gameError: null,
-      getGame: mockGetGame, pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: mockGetGame, pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     renderGamePage();
@@ -205,7 +205,7 @@ describe('GamePage - after load', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: game, isGameLoading: false, gameError: null,
-      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     renderGamePage();
@@ -220,7 +220,7 @@ describe('GamePage - after load', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: game, isGameLoading: false, gameError: null,
-      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     renderGamePage();
@@ -235,7 +235,7 @@ describe('GamePage - after load', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: game, isGameLoading: false, gameError: null,
-      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     renderGamePage();
@@ -252,7 +252,7 @@ describe('GamePage - after load', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: null, isGameLoading: false, gameError: null,
-      getGame: mockGetGame, pauseGame: vi.fn(), resumeGame: mockResumeGame, makeMove: vi.fn(), undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: mockGetGame, pauseGame: vi.fn(), resumeGame: mockResumeGame, makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     renderGamePage('g1');
@@ -291,7 +291,7 @@ describe('GamePage - cell selection', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: game, isGameLoading: false, gameError: null,
-      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     renderGamePage();
@@ -313,7 +313,7 @@ describe('GamePage - keyboard navigation', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: game, isGameLoading: false, gameError: null,
-      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     renderGamePage();
@@ -342,7 +342,7 @@ describe('GamePage - number input', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: game, isGameLoading: false, gameError: null,
-      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: mockMakeMove, undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: mockMakeMove, undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     renderGamePage();
@@ -368,7 +368,7 @@ describe('GamePage - number input', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: game, isGameLoading: false, gameError: null,
-      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: mockMakeMove, undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: mockMakeMove, undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     renderGamePage();
@@ -391,7 +391,7 @@ describe('GamePage - erase', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: game, isGameLoading: false, gameError: null,
-      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: mockMakeMove, undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: mockMakeMove, undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     renderGamePage();
@@ -418,7 +418,7 @@ describe('GamePage - undo / reset', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: game, isGameLoading: false, gameError: null,
-      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: mockUndoMove, resetGame: vi.fn(),
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: mockUndoMove, requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     renderGamePage();
@@ -439,7 +439,7 @@ describe('GamePage - undo / reset', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: game, isGameLoading: false, gameError: null,
-      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), resetGame: mockResetGame,
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: mockResetGame,
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     renderGamePage();
@@ -461,7 +461,7 @@ describe('GamePage - home navigation', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: game, isGameLoading: false, gameError: null,
-      getGame: vi.fn(), pauseGame: mockPauseGame, resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: vi.fn(), pauseGame: mockPauseGame, resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     renderGamePage('g1');
@@ -483,7 +483,7 @@ describe('GamePage - pencil mode', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: game, isGameLoading: false, gameError: null,
-      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     renderGamePage();
@@ -507,7 +507,7 @@ describe('GamePage - pencil mode', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: game, isGameLoading: false, gameError: null,
-      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: mockAddPossibleValue, removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
     renderGamePage();
@@ -557,7 +557,7 @@ describe('GamePage - victory', () => {
       savedGames: [], isLoading: false, error: null, isLoaded: false,
       loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
       currentGame: game, isGameLoading: false, gameError: null,
-      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: mockMakeMove, undoMove: vi.fn(), resetGame: vi.fn(),
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: mockMakeMove, undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
       addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
     });
 

--- a/src/frontend/Sudoku.React/src/pages/GamePage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/GamePage.tsx
@@ -24,6 +24,7 @@ export default function GamePage() {
     resumeGame,
     makeMove,
     undoMove,
+    requestHint,
     resetGame,
     addPossibleValue,
     removePossibleValue,
@@ -149,7 +150,7 @@ export default function GamePage() {
   const handleNumberInput = async (value: number) => {
     if (!game || !selectedCell || !profileId) return;
     const cell = game.cells.find(c => c.row === selectedCell.row && c.column === selectedCell.column);
-    if (!cell || cell.isFixed) return;
+    if (!cell || cell.isFixed || cell.isHint) return;
 
     if (pencilMode) {
       await handleCellAction(game.cells, async () => {
@@ -169,7 +170,7 @@ export default function GamePage() {
   const handleErase = async () => {
     if (!game || !selectedCell || !profileId) return;
     const cell = game.cells.find(c => c.row === selectedCell.row && c.column === selectedCell.column);
-    if (!cell || cell.isFixed) return;
+    if (!cell || cell.isFixed || cell.isHint) return;
 
     if (pencilMode && cell.possibleValues.length > 0) {
       await handleCellAction(game.cells, () =>
@@ -185,6 +186,11 @@ export default function GamePage() {
   const handleUndo = async () => {
     if (!game || !profileId) return;
     await handleCellAction(game.cells, () => undoMove(profileId, game.id));
+  };
+
+  const handleHint = async () => {
+    if (!game || !profileId || game.statistics.hintsRemaining <= 0) return;
+    await handleCellAction(game.cells, () => requestHint(profileId, game.id, formatDuration(elapsedRef.current)));
   };
 
   const handleReset = async () => {
@@ -308,9 +314,11 @@ export default function GamePage() {
           cells={game.cells}
           pencilMode={pencilMode}
           canUndo={(game.moveHistory?.length ?? 0) > 0}
+          hintsRemaining={game.statistics.hintsRemaining}
           onNumberClick={handleNumberInput}
           onErase={handleErase}
           onUndo={handleUndo}
+          onHint={handleHint}
           onReset={handleReset}
           onTogglePencil={() => setPencilMode(p => !p)}
         />

--- a/src/frontend/Sudoku.React/src/test/helpers.ts
+++ b/src/frontend/Sudoku.React/src/test/helpers.ts
@@ -6,6 +6,7 @@ export function makeCell(overrides: Partial<CellModel> = {}): CellModel {
     column: 0,
     value: null,
     isFixed: false,
+    isHint: false,
     hasValue: false,
     possibleValues: [],
     ...overrides,
@@ -16,6 +17,8 @@ export function makeStats(overrides: Partial<GameStatisticsModel> = {}): GameSta
   return {
     totalMoves: 0,
     invalidMoves: 0,
+    hintsUsed: 0,
+    hintsRemaining: 3,
     playDuration: '00:00:00',
     ...overrides,
   };

--- a/src/frontend/Sudoku.React/src/types/index.ts
+++ b/src/frontend/Sudoku.React/src/types/index.ts
@@ -3,6 +3,7 @@ export interface CellModel {
   column: number;
   value: number | null;
   isFixed: boolean;
+  isHint: boolean;
   hasValue: boolean;
   possibleValues: number[];
 }
@@ -10,6 +11,8 @@ export interface CellModel {
 export interface GameStatisticsModel {
   totalMoves: number;
   invalidMoves: number;
+  hintsUsed: number;
+  hintsRemaining: number;
   playDuration: string;
 }
 


### PR DESCRIPTION
## Description

Implements the Hint System from #218. Players can request a hint that reveals one correct cell, limited to **3 hints per game** (all difficulties). Hints are computed **server-side** (server-authoritative) and the previously-disabled Zen-redesign Hint button is now wired up. Closes #218.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **Domain:** `Cell.IsHint` flag + `Cell.CreateHint()` factory (locked cell, distinct from original clues); `GameStatistics` gains `MaxHints=3`, `HintsUsed`, `HintsRemaining`, `RecordHint()`; `SudokuGame.RevealHint()` auto-picks a random empty cell, reveals & locks it, raises `HintRevealedEvent`, and completes the game if it fills the last cell. Reset clears hint cells; Undo never reverts them. New `HintLimitReachedException` / `NoAvailableCellsForHintException`.
- **Application:** `RequestHintCommand` + `RequestHintCommandHandler` — solves the puzzle from the **fixed clues only** (via `IPuzzleSolver`) so a wrong player entry can't make the hint unsolvable, then passes the solution to the domain (keeps the domain solver-free). DTOs expose `HintsUsed`/`HintsRemaining`/`IsHint`.
- **Infrastructure:** `HintsUsed` and `IsHint` persisted through the document + mapper (existing games default to 0/false).
- **API:** `POST /api/players/{profileId}/games/{gameId}/actions/hint` (returns 204; client re-fetches).
- **React:** `apiClient.getHint`, `useGameService.requestHint`, enabled Hint button with a remaining-count badge (disables at 0), and distinct accent styling for revealed cells.
- **Scoring:** only `HintsUsed` is tracked now; the difficulty-based scoring formula the issue mentions is intentionally deferred (no scoring system exists yet).

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

Verification:
- `dotnet build` (solution) — succeeded
- Backend tests — **670 passed** (new domain, handler, DTO, mapper, statistics, cell tests)
- Frontend `npm run test` — **161 passed**; `tsc --noEmit` clean
- `npm run lint` — no new issues (pre-existing errors unchanged)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)