### PR TITLE
Fix difficulty label, game-page widths, and stale saved-game stats

### DIFF
--- a/src/backend/Sudoku.Infrastructure/Mappers/SudokuGameMapper.cs
+++ b/src/backend/Sudoku.Infrastructure/Mappers/SudokuGameMapper.cs
@@ -14,7 +14,7 @@ public static class SudokuGameMapper
             GameId = game.Id.Value.ToString(),
             ProfileId = game.ProfileId.ToString(),
             DisplayName = game.DisplayName.Value,
-            Difficulty = game.Difficulty,
+            Difficulty = game.Difficulty.Name,
             Status = game.Status,
             Cells = game.GetCells().Select(ToDocument).ToList(),
             Statistics = ToDocument(game.Statistics),
@@ -44,11 +44,15 @@ public static class SudokuGameMapper
 
         var displayName = PlayerAlias.Create(string.IsNullOrEmpty(document.DisplayName) ? "Unknown" : document.DisplayName);
 
+        var difficulty = string.IsNullOrEmpty(document.Difficulty)
+            ? GameDifficulty.Easy
+            : GameDifficulty.FromName(document.Difficulty);
+
         var sudokuGame = SudokuGame.Reconstitute(
             GameId.Create(document.GameId),
             profileId,
             displayName,
-            document.Difficulty,
+            difficulty,
             document.Status,
             document.Statistics.ToDomain(),
             document.Cells.Select(ToDomain).ToList(),

--- a/src/backend/Sudoku.Infrastructure/Models/SudokuGameDocument.cs
+++ b/src/backend/Sudoku.Infrastructure/Models/SudokuGameDocument.cs
@@ -1,6 +1,7 @@
 using Newtonsoft.Json;
 using Sudoku.Domain.Enums;
 using Sudoku.Domain.ValueObjects;
+using Sudoku.Infrastructure.Serialization;
 
 namespace Sudoku.Infrastructure.Models;
 
@@ -19,7 +20,8 @@ public class SudokuGameDocument
     public string? DisplayName { get; set; }
 
     [JsonProperty("difficulty")]
-    public GameDifficulty Difficulty { get; set; } = GameDifficulty.Easy;
+    [JsonConverter(typeof(GameDifficultyStringConverter))]
+    public string Difficulty { get; set; } = GameDifficulty.Easy.Name;
 
     [JsonProperty("status")]
     public GameStatusEnum Status { get; set; }

--- a/src/backend/Sudoku.Infrastructure/Serialization/GameDifficultyStringConverter.cs
+++ b/src/backend/Sudoku.Infrastructure/Serialization/GameDifficultyStringConverter.cs
@@ -1,0 +1,34 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Sudoku.Infrastructure.Serialization;
+
+/// <summary>
+/// Serializes a game difficulty as a plain string. On read it also accepts the legacy
+/// value-object shape (<c>{ "value": n, "name": "..." }</c>) that older documents persisted,
+/// returning the difficulty name so existing saved games remain loadable.
+/// </summary>
+public class GameDifficultyStringConverter : JsonConverter<string?>
+{
+    public override string? ReadJson(JsonReader reader, Type objectType, string? existingValue, bool hasExistingValue, JsonSerializer serializer)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonToken.Null:
+                return null;
+            case JsonToken.String:
+                return (string?)reader.Value;
+            case JsonToken.StartObject:
+                var obj = JObject.Load(reader);
+                var name = obj["name"] ?? obj["Name"];
+                return name?.Value<string>();
+            default:
+                throw new JsonSerializationException($"Unexpected token {reader.TokenType} when reading difficulty.");
+        }
+    }
+
+    public override void WriteJson(JsonWriter writer, string? value, JsonSerializer serializer)
+    {
+        writer.WriteValue(value);
+    }
+}

--- a/src/backend/Tests/Infrastructure/Mappers/SudokuGameMapperTests.cs
+++ b/src/backend/Tests/Infrastructure/Mappers/SudokuGameMapperTests.cs
@@ -1,3 +1,4 @@
+using Sudoku.Domain.ValueObjects;
 using Sudoku.Infrastructure.Mappers;
 using Sudoku.Infrastructure.Models;
 using UnitTests.Helpers.Factories;
@@ -6,6 +7,25 @@ namespace UnitTests.Infrastructure.Mappers;
 
 public class SudokuGameMapperTests : MoqBaseTestByType<SudokuGameDocument>
 {
+    [Theory]
+    [InlineData("Easy")]
+    [InlineData("Medium")]
+    [InlineData("Hard")]
+    [InlineData("Expert")]
+    public void RoundTrip_PreservesDifficulty(string difficultyName)
+    {
+        // Arrange
+        var difficulty = GameDifficulty.FromName(difficultyName);
+        var game = GameFactory.CreateGameWithDifficulty(difficulty);
+
+        // Act
+        var document = SudokuGameMapper.ToDocument(game);
+        var restored = SudokuGameMapper.ToDomain(document);
+
+        // Assert
+        restored.Difficulty.Should().Be(difficulty);
+    }
+
     [Fact]
     public void RoundTrip_PreservesHintCellsAndHintsUsed()
     {

--- a/src/backend/Tests/Infrastructure/Serialization/GameDifficultyStringConverterTests.cs
+++ b/src/backend/Tests/Infrastructure/Serialization/GameDifficultyStringConverterTests.cs
@@ -1,0 +1,50 @@
+using Newtonsoft.Json;
+using Sudoku.Infrastructure.Models;
+
+namespace UnitTests.Infrastructure.Serialization;
+
+public class GameDifficultyStringConverterTests
+{
+    [Theory]
+    [InlineData("Easy")]
+    [InlineData("Medium")]
+    [InlineData("Hard")]
+    [InlineData("Expert")]
+    public void Document_JsonRoundTrip_PreservesDifficulty(string difficulty)
+    {
+        // Arrange
+        var document = new SudokuGameDocument { Difficulty = difficulty };
+
+        // Act
+        var json = JsonConvert.SerializeObject(document);
+        var restored = JsonConvert.DeserializeObject<SudokuGameDocument>(json);
+
+        // Assert
+        restored!.Difficulty.Should().Be(difficulty);
+    }
+
+    [Fact]
+    public void Document_SerializesDifficultyAsPlainString()
+    {
+        // Arrange
+        var document = new SudokuGameDocument { Difficulty = "Medium" };
+
+        // Act
+        var json = JsonConvert.SerializeObject(document);
+
+        // Assert
+        json.Should().Contain("\"difficulty\":\"Medium\"");
+    }
+
+    [Theory]
+    [InlineData("{\"difficulty\":{\"value\":2,\"name\":\"Medium\"}}", "Medium")]
+    [InlineData("{\"difficulty\":{\"Value\":3,\"Name\":\"Hard\"}}", "Hard")]
+    public void Document_LegacyObjectForm_ReadsDifficultyName(string json, string expected)
+    {
+        // Act - older documents persisted difficulty as a { value, name } object
+        var restored = JsonConvert.DeserializeObject<SudokuGameDocument>(json);
+
+        // Assert
+        restored!.Difficulty.Should().Be(expected);
+    }
+}

--- a/src/frontend/Sudoku.React/src/components/GameControls.module.css
+++ b/src/frontend/Sudoku.React/src/components/GameControls.module.css
@@ -2,8 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  max-width: 440px;
-  margin: 0 auto;
+  width: 100%;
 }
 
 /* Number pad: single row of 9 */

--- a/src/frontend/Sudoku.React/src/components/GameStats.module.css
+++ b/src/frontend/Sudoku.React/src/components/GameStats.module.css
@@ -2,8 +2,7 @@
   background-color: var(--surface);
   border: 1px solid var(--line);
   border-radius: 14px;
-  max-width: 440px;
-  margin: 0 auto;
+  width: 100%;
   padding: 12px 16px;
   box-shadow: 0 2px 12px var(--shadow);
 }

--- a/src/frontend/Sudoku.React/src/hooks/useGameService.test.ts
+++ b/src/frontend/Sudoku.React/src/hooks/useGameService.test.ts
@@ -113,9 +113,10 @@ describe('useGameService', () => {
   });
 
   describe('loadGames', () => {
-    it('should load games from localStorage cache first', async () => {
+    it('should paint cached games first, then revalidate from the API', async () => {
       const cachedGames = JSON.stringify(mockGames);
       mockLocalStorage.getItem.mockReturnValue(cachedGames);
+      vi.mocked(apiClient.getGames).mockResolvedValue(mockGames);
 
       const { result } = renderHook(() => useGameService());
 
@@ -124,15 +125,40 @@ describe('useGameService', () => {
       });
 
       expect(mockLocalStorage.getItem).toHaveBeenCalledWith('savedGames');
-      expect(apiClient.getGames).not.toHaveBeenCalled();
+      // Stale-while-revalidate: the cache is only a fast first paint; the API is
+      // still queried so stats (moves/time/difficulty) reflect server truth.
+      expect(apiClient.getGames).toHaveBeenCalledWith('test-player');
       expect(result.current.savedGames).toEqual([mockGames[0], mockGames[2]]); // Only non-completed games
       expect(result.current.isLoaded).toBe(true);
       expect(result.current.isLoading).toBe(false);
     });
 
+    it('should overwrite stale cached stats with fresh API data', async () => {
+      const staleGame: GameModel = {
+        ...mockGames[0],
+        statistics: { ...mockGames[0].statistics, totalMoves: 0, playDuration: '00:00:00' },
+      };
+      const freshGame: GameModel = {
+        ...mockGames[0],
+        statistics: { ...mockGames[0].statistics, totalMoves: 12, playDuration: '00:08:00' },
+      };
+      mockLocalStorage.getItem.mockReturnValue(JSON.stringify([staleGame]));
+      vi.mocked(apiClient.getGames).mockResolvedValue([freshGame]);
+
+      const { result } = renderHook(() => useGameService());
+
+      await act(async () => {
+        await result.current.loadGames('test-player');
+      });
+
+      expect(apiClient.getGames).toHaveBeenCalledWith('test-player');
+      expect(result.current.savedGames).toEqual([freshGame]);
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith('savedGames', JSON.stringify([freshGame]));
+    });
+
     it('should fallback to API when no cached games exist', async () => {
       mockLocalStorage.getItem.mockReturnValue(null);
-      (apiClient.getGames as any).mockResolvedValue(mockGames);
+      vi.mocked(apiClient.getGames).mockResolvedValue(mockGames);
 
       const { result } = renderHook(() => useGameService());
 
@@ -149,7 +175,7 @@ describe('useGameService', () => {
 
     it('should fallback to API when cached data is corrupted', async () => {
       mockLocalStorage.getItem.mockReturnValue('invalid-json');
-      (apiClient.getGames as any).mockResolvedValue(mockGames);
+      vi.mocked(apiClient.getGames).mockResolvedValue(mockGames);
 
       const { result } = renderHook(() => useGameService());
 
@@ -165,7 +191,7 @@ describe('useGameService', () => {
     it('should force refresh from API when forceRefresh is true', async () => {
       const cachedGames = JSON.stringify(mockGames);
       mockLocalStorage.getItem.mockReturnValue(cachedGames);
-      (apiClient.getGames as any).mockResolvedValue([mockGames[0]]);
+      vi.mocked(apiClient.getGames).mockResolvedValue([mockGames[0]]);
 
       const { result } = renderHook(() => useGameService());
 
@@ -180,7 +206,7 @@ describe('useGameService', () => {
 
     it('should handle API errors gracefully', async () => {
       mockLocalStorage.getItem.mockReturnValue(null);
-      (apiClient.getGames as any).mockRejectedValue(new Error('API Error'));
+      vi.mocked(apiClient.getGames).mockRejectedValue(new Error('API Error'));
 
       const { result } = renderHook(() => useGameService());
 
@@ -210,7 +236,7 @@ describe('useGameService', () => {
     it('should prevent multiple simultaneous loads', async () => {
       mockLocalStorage.getItem.mockReturnValue(null);
       let callCount = 0;
-      (apiClient.getGames as any).mockImplementation(() => {
+      vi.mocked(apiClient.getGames).mockImplementation(() => {
         callCount++;
         return new Promise(resolve => setTimeout(() => resolve(mockGames), 100));
       });
@@ -238,6 +264,8 @@ describe('useGameService', () => {
       // Setup initial state with cached games
       const cachedGames = JSON.stringify(mockGames);
       mockLocalStorage.getItem.mockReturnValue(cachedGames);
+      // loadGames now always revalidates from the API (stale-while-revalidate)
+      vi.mocked(apiClient.getGames).mockResolvedValue(mockGames);
     });
 
     it('should delete game from API and update local state', async () => {
@@ -293,7 +321,7 @@ describe('useGameService', () => {
       const { result } = renderHook(() => useGameService());
 
       // Load initial games from API
-      (apiClient.getGames as any).mockResolvedValue(mockGames);
+      vi.mocked(apiClient.getGames).mockResolvedValue(mockGames);
       await act(async () => {
         await result.current.loadGames('test-player');
       });
@@ -322,7 +350,7 @@ describe('useGameService', () => {
     it('should force reload games from API', async () => {
       const cachedGames = JSON.stringify(mockGames);
       mockLocalStorage.getItem.mockReturnValue(cachedGames);
-      (apiClient.getGames as any).mockResolvedValue([mockGames[0]]);
+      vi.mocked(apiClient.getGames).mockResolvedValue([mockGames[0]]);
 
       const { result } = renderHook(() => useGameService());
 
@@ -401,7 +429,7 @@ describe('useGameService', () => {
       const getGamesPromise = new Promise<GameModel[]>(resolve => {
         resolveGetGames = resolve;
       });
-      (apiClient.getGames as any).mockReturnValue(getGamesPromise);
+      vi.mocked(apiClient.getGames).mockReturnValue(getGamesPromise);
 
       const { result } = renderHook(() => useGameService());
 

--- a/src/frontend/Sudoku.React/src/hooks/useGameService.ts
+++ b/src/frontend/Sudoku.React/src/hooks/useGameService.ts
@@ -62,7 +62,9 @@ export function useGameService(): UseGameServiceReturn {
     setError(null);
 
     try {
-      // First check localStorage if not forcing refresh
+      // Stale-while-revalidate: paint cached games immediately (if any) for a fast
+      // first render, then always fetch from the API below to refresh with the
+      // authoritative server state (move count, play duration, difficulty, etc.).
       if (!forceRefresh) {
         const cachedGames = localStorage.getItem('savedGames');
         if (cachedGames) {
@@ -72,8 +74,6 @@ export function useGameService(): UseGameServiceReturn {
               const availableGames = parsedGames.filter(g => g.status !== 'Completed');
               setSavedGames(availableGames);
               setIsLoaded(true);
-              setIsLoading(false);
-              return;
             }
           } catch {
             localStorage.removeItem('savedGames');


### PR DESCRIPTION
## Description

Fixes five reported bugs spanning the React frontend and the backend persistence layer.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- **Difficulty always "Easy" (game header + saved-games list):** `SudokuGameDocument.Difficulty` stored the `GameDifficulty` value object, which Newtonsoft (Cosmos serializer) cannot reconstruct (private ctor, get-only props), so every game read back defaulted to `Easy`. Now stored as a `string` (mirroring `SudokuPuzzleDocument`), with the mapper using `GameDifficulty.FromName(...)`. Added `GameDifficultyStringConverter` so existing documents in the legacy `{value,name}` object form still load and self-correct on next save.
- **Game stats bar too narrow / number buttons too small:** removed `margin: 0 auto` (which overrode the flex column's `stretch`) and set `width: 100%` on `.gameStats` and `.controls`, so both now span the full board width.
- **Saved games always show 0 time / 0 moves:** `loadGames` short-circuited on a stale `localStorage` cache written at create time and never updated during play. Converted to stale-while-revalidate — the cache still paints instantly, but the API is always re-queried so move count, play duration, and difficulty reflect server truth.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

Backend: full suite **681/681** pass. Added a mapper round-trip test across all four difficulties and a JSON round-trip test that reproduces the original bug (difficulty survives Newtonsoft serialization; legacy object form still reads correctly). Frontend: `npm run build` succeeds, **18/18** `useGameService` tests pass, including a new "overwrite stale cached stats with fresh API data" test.

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)