### PR TITLE
Update NuGet packages to latest and fix Functions Cosmos DI

### DIFF
--- a/src/backend/Sudoku.Api/Sudoku.Api.csproj
+++ b/src/backend/Sudoku.Api/Sudoku.Api.csproj
@@ -11,14 +11,15 @@
 
   <ItemGroup>
     <PackageReference Include="Aspire.Azure.Security.KeyVault" Version="13.4.6" />
-    <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.4.3" />
-    <PackageReference Include="MediatR" Version="14.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.4.6" />
+    <PackageReference Include="MediatR" Version="14.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.10.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/backend/Sudoku.Application/Sudoku.Application.csproj
+++ b/src/backend/Sudoku.Application/Sudoku.Application.csproj
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="14.1.0" />
+    <PackageReference Include="MediatR" Version="14.2.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/backend/Sudoku.Functions/Program.cs
+++ b/src/backend/Sudoku.Functions/Program.cs
@@ -5,6 +5,7 @@ using Sudoku.Functions.Services;
 using Sudoku.Infrastructure.Configuration;
 
 var builder = FunctionsApplication.CreateBuilder(args);
+builder.AddAzureCosmosClient("CosmosDb");
 builder.Services.AddInfrastructureServices(builder.Configuration);
 builder.Services.AddScoped<IPuzzlePoolSeeder, PuzzlePoolSeeder>();
 builder.Build().Run();

--- a/src/backend/Sudoku.Functions/Sudoku.Functions.csproj
+++ b/src/backend/Sudoku.Functions/Sudoku.Functions.csproj
@@ -10,11 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
+    <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.4.6" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventGrid" Version="3.4.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5">
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventGrid" Version="3.6.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/backend/Sudoku.Infrastructure/Sudoku.Infrastructure.csproj
+++ b/src/backend/Sudoku.Infrastructure/Sudoku.Infrastructure.csproj
@@ -14,17 +14,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.4.3" />
+    <PackageReference Include="Aspire.Microsoft.Azure.Cosmos" Version="13.4.6" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.28.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.60.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.14.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="System.Text.Json" Version="10.0.8" />
+    <PackageReference Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/src/backend/Sudoku.McpServer/Sudoku.McpServer.csproj
+++ b/src/backend/Sudoku.McpServer/Sudoku.McpServer.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Monitor.Query" Version="1.7.1" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/backend/Sudoku.ServiceDefaults/Sudoku.ServiceDefaults.csproj
+++ b/src/backend/Sudoku.ServiceDefaults/Sudoku.ServiceDefaults.csproj
@@ -11,12 +11,12 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.5.0" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="8.5.0" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />

--- a/src/backend/Tests/UnitTests.csproj
+++ b/src/backend/Tests/UnitTests.csproj
@@ -12,13 +12,13 @@
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageReference Include="bunit" Version="2.7.2" />
-    <PackageReference Include="DepenMock.Moq" Version="3.1.0" />
-    <PackageReference Include="DepenMock.XUnit.V3" Version="3.1.0" />
+    <PackageReference Include="DepenMock.Moq" Version="4.0.0" />
+    <PackageReference Include="DepenMock.XUnit.V3" Version="4.0.0" />
     <PackageReference Include="FluentAssertions" Version="8.10.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
## Description

Brings all direct NuGet `PackageReference` versions across the backend up to their latest releases. Resolves a **High-severity security advisory** flagged during `dotnet restore` and fixes a latent DI misconfiguration in the Functions host that the `Microsoft.Azure.Functions.Worker` upgrade exposed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Other (please describe): dependency updates

## Changes Made

- **Security:** Pinned `Microsoft.OpenApi` to `2.10.0` in `Sudoku.Api` to resolve [GHSA-v5pm-xwqc-g5wc](https://github.com/advisories/GHSA-v5pm-xwqc-g5wc) (was transitively resolving to vulnerable `2.4.1` via Swashbuckle).
- **Test framework:** `DepenMock.Moq` / `DepenMock.XUnit.V3` `3.1.0 → 4.0.0` (major bump; all 681 tests pass with no test-code changes).
- **Other bumps:** MediatR `14.1→14.2`, Aspire.* `13.4.3→13.4.6`, Swashbuckle `10.1.7→10.2.3`, `Microsoft.Azure.Functions.Worker` `2.0.0→2.52.0` (+ EventGrid/Sdk), OpenTelemetry `1.15.x→1.16.0`, `Microsoft.Extensions.*` `10.0.8→10.0.9`, Azure.Storage.Blobs, Microsoft.Azure.Cosmos, ModelContextProtocol `1.3→1.4`, Microsoft.NET.Test.Sdk `18.6→18.7`.
- **DI fix:** Registered `CosmosClient` in the Functions host (`builder.AddAzureCosmosClient("CosmosDb")`) + added the `Aspire.Microsoft.Azure.Cosmos` package. The newer Worker SDK validates the DI container on build; `AddInfrastructureServices` registers Cosmos services that depend on `CosmosClient` without registering the client itself (the API already did this separately), so the host now failed fast at startup.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

`dotnet build` — 0 errors. `dotnet test` — 681 passed, 0 failed. `dotnet list package --vulnerable --include-transitive` — no vulnerable packages. The Functions DI fix was verified by reproducing the exact container-validation failure and confirming the registration resolves it.

## Follow-up (not addressed here)

- `Azure.Monitor.Query` 1.7.1 (McpServer) and `Aspire.Hosting.NodeJs` 9.5.2 (AppHost) are **deprecated**; migrating to their successors requires code changes — left for a separate PR.
- `System.Text.Json` in `Sudoku.Infrastructure` emits `NU1510` (reference likely unnecessary — provided by the framework); candidate for removal.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
