### PR TITLE
Migrate Cosmos DB prod off free tier to serverless

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -234,7 +234,9 @@ jobs:
           RG="rg-xenobiasoft-sudoku-prod-westus2"
           APP="${AZURE_FUNCTIONS_NAME}"
           FLEX_PLAN="XenobiasoftFunctionsPlan-prod"
-          COSMOS="cosmos-sudoku-prod"
+          # Kept in sync with COSMOS_ACCOUNT_NAME in scripts/assign-roles.sh —
+          # migrated off the free tier (2026-07) to cosmos-sudoku-prod2.
+          COSMOS="cosmos-sudoku-prod2"
 
           # Existence via an RG-scoped list + client-side filter (returns an
           # empty string / exit 0 when absent, so `set -e` only trips on a real

--- a/docs/runbooks/cosmos-db-tier-migration.md
+++ b/docs/runbooks/cosmos-db-tier-migration.md
@@ -3,7 +3,7 @@
 | Field | Value |
 |---|---|
 | **Date** | 2026-07-09 |
-| **Status** | Code/config changes staged on branch `feature/cosmos-tier-migration` — not merged. No Azure-side step (Phases 0-8) has been executed. |
+| **Status** | Code/config changes staged on branch `feature/cosmos-tier-migration` — not merged. Phase 0 complete (see below). Phases 1-9 not yet executed. |
 | **Owner** | Project maintainer |
 | **Related** | [ADR-004 — Cosmos DB as persistence backend](../adr/ADR-004-cosmosdb.md), [.claude/rules/rbac-role-assignments.md](../../.claude/rules/rbac-role-assignments.md) |
 
@@ -25,6 +25,16 @@ These file changes exist on the feature branch and require no further edits. Eve
 The `CosmosClient` is constructed by Aspire's `builder.AddAzureCosmosClient("CosmosDb")` (`src/backend/Sudoku.Api/Program.cs:36`), which resolves the **connection string** `ConnectionStrings:CosmosDb`. In production that value comes from the Key Vault secret `ConnectionStrings--CosmosDb` in `kv-xenobiasoft-prod`, loaded by `AddAzureKeyVault` (`Program.cs:28`). Key Vault's configuration provider is registered *after* the App Configuration provider, so it wins.
 
 **The cutover is therefore a Key Vault secret change (Phase 5.3), not an App Config change.** If you had flipped only the App Config key, the cutover would have appeared to succeed, the API would have kept serving from `cosmos-sudoku-prod`, Phase 6 validation would have looked perfectly clean — and Phase 8's `az cosmosdb delete` would have been what finally took production down.
+
+### The API authenticates with an account key, not managed identity
+
+Phase 0 confirmed the secret holds a **full connection string** of the form `AccountEndpoint=…;AccountKey=…`. Three consequences:
+
+- **`CosmosDb:UseManagedIdentity = true` in App Configuration is misleading.** It does not select credentials. `CosmosDbOptions.UseManagedIdentity` is read in exactly one place — `CosmosDbService.cs:182` — where it gates *container auto-creation*. Cosmos authentication is whatever the connection string implies, and it implies key auth.
+- **The Cosmos data-plane RBAC grants in `scripts/assign-roles.sh` are vestigial for the API.** They're harmless, and `Sudoku.Functions` may still depend on them, so leave them in place. But they are not what lets the API read and write.
+- **`disableLocalAuth` must stay `false` on the new account** (it is — `storage.bicep:170`). Setting it `true` would break the API instantly, since key auth would be refused.
+
+Phase 5.3 must therefore carry the **new account's key**, not just its endpoint. And because the key is embedded in the secret, rotating either account's keys out-of-band will break the app until the secret is updated.
 
 ## Why
 
@@ -48,21 +58,16 @@ Decisions locked in for this plan:
 - No TTL on any container, and no ETag/optimistic-concurrency usage, so an upsert-based copy is safe.
 - `infra/params/staging.bicepparam` uses a separate, non-free account and leaves `cosmosDbServerless` at its `false` default — staging is unaffected.
 
-## Phase 0 — Confirm the Key Vault secret (do this first)
-
-Everything downstream depends on this secret's exact name and value format.
+## Phase 0 — Confirm the Key Vault secret ✅ complete
 
 ```
 az keyvault secret list --vault-name kv-xenobiasoft-prod --query "[].name" -o tsv
 az keyvault secret show --vault-name kv-xenobiasoft-prod --name ConnectionStrings--CosmosDb --query value -o tsv
 ```
 
-Two possible formats, and they change Phase 5.3:
+**Result:** the secret `ConnectionStrings--CosmosDb` holds a full connection string, `AccountEndpoint=https://cosmos-sudoku-prod.documents.azure.com:443/;AccountKey=…`. The API is on **key auth**. See the warning section above for what that implies.
 
-- **Bare endpoint URI** (`https://cosmos-sudoku-prod.documents.azure.com:443/`) — Aspire treats it as an `AccountEndpoint` and authenticates with `DefaultAzureCredential`. Consistent with the managed-identity grants in `assign-roles.sh`. Cutover swaps the host and nothing else.
-- **Full connection string** (`AccountEndpoint=…;AccountKey=…`) — the API is using **key auth**, the Cosmos RBAC grants are vestigial, and the cutover must also carry the *new account's* key.
-
-Confirm nothing else supplies the endpoint:
+Optionally confirm nothing else supplies the endpoint:
 ```
 az webapp config appsettings list --name XenobiasoftSudokuApi-prod \
   -g rg-xenobiasoft-sudoku-prod-westus2 --query "[?contains(name,'Cosmos')]"
@@ -104,7 +109,9 @@ bash scripts/assign-roles.sh
 ```
 It's idempotent and grants Cosmos Data Contributor to the API app, Functions app, and your developer principal. It also runs automatically as the last step of `deploy-infra` in CI, so a normal `main` push after Phase 1 applies it for you.
 
-**Cosmos data-plane role assignments propagate slowly** — typically a few minutes, occasionally much longer. Do not proceed to Phase 3 until a data-plane read from your developer principal succeeds against the new account. Verify the assignments exist:
+Since Phase 0 established that the API authenticates with an account key, these grants are **not** on the critical path for the cutover — the API would work even if they hadn't propagated. Run the script anyway: it keeps the new account's grants consistent with the old, and `Sudoku.Functions` (whose Cosmos credential source is unverified — see Phase 1 step 4) may depend on them.
+
+Cosmos data-plane role assignments propagate slowly, typically a few minutes. Verify they landed:
 ```
 az cosmosdb sql role assignment list --account-name cosmos-sudoku-prod2 -g rg-xenobiasoft-sudoku-prod-westus2 -o table
 ```
@@ -157,13 +164,25 @@ python scripts/migrate-cosmos-data.py \
 
 Run it once with `--dry-run --prune` first and read the list of documents it would delete.
 
-**5.3 — Flip the Key Vault secret.** This is the actual cutover. Preserve whatever value format Phase 0 revealed:
+**5.3 — Flip the Key Vault secret.** This is the actual cutover. Phase 0 established the value is a full connection string, so it must carry the new account's **endpoint and key**.
+
+First record the current value — you need it verbatim to roll back (Phase 7), and once Phase 8 deletes the old account its key dies with it:
 ```
+az keyvault secret show --vault-name kv-xenobiasoft-prod \
+  --name ConnectionStrings--CosmosDb --query value -o tsv
+```
+Keep it somewhere outside the repo. Key Vault also retains the prior version automatically — `az keyvault secret list-versions --vault-name kv-xenobiasoft-prod --name ConnectionStrings--CosmosDb` — so this is belt-and-braces.
+
+Then fetch the new account's key and write the new secret:
+```
+NEW_KEY=$(az cosmosdb keys list --name cosmos-sudoku-prod2 \
+  -g rg-xenobiasoft-sudoku-prod-westus2 --query primaryMasterKey -o tsv)
+
 az keyvault secret set --vault-name kv-xenobiasoft-prod \
   --name ConnectionStrings--CosmosDb \
-  --value "https://cosmos-sudoku-prod2.documents.azure.com:443/"
+  --value "AccountEndpoint=https://cosmos-sudoku-prod2.documents.azure.com:443/;AccountKey=${NEW_KEY};"
 ```
-If Phase 0 showed a full `AccountEndpoint=…;AccountKey=…` connection string, supply the same shape with the new account's endpoint and key.
+Match the old value's exact shape (trailing `;`, any `Database=` segment) rather than assuming the form above. `az keyvault secret set` writes the value as a command-line argument, so it will land in your shell history — clear it afterwards.
 
 Optionally also run `scripts/set-app-config.sh` (manual-only, not part of CI) so the dead `CosmosDb:AccountEndpoint` key isn't left stale. It changes nothing functionally.
 
@@ -182,32 +201,47 @@ The restart is **required**, not merely advisable: the Key Vault configuration p
 
 ## Phase 6 — Post-cutover validation
 
-- Watch Application Insights / logs for `CosmosException` or the `InvalidOperationException` thrown by `CosmosDbService.InitializeCosmosDbAsync` (missing database/container) for the first hour of real traffic.
+- **Confirm you are actually on the new account.** The failure mode this runbook exists to prevent is a cutover that silently didn't happen — and a cutover that didn't happen produces *no errors at all*. `CosmosDbService.InitializeCosmosDbAsync` logs the endpoint it connected to (`CosmosDbService.cs:180`), so check it directly:
+  ```
+  az webapp log tail --name XenobiasoftSudokuApi-prod -g rg-xenobiasoft-sudoku-prod-westus2 \
+    | grep "Initializing CosmosDB at endpoint"
+  ```
+  It must name `cosmos-sudoku-prod2`. Corroborate with metrics: requests on the new account non-zero, requests on the old account dropping to zero.
+- Watch Application Insights / logs for `CosmosException` or the `InvalidOperationException` thrown by `InitializeCosmosDbAsync` (missing database/container) for the first hour of real traffic. A `401`/`403` here means the connection string's key doesn't match the new account.
 - Confirm the new account's metrics show request charges (serverless: per-operation RU, no throttling).
-- **Confirm you are actually on the new account** — the failure mode this runbook exists to prevent is a cutover that silently didn't happen. Check the new account's metrics show non-zero requests, and the old account's drop to zero.
 - Leave `cosmos-sudoku-prod` **running and untouched** — this is your rollback path.
 
 ## Phase 7 — Rollback (if something's wrong post-cutover)
 
-Set the Key Vault secret back to the old account's endpoint and restart the API:
+Restore the connection string you recorded in Phase 5.3 — endpoint **and** the old account's key — then restart the API:
 ```
 az keyvault secret set --vault-name kv-xenobiasoft-prod \
   --name ConnectionStrings--CosmosDb \
-  --value "https://cosmos-sudoku-prod.documents.azure.com:443/"
+  --value "<the exact value captured in Phase 5.3>"
 az webapp restart --name XenobiasoftSudokuApi-prod -g rg-xenobiasoft-sudoku-prod-westus2
 ```
+If you didn't capture it, recover the previous version:
+```
+az keyvault secret list-versions --vault-name kv-xenobiasoft-prod --name ConnectionStrings--CosmosDb -o table
+az keyvault secret show --vault-name kv-xenobiasoft-prod --name ConnectionStrings--CosmosDb --version <prior-version-id> --query value -o tsv
+```
+Confirm the rollback took using the endpoint log line from Phase 6.
+
 Any writes that landed on the new account during the failed window must be manually replayed back to the old account (same script, endpoints reversed, with `--since` set to the cutover epoch) before re-attempting. This is the cost of the maintenance-window approach vs. dual-write — keep the window short.
 
 ## Phase 8 — Decommission the old account
 
-Only after at least 1-2 weeks of clean operation on the new account, and only once Phase 6 has positively confirmed traffic is hitting `cosmos-sudoku-prod2`:
+Only after at least 1-2 weeks of clean operation on the new account, and only once Phase 6 has **positively confirmed via the endpoint log line** that traffic is hitting `cosmos-sudoku-prod2`. This is the irreversible step, and the whole point of Phase 6's check is to stop you taking it while the API is quietly still on the old account.
 
 1. `az cosmosdb delete --name cosmos-sudoku-prod --resource-group rg-xenobiasoft-sudoku-prod-westus2`
 2. This also frees the subscription's one free-tier slot.
 
+After this, Phase 7 rollback is gone: the old account's access key dies with the account, so the connection string you saved is worthless.
+
 ## Phase 9 — Cleanup
 
-- **Remove the dead Cosmos config.** `CosmosDbOptions.AccountEndpoint`, `.DisableSslValidation`, and `.ConnectionMode` are bound but never read. The matching App Config keys (`set-app-config.sh`) and the `CosmosDb__AccountEndpoint` / `CosmosDb__UseManagedIdentity` app settings in `compute.bicep` and `functions.bicep` are all inert. Deleting them would have prevented the entire class of confusion this runbook's warning section describes.
+- **Remove the dead Cosmos config.** `CosmosDbOptions.AccountEndpoint`, `.DisableSslValidation`, and `.ConnectionMode` are bound but never read, as is the `CosmosDb__AccountEndpoint` app setting pushed by `compute.bicep` and `functions.bicep`. Deleting them would have prevented the entire class of confusion this runbook's warning section describes.
+- **Decide on Cosmos authentication.** The API uses an account key while `CosmosDb:UseManagedIdentity` reads `true` — a flag that only gates container auto-creation (`CosmosDbService.cs:182`) and has nothing to do with credentials. The managed identities already hold Cosmos Data Contributor via `assign-roles.sh`, so switching the Key Vault secret to a bare endpoint URI would let `DefaultAzureCredential` take over and remove the embedded key entirely. Worth doing as a follow-up, but **not** during this migration — one variable at a time.
 - Clarify how `Sudoku.Functions` obtains `ConnectionStrings:CosmosDb`; it registers a `CosmosClient` but no Key Vault or App Configuration provider.
 - Remove the now-unused `cosmosDbEnableFreeTier` parameter from `infra/main.bicep` and `infra/modules/storage.bicep`, or leave it defaulted to `false` — harmless either way.
 - Cosmos account names are immutable, so the `2` suffix is permanent short of another full migration. Not worth doing.

--- a/docs/runbooks/cosmos-db-tier-migration.md
+++ b/docs/runbooks/cosmos-db-tier-migration.md
@@ -1,0 +1,221 @@
+# Runbook — Migrating `cosmos-sudoku-prod` from Free Tier to Paid (Serverless)
+
+| Field | Value |
+|---|---|
+| **Date** | 2026-07-09 |
+| **Status** | Code/config changes staged on branch `feature/cosmos-tier-migration` — not merged. No Azure-side step (Phases 0-8) has been executed. |
+| **Owner** | Project maintainer |
+| **Related** | [ADR-004 — Cosmos DB as persistence backend](../adr/ADR-004-cosmosdb.md), [.claude/rules/rbac-role-assignments.md](../../.claude/rules/rbac-role-assignments.md) |
+
+## What's already done in this repo
+
+These file changes exist on the feature branch and require no further edits. Everything else below is an Azure CLI step you must run yourself — this environment has no Azure credentials.
+
+- `infra/main.bicep` / `infra/modules/storage.bicep`: added a `cosmosDbServerless` param. When `true`, the account gets the `EnableServerless` capability, the `capacity.totalThroughputLimit` property is omitted entirely (serverless rejects an explicit throughput cap), `isZoneRedundant` is forced off (serverless is single-region and has no AZ support), and the `gamesThroughput`/`profilesThroughput` sub-resources are skipped.
+- `infra/params/prod.bicepparam`: now points at `cosmosDbAccountName = 'cosmos-sudoku-prod2'`, `cosmosDbEnableFreeTier = false`, `cosmosDbServerless = true`.
+- `scripts/assign-roles.sh`: `COSMOS_ACCOUNT_NAME` updated to `cosmos-sudoku-prod2`.
+- `.github/workflows/main.yml`: the Functions-app-recreate step's `COSMOS` variable updated to match.
+- `scripts/set-app-config.sh`: `CosmosDb:AccountEndpoint` (Production label) updated to the new endpoint — **but see the warning below: this key is not what re-points the API.**
+- `scripts/migrate-cosmos-data.py`: a parameterized bulk-copy / delta-sync / delete-reconciliation script for Phases 3 and 5.2. Run `python scripts/migrate-cosmos-data.py --help` for usage. Requires `pip install "azure-cosmos>=4.5,<5"`.
+
+## ⚠️ The endpoint the API actually uses
+
+**`CosmosDb:AccountEndpoint` is dead config.** Nothing in the codebase reads `CosmosDbOptions.AccountEndpoint`. Changing it in App Configuration — or changing the `CosmosDb__AccountEndpoint` app setting that `compute.bicep` / `functions.bicep` push — has no effect on which account the API talks to.
+
+The `CosmosClient` is constructed by Aspire's `builder.AddAzureCosmosClient("CosmosDb")` (`src/backend/Sudoku.Api/Program.cs:36`), which resolves the **connection string** `ConnectionStrings:CosmosDb`. In production that value comes from the Key Vault secret `ConnectionStrings--CosmosDb` in `kv-xenobiasoft-prod`, loaded by `AddAzureKeyVault` (`Program.cs:28`). Key Vault's configuration provider is registered *after* the App Configuration provider, so it wins.
+
+**The cutover is therefore a Key Vault secret change (Phase 5.3), not an App Config change.** If you had flipped only the App Config key, the cutover would have appeared to succeed, the API would have kept serving from `cosmos-sudoku-prod`, Phase 6 validation would have looked perfectly clean — and Phase 8's `az cosmosdb delete` would have been what finally took production down.
+
+## Why
+
+Azure Cosmos DB's free tier discount can only be selected **at account creation** and cannot be toggled on an existing account. There is no in-place "upgrade" path. The only way off free tier is to stand up a new, non-free account and move the data over.
+
+Decisions locked in for this plan:
+- **Cutover style:** brief maintenance window, not dual-write. Acceptable for this app's traffic level and much simpler to script and verify.
+- **Capacity mode:** switch to **Serverless** on the new account instead of re-provisioning 400 RU/s × 2 containers. Provisioned throughput would cost a flat ~$45-50/mo the moment free tier is gone, regardless of traffic; serverless bills per request, which fits a low/bursty personal-project workload far better.
+- **Account name:** the new account gets a new name, `cosmos-sudoku-prod2`. The old `cosmos-sudoku-prod` account is left completely untouched until the migration is verified, giving a free rollback path with no extra backup step.
+
+## Current state (verified in this repo)
+
+- Resource group: `rg-xenobiasoft-sudoku-prod-westus2`, subscription `c0c21e76-a03c-4747-af34-0720b273ff00`.
+- Account: `cosmos-sudoku-prod` — `enableFreeTier: true`, kind `GlobalDocumentDB`, Session consistency, zone-redundant, periodic backup (4h interval / 8h retention / geo-redundant), account-wide `totalThroughputLimit: 1000`.
+- Database: `sudoku`. Containers:
+  - `games` — partition key `/gameId`, 400 RU/s manual throughput.
+  - `profiles` — partition key `/profileId`, 400 RU/s manual throughput.
+- `disableLocalAuth: false`, so the key-based migration script works.
+- Access: managed identity via **Cosmos DB Built-in Data Contributor** for the API app, Functions app, and the developer principal, granted in `scripts/assign-roles.sh` (not Bicep — see the RBAC rule doc). `Sudoku.Functions` wires up a `CosmosClient` even though its actual writes go to blob storage for the puzzle pool, so its identity needs the same grant.
+- **Only the API writes to Cosmos.** `Sudoku.Functions` registers the Cosmos repositories via `AddInfrastructureServices` but resolves only `IPuzzlePoolService` (blob-backed); `Sudoku.McpServer` has no Cosmos dependency at all. Stopping the API is sufficient to freeze all Cosmos writes.
+- No TTL on any container, and no ETag/optimistic-concurrency usage, so an upsert-based copy is safe.
+- `infra/params/staging.bicepparam` uses a separate, non-free account and leaves `cosmosDbServerless` at its `false` default — staging is unaffected.
+
+## Phase 0 — Confirm the Key Vault secret (do this first)
+
+Everything downstream depends on this secret's exact name and value format.
+
+```
+az keyvault secret list --vault-name kv-xenobiasoft-prod --query "[].name" -o tsv
+az keyvault secret show --vault-name kv-xenobiasoft-prod --name ConnectionStrings--CosmosDb --query value -o tsv
+```
+
+Two possible formats, and they change Phase 5.3:
+
+- **Bare endpoint URI** (`https://cosmos-sudoku-prod.documents.azure.com:443/`) — Aspire treats it as an `AccountEndpoint` and authenticates with `DefaultAzureCredential`. Consistent with the managed-identity grants in `assign-roles.sh`. Cutover swaps the host and nothing else.
+- **Full connection string** (`AccountEndpoint=…;AccountKey=…`) — the API is using **key auth**, the Cosmos RBAC grants are vestigial, and the cutover must also carry the *new account's* key.
+
+Confirm nothing else supplies the endpoint:
+```
+az webapp config appsettings list --name XenobiasoftSudokuApi-prod \
+  -g rg-xenobiasoft-sudoku-prod-westus2 --query "[?contains(name,'Cosmos')]"
+```
+Expect to see only the dead `CosmosDb__AccountEndpoint` / `CosmosDb__UseManagedIdentity` pair.
+
+## Phase 1 — Provision the new account via Bicep
+
+1. Push the branch through the pipeline (merge to `main`), or run manually:
+   ```
+   az deployment group create \
+     --resource-group rg-xenobiasoft-sudoku-prod-westus2 \
+     --template-file infra/main.bicep \
+     --parameters infra/params/prod.bicepparam
+   ```
+   Bicep only manages resources declared in the template by name, so changing `cosmosDbAccountName` makes this an **additive** deployment for the Cosmos account: it creates `cosmos-sudoku-prod2` fresh and leaves `cosmos-sudoku-prod` alone.
+
+2. **It does not leave the running apps alone.** The same deployment rewrites `CosmosDb__AccountEndpoint` on the API and Functions apps (`compute.bicep:115`, `functions.bicep:169`) to the new account's endpoint and restarts them. This is harmless **only because that app setting is dead config** (see the warning above) — the API's client still resolves the old endpoint from the Key Vault secret. Do not "fix" this by pointing the Key Vault secret at the new account yet; the data isn't there.
+
+3. Confirm the new account and both containers exist:
+   ```
+   az cosmosdb show --name cosmos-sudoku-prod2 -g rg-xenobiasoft-sudoku-prod-westus2 --query "{capabilities:capabilities, freeTier:enableFreeTier}"
+   az cosmosdb sql container list --account-name cosmos-sudoku-prod2 -g rg-xenobiasoft-sudoku-prod-westus2 -d sudoku --query "[].id"
+   ```
+
+4. Confirm production is **still serving from the old account** — this is the check that proves step 2's reasoning held:
+   ```
+   az webapp log tail --name XenobiasoftSudokuApi-prod -g rg-xenobiasoft-sudoku-prod-westus2
+   ```
+   Load an existing game in the app. It must still work. Also confirm the Functions app started cleanly — its Cosmos client registration reads `ConnectionStrings:CosmosDb`, but `Sudoku.Functions/Program.cs` registers neither a Key Vault nor an App Configuration provider, so where it gets that value is unverified.
+
+5. **Deploy-time fallbacks.** `isZoneRedundant` and `capacity` are already gated on `cosmosDbServerless`. If ARM additionally rejects `enableAutomaticFailover: true` or `enableBurstCapacity: false` on a serverless account, gate those on `!cosmosDbServerless` the same way in `storage.bicep` and redeploy.
+
+## Phase 2 — Grant access on the new account
+
+`scripts/assign-roles.sh` and `.github/workflows/main.yml` already target `cosmos-sudoku-prod2`. Run it after Phase 1's deploy:
+```
+bash scripts/assign-roles.sh
+```
+It's idempotent and grants Cosmos Data Contributor to the API app, Functions app, and your developer principal. It also runs automatically as the last step of `deploy-infra` in CI, so a normal `main` push after Phase 1 applies it for you.
+
+**Cosmos data-plane role assignments propagate slowly** — typically a few minutes, occasionally much longer. Do not proceed to Phase 3 until a data-plane read from your developer principal succeeds against the new account. Verify the assignments exist:
+```
+az cosmosdb sql role assignment list --account-name cosmos-sudoku-prod2 -g rg-xenobiasoft-sudoku-prod-westus2 -o table
+```
+
+## Phase 3 — Bulk-copy existing data
+
+Fetch each account's primary key:
+```
+az cosmosdb keys list --name cosmos-sudoku-prod  -g rg-xenobiasoft-sudoku-prod-westus2 --query primaryMasterKey -o tsv
+az cosmosdb keys list --name cosmos-sudoku-prod2 -g rg-xenobiasoft-sudoku-prod-westus2 --query primaryMasterKey -o tsv
+```
+Then run the bulk copy (add `--dry-run` first for a count-only pass):
+```
+python scripts/migrate-cosmos-data.py \
+  --src-endpoint https://cosmos-sudoku-prod.documents.azure.com:443/ --src-key <old-key> \
+  --dst-endpoint https://cosmos-sudoku-prod2.documents.azure.com:443/ --dst-key <new-key> \
+  --database sudoku --containers games profiles
+```
+It prints a start epoch — **record it**, you'll pass it as `--since` in Phase 5.2.
+
+Notes:
+- `upsert_item` preserves `id` and the partition key field (`gameId` / `profileId`) exactly, which is all `CosmosDbGameRepository` / `CosmosDbUserProfileRepository` rely on. Cosmos system properties (`_rid`, `_self`, `_etag`, `_attachments`, `_ts`) are stripped before writing; the destination regenerates them.
+- Keys are passed as CLI args or `SRC_KEY`/`DST_KEY` env vars — don't commit them anywhere.
+- The copy reads the source with `read_all_items()`, consuming RU on the old account's 400 RU/s containers. The SDK retries throttles automatically; expect it to be slow rather than to fail.
+
+## Phase 4 — Verify the copy
+
+- Compare item counts per container: `SELECT VALUE COUNT(1) FROM c` against both accounts (Data Explorer or SDK). Traffic is still live, so the new account will be slightly behind. That's expected and handled in Phase 5.
+- Spot-check a handful of `games` and `profiles` documents by `id`. Compare **domain fields only** — `_ts`, `_etag`, `_rid`, and `_self` are regenerated by the destination and will always differ, so a byte-for-byte comparison is meaningless.
+- Do **not** cut over yet.
+
+## Phase 5 — Cutover (maintenance window)
+
+Pick a low-traffic time.
+
+**5.1 — Stop writes.** Stop the API App Service so no `MakeMove`/`CreateGame`/profile-update calls land during the sync. A few minutes of API downtime. The Functions and MCP apps don't write to Cosmos and can stay up.
+```
+az webapp stop --name XenobiasoftSudokuApi-prod -g rg-xenobiasoft-sudoku-prod-westus2
+```
+
+**5.2 — Delta sync with delete reconciliation.** Re-run the script with the epoch from Phase 3, plus `--prune`:
+```
+python scripts/migrate-cosmos-data.py \
+  --src-endpoint https://cosmos-sudoku-prod.documents.azure.com:443/ --src-key <old-key> \
+  --dst-endpoint https://cosmos-sudoku-prod2.documents.azure.com:443/ --dst-key <new-key> \
+  --database sudoku --containers games profiles --since <epoch-from-phase-3> --prune
+```
+
+`--prune` is not optional. `DeleteGameCommandHandler`, `DeletePlayerGamesCommandHandler`, and `DeleteProfileCommandHandler` all hard-delete with no tombstone, so a `--since` delta cannot observe a deletion — the document is simply absent from the source query, and the copy made during Phase 3 survives on the destination. Without `--prune`, any game or profile deleted between the bulk copy and now **reappears** on the new account, and a resurrected profile can collide with the alias-uniqueness query in `CosmosDbUserProfileRepository`. `--prune` enumerates both sides and deletes destination documents the source no longer has. It is only safe because 5.1 stopped writes.
+
+Run it once with `--dry-run --prune` first and read the list of documents it would delete.
+
+**5.3 — Flip the Key Vault secret.** This is the actual cutover. Preserve whatever value format Phase 0 revealed:
+```
+az keyvault secret set --vault-name kv-xenobiasoft-prod \
+  --name ConnectionStrings--CosmosDb \
+  --value "https://cosmos-sudoku-prod2.documents.azure.com:443/"
+```
+If Phase 0 showed a full `AccountEndpoint=…;AccountKey=…` connection string, supply the same shape with the new account's endpoint and key.
+
+Optionally also run `scripts/set-app-config.sh` (manual-only, not part of CI) so the dead `CosmosDb:AccountEndpoint` key isn't left stale. It changes nothing functionally.
+
+**5.4 — Restart the API.**
+```
+az webapp start --name XenobiasoftSudokuApi-prod -g rg-xenobiasoft-sudoku-prod-westus2
+```
+The restart is **required**, not merely advisable: the Key Vault configuration provider reads once at startup and does not poll, and the `CosmosClient` is a singleton built from that value at registration time. Nothing picks up the new secret without a process restart.
+
+**5.5 — Smoke test.** The critical check is that **pre-existing data is present under the new account** — that's what proves Phases 3 and 5.2 worked:
+
+1. Load a game that existed *before* the migration. It must open normally. If it 404s, the copy or the cutover failed — roll back (Phase 7).
+2. Confirm the profile list and its aliases look right, and that nothing you deleted before the migration has reappeared (this verifies `--prune`).
+3. Create a new game and make a move.
+4. Check Application Insights for `CosmosException` immediately after restart.
+
+## Phase 6 — Post-cutover validation
+
+- Watch Application Insights / logs for `CosmosException` or the `InvalidOperationException` thrown by `CosmosDbService.InitializeCosmosDbAsync` (missing database/container) for the first hour of real traffic.
+- Confirm the new account's metrics show request charges (serverless: per-operation RU, no throttling).
+- **Confirm you are actually on the new account** — the failure mode this runbook exists to prevent is a cutover that silently didn't happen. Check the new account's metrics show non-zero requests, and the old account's drop to zero.
+- Leave `cosmos-sudoku-prod` **running and untouched** — this is your rollback path.
+
+## Phase 7 — Rollback (if something's wrong post-cutover)
+
+Set the Key Vault secret back to the old account's endpoint and restart the API:
+```
+az keyvault secret set --vault-name kv-xenobiasoft-prod \
+  --name ConnectionStrings--CosmosDb \
+  --value "https://cosmos-sudoku-prod.documents.azure.com:443/"
+az webapp restart --name XenobiasoftSudokuApi-prod -g rg-xenobiasoft-sudoku-prod-westus2
+```
+Any writes that landed on the new account during the failed window must be manually replayed back to the old account (same script, endpoints reversed, with `--since` set to the cutover epoch) before re-attempting. This is the cost of the maintenance-window approach vs. dual-write — keep the window short.
+
+## Phase 8 — Decommission the old account
+
+Only after at least 1-2 weeks of clean operation on the new account, and only once Phase 6 has positively confirmed traffic is hitting `cosmos-sudoku-prod2`:
+
+1. `az cosmosdb delete --name cosmos-sudoku-prod --resource-group rg-xenobiasoft-sudoku-prod-westus2`
+2. This also frees the subscription's one free-tier slot.
+
+## Phase 9 — Cleanup
+
+- **Remove the dead Cosmos config.** `CosmosDbOptions.AccountEndpoint`, `.DisableSslValidation`, and `.ConnectionMode` are bound but never read. The matching App Config keys (`set-app-config.sh`) and the `CosmosDb__AccountEndpoint` / `CosmosDb__UseManagedIdentity` app settings in `compute.bicep` and `functions.bicep` are all inert. Deleting them would have prevented the entire class of confusion this runbook's warning section describes.
+- Clarify how `Sudoku.Functions` obtains `ConnectionStrings:CosmosDb`; it registers a `CosmosClient` but no Key Vault or App Configuration provider.
+- Remove the now-unused `cosmosDbEnableFreeTier` parameter from `infra/main.bicep` and `infra/modules/storage.bicep`, or leave it defaulted to `false` — harmless either way.
+- Cosmos account names are immutable, so the `2` suffix is permanent short of another full migration. Not worth doing.
+- Add a note to [ADR-004](../adr/ADR-004-cosmosdb.md) recording the account rename and the serverless switch. Its "Cost model" section currently doesn't mention capacity mode at all.
+
+## Things to double-check before running this for real
+
+- **Phase 0 first.** The name and value format of the `ConnectionStrings--CosmosDb` secret determine Phase 5.3 entirely.
+- Whether Azure accepts the existing backup policy, `enableAutomaticFailover`, and `enableBurstCapacity` on a **serverless** account in `westus2` — confirm at Phase 1 deploy time and gate on `!cosmosDbServerless` if not.
+- Exact current document counts in `games` and `profiles` (Phase 4) before trusting the copy.
+- That no other environment or local dev config points at `cosmos-sudoku-prod`'s endpoint directly (checked: the `Development` label in `set-app-config.sh` and `appsettings.Development.json` both point at the Cosmos emulator, `https://localhost:8081/` — local dev is unaffected).

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -45,6 +45,9 @@ param cosmosDbAccountName string
 @description('Enable the Cosmos DB free tier. Only one account per subscription may use this.')
 param cosmosDbEnableFreeTier bool = true
 
+@description('Deploy the Cosmos DB account in Serverless capacity mode instead of manual provisioned throughput. Cannot be combined with free tier.')
+param cosmosDbServerless bool = false
+
 // ---------------------------------------------------------------------------
 // Key Vault parameters
 // ---------------------------------------------------------------------------
@@ -112,6 +115,7 @@ module storage 'modules/storage.bicep' = {
     storageAccountName: storageAccountName
     cosmosDbAccountName: cosmosDbAccountName
     cosmosDbEnableFreeTier: cosmosDbEnableFreeTier
+    cosmosDbServerless: cosmosDbServerless
   }
 }
 

--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -6,6 +6,9 @@ param cosmosDbAccountName string
 @description('Enable the Cosmos DB free tier. Only one account per subscription may use this. Set to false if another account in the subscription already uses it.')
 param cosmosDbEnableFreeTier bool = true
 
+@description('Deploy the Cosmos DB account in Serverless capacity mode instead of manual provisioned throughput. Cannot be combined with free tier.')
+param cosmosDbServerless bool = false
+
 var tags = {
   environment: environment
   project: 'XenobiaSoftSudoku'
@@ -118,6 +121,14 @@ resource tableService 'Microsoft.Storage/storageAccounts/tableServices@2023-01-0
 // Cosmos DB
 // ---------------------------------------------------------------------------
 
+// Serverless accounts reject an explicit throughput cap, so `capacity` is
+// omitted entirely rather than passed as an empty object.
+var cosmosDbCapacity = cosmosDbServerless ? {} : {
+  capacity: {
+    totalThroughputLimit: 1000
+  }
+}
+
 resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
   name: cosmosDbAccountName
   location: location
@@ -126,7 +137,7 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
     defaultExperience: 'Core (SQL)'
     'hidden-workload-type': 'Production'
   })
-  properties: {
+  properties: union({
     databaseAccountOfferType: 'Standard'
     analyticalStorageConfiguration: {
         schemaType: 'WellDefined'
@@ -138,7 +149,8 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
       {
         locationName: location
         failoverPriority: 0
-        isZoneRedundant: true
+        // Serverless accounts are single-region and do not support availability zones.
+        isZoneRedundant: !cosmosDbServerless
       }
     ]
     backupPolicy: {
@@ -149,10 +161,11 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
         backupStorageRedundancy: 'Geo'
       }
     }
-    capabilities: []
-    capacity: {
-      totalThroughputLimit: 1000
-    }
+    capabilities: cosmosDbServerless ? [
+      {
+        name: 'EnableServerless'
+      }
+    ] : []
     defaultIdentity: 'FirstPartyIdentity'
     enableFreeTier: cosmosDbEnableFreeTier
     enableAutomaticFailover: true
@@ -168,7 +181,7 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
     virtualNetworkRules: []
     ipRules: []
     cors: []
-  }
+  }, cosmosDbCapacity)
 }
 
 resource sudokuDatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-05-15' = {
@@ -219,7 +232,7 @@ resource gamesContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/cont
     }
 }
 
-resource gamesThroughput 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings@2024-05-15' = {
+resource gamesThroughput 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings@2024-05-15' = if (!cosmosDbServerless) {
   parent: gamesContainer
   name: 'default'
   properties: {
@@ -257,7 +270,7 @@ resource profilesContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/c
   }
 }
 
-resource profilesThroughput 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings@2024-05-15' = {
+resource profilesThroughput 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings@2024-05-15' = if (!cosmosDbServerless) {
   parent: profilesContainer
   name: 'default'
   properties: {

--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -167,12 +167,17 @@ resource cosmosDbAccount 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
       }
     ] : []
     defaultIdentity: 'FirstPartyIdentity'
-    enableFreeTier: cosmosDbEnableFreeTier
+    // Free tier requires provisioned throughput, so it cannot coexist with
+    // serverless. Forced off rather than left to fail the deployment, since
+    // cosmosDbEnableFreeTier defaults to true.
+    enableFreeTier: cosmosDbEnableFreeTier && !cosmosDbServerless
     enableAutomaticFailover: true
     enableMultipleWriteLocations: false
     enableAnalyticalStorage: false
     enableBurstCapacity: false
     enablePartitionMerge: false
+    // Must stay false: the API authenticates with the account key embedded in
+    // the ConnectionStrings--CosmosDb Key Vault secret, not managed identity.
     disableLocalAuth: false
     disableKeyBasedMetadataWriteAccess: false
     minimalTlsVersion: 'Tls12'

--- a/infra/params/prod.bicepparam
+++ b/infra/params/prod.bicepparam
@@ -19,8 +19,14 @@ param enableSwaCustomDomain = true
 
 // Storage
 param storageAccountName = 'stxenobiasoftprod'
-param cosmosDbAccountName = 'cosmos-sudoku-prod'
-param cosmosDbEnableFreeTier = true
+// Migrated off the free tier (2026-07): free tier can only be set at account
+// creation and cannot be converted in place, so this points at a newly
+// provisioned, serverless, paid account. The original free-tier account
+// (cosmos-sudoku-prod) is intentionally left out of this template so Bicep
+// never touches it — see docs/runbooks/cosmos-db-tier-migration.md.
+param cosmosDbAccountName = 'cosmos-sudoku-prod2'
+param cosmosDbEnableFreeTier = false
+param cosmosDbServerless = true
 
 // Key Vault
 param keyVaultName = 'kv-xenobiasoft-prod'

--- a/scripts/assign-roles.sh
+++ b/scripts/assign-roles.sh
@@ -46,7 +46,10 @@ FUNCTIONS_APP_NAME="xenobiasoftsudokufunctions-prod"
 MCP_APP_NAME="xenobiasoftsudokumcp-prod"
 
 KEY_VAULT_NAME="kv-xenobiasoft-prod"
-COSMOS_ACCOUNT_NAME="cosmos-sudoku-prod"
+# Migrated off the free tier (2026-07) to a new serverless paid account; the
+# old cosmos-sudoku-prod account is left running as a rollback copy until the
+# migration is verified — see docs/runbooks/cosmos-db-tier-migration.md.
+COSMOS_ACCOUNT_NAME="cosmos-sudoku-prod2"
 APP_CONFIG_NAME="appcs-xenobiasoft-prod"
 STORAGE_ACCOUNT_NAME="stxenobiasoftprod"
 

--- a/scripts/migrate-cosmos-data.py
+++ b/scripts/migrate-cosmos-data.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+One-off data copy for the Cosmos DB free-tier -> paid-tier migration.
+See docs/runbooks/cosmos-db-tier-migration.md for the full runbook.
+
+Copies all items (or, with --since, only items changed at or after a given Unix
+epoch timestamp) from every container in a source Cosmos DB database to a
+same-named container in a destination database. Intended usage:
+
+  1. Bulk copy (Phase 3 of the runbook), no --since:
+       python migrate-cosmos-data.py \
+         --src-endpoint https://cosmos-sudoku-prod.documents.azure.com:443/ \
+         --src-key <old-account-primary-key> \
+         --dst-endpoint https://cosmos-sudoku-prod2.documents.azure.com:443/ \
+         --dst-key <new-account-primary-key> \
+         --database sudoku --containers games profiles
+
+  2. Delta sync + delete reconciliation during the maintenance window (Phase 5
+     of the runbook), using the epoch timestamp printed at the start of step 1:
+       python migrate-cosmos-data.py ... --since 1783728000 --prune
+
+--prune deletes destination documents that no longer exist in the source. The
+application hard-deletes games and profiles without leaving a tombstone, so a
+--since delta cannot observe a deletion: the document is simply absent from the
+source query, and the copy made during the bulk pass survives. Without --prune,
+anything deleted between the bulk copy and the cutover comes back to life on the
+new account. Only run --prune once writes are stopped (Phase 5.1) — against a
+live source it races traffic and will delete documents the destination should
+keep.
+
+Requires: pip install "azure-cosmos>=4.5,<5"
+
+Keys are read from the CLI args or the SRC_KEY / DST_KEY env vars — never
+commit real keys. Fetch them with:
+  az cosmosdb keys list --name <account> -g <resource-group> --query primaryMasterKey -o tsv
+
+This is a throwaway operational script, not part of the application build —
+it is not referenced by any .csproj and has no test coverage requirement.
+"""
+import argparse
+import os
+import sys
+import time
+
+from azure.cosmos import CosmosClient
+
+# Cosmos regenerates these on write; they carry no meaning in the destination.
+SYSTEM_PROPERTIES = ("_rid", "_self", "_etag", "_attachments", "_ts")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--src-endpoint", required=True, help="Source Cosmos DB account endpoint URL")
+    parser.add_argument("--dst-endpoint", required=True, help="Destination Cosmos DB account endpoint URL")
+    parser.add_argument("--src-key", default=os.environ.get("SRC_KEY"), help="Source account primary key (or set SRC_KEY env var)")
+    parser.add_argument("--dst-key", default=os.environ.get("DST_KEY"), help="Destination account primary key (or set DST_KEY env var)")
+    parser.add_argument("--database", default="sudoku", help="Database name (default: sudoku)")
+    parser.add_argument("--containers", nargs="+", default=["games", "profiles"], help="Container names to copy (default: games profiles)")
+    parser.add_argument("--since", type=int, default=None, help="Only copy items with _ts >= this Unix epoch (for delta sync)")
+    parser.add_argument("--prune", action="store_true", help="Delete destination items that no longer exist in the source. Requires writes to be stopped.")
+    parser.add_argument("--dry-run", action="store_true", help="Read and report counts without writing to or deleting from the destination")
+    return parser.parse_args()
+
+
+def partition_key_field(container):
+    """The document property a container partitions on, e.g. 'gameId'."""
+    paths = container.read()["partitionKey"]["paths"]
+    return paths[0].lstrip("/")
+
+
+def strip_system_properties(item):
+    return {key: value for key, value in item.items() if key not in SYSTEM_PROPERTIES}
+
+
+def copy_items(src_container, dst_container, since, dry_run):
+    if since is None:
+        items = src_container.read_all_items()
+    else:
+        # `>=` not `>`: _ts is second-granular, so a document written during the
+        # same second the bulk copy started — but after that partition was already
+        # scanned — would otherwise be missed by both passes. Upserts are idempotent,
+        # so the one-second overlap costs nothing.
+        items = src_container.query_items(
+            query="SELECT * FROM c WHERE c._ts >= @since",
+            parameters=[{"name": "@since", "value": since}],
+        )
+
+    count = 0
+    for item in items:
+        if not dry_run:
+            dst_container.upsert_item(strip_system_properties(item))
+        count += 1
+
+    return count
+
+
+def item_keys(container, pk_field):
+    """Every (id, partition-key value) pair in a container."""
+    query = f'SELECT c.id, c["{pk_field}"] AS pk FROM c'
+    return {(row["id"], row.get("pk")) for row in container.query_items(query=query)}
+
+
+def prune_items(src_container, dst_container, pk_field, dry_run):
+    orphans = item_keys(dst_container, pk_field) - item_keys(src_container, pk_field)
+
+    pruned = 0
+    for item_id, partition_key in sorted(orphans, key=lambda pair: pair[0]):
+        if partition_key is None:
+            print(f"  SKIP {item_id}: no '{pk_field}' value to partition on", file=sys.stderr)
+            continue
+        if dry_run:
+            print(f"  would delete {item_id} (partition {partition_key})")
+        else:
+            dst_container.delete_item(item=item_id, partition_key=partition_key)
+        pruned += 1
+
+    return pruned
+
+
+def main():
+    args = parse_args()
+
+    if not args.src_key or not args.dst_key:
+        print("ERROR: --src-key/--dst-key (or SRC_KEY/DST_KEY env vars) are required.", file=sys.stderr)
+        sys.exit(1)
+
+    start_epoch = int(time.time())
+    print(f"Migration run started at epoch {start_epoch} ({time.ctime(start_epoch)}).")
+    if args.since is None:
+        print("Record this timestamp — pass it as --since on the delta-sync run before cutover.")
+    if args.prune and not args.dry_run:
+        print("WARNING: --prune deletes destination documents that are absent from the source.")
+        print("         Writes to the source must already be stopped (runbook Phase 5.1).")
+
+    src_db = CosmosClient(args.src_endpoint, args.src_key).get_database_client(args.database)
+    dst_db = CosmosClient(args.dst_endpoint, args.dst_key).get_database_client(args.database)
+
+    total_copied = 0
+    total_pruned = 0
+    for container_name in args.containers:
+        src_container = src_db.get_container_client(container_name)
+        dst_container = dst_db.get_container_client(container_name)
+
+        copied = copy_items(src_container, dst_container, args.since, args.dry_run)
+        print(f"{container_name}: {'would copy' if args.dry_run else 'copied'} {copied} item(s)")
+        total_copied += copied
+
+        if args.prune:
+            src_pk = partition_key_field(src_container)
+            dst_pk = partition_key_field(dst_container)
+            if src_pk != dst_pk:
+                print(f"ERROR: {container_name} partition key differs (source '{src_pk}', destination '{dst_pk}').", file=sys.stderr)
+                sys.exit(1)
+
+            pruned = prune_items(src_container, dst_container, dst_pk, args.dry_run)
+            print(f"{container_name}: {'would delete' if args.dry_run else 'deleted'} {pruned} orphaned item(s)")
+            total_pruned += pruned
+
+    print(f"Done. Total items {'that would be copied' if args.dry_run else 'copied'}: {total_copied}")
+    if args.prune:
+        print(f"      Total orphans {'that would be deleted' if args.dry_run else 'deleted'}: {total_pruned}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/set-app-config.sh
+++ b/scripts/set-app-config.sh
@@ -46,7 +46,14 @@ push_production() {
     set_key "$LABEL" "CosmosDb:DisableSslValidation" "false"
     set_key "$LABEL" "CosmosDb:AutoCreateContainers" "false"
     set_key "$LABEL" "CosmosDb:UseManagedIdentity"   "true"
-    set_key "$LABEL" "CosmosDb:AccountEndpoint"      "https://cosmos-sudoku-prod.documents.azure.com:443/"
+    # NOTE: this key is NOT what points the CosmosClient at an account. Nothing
+    # reads CosmosDbOptions.AccountEndpoint; the client is built by Aspire's
+    # AddAzureCosmosClient("CosmosDb"), which resolves ConnectionStrings:CosmosDb
+    # from the Key Vault secret ConnectionStrings--CosmosDb. That secret is the
+    # authoritative endpoint and is what a tier migration must change.
+    # Kept in sync here only so the value isn't misleadingly stale.
+    # See docs/runbooks/cosmos-db-tier-migration.md.
+    set_key "$LABEL" "CosmosDb:AccountEndpoint"      "https://cosmos-sudoku-prod2.documents.azure.com:443/"
     set_key "$LABEL" "CosmosDb:ConnectionMode"       "Direct"
 
     # -------------------------------------------------------------------------

--- a/scripts/set-app-config.sh
+++ b/scripts/set-app-config.sh
@@ -45,12 +45,17 @@ push_production() {
     set_key "$LABEL" "CosmosDb:DatabaseName"         "sudoku"
     set_key "$LABEL" "CosmosDb:DisableSslValidation" "false"
     set_key "$LABEL" "CosmosDb:AutoCreateContainers" "false"
+    # NOTE: this does NOT select credentials. CosmosDbOptions.UseManagedIdentity
+    # is read only by CosmosDbService to gate container auto-creation. The API
+    # actually authenticates with the account key embedded in the Key Vault
+    # secret below.
     set_key "$LABEL" "CosmosDb:UseManagedIdentity"   "true"
     # NOTE: this key is NOT what points the CosmosClient at an account. Nothing
     # reads CosmosDbOptions.AccountEndpoint; the client is built by Aspire's
     # AddAzureCosmosClient("CosmosDb"), which resolves ConnectionStrings:CosmosDb
-    # from the Key Vault secret ConnectionStrings--CosmosDb. That secret is the
-    # authoritative endpoint and is what a tier migration must change.
+    # from the Key Vault secret ConnectionStrings--CosmosDb. That secret holds a
+    # full AccountEndpoint=...;AccountKey=... connection string and is what a
+    # tier migration must change.
     # Kept in sync here only so the value isn't misleadingly stale.
     # See docs/runbooks/cosmos-db-tier-migration.md.
     set_key "$LABEL" "CosmosDb:AccountEndpoint"      "https://cosmos-sudoku-prod2.documents.azure.com:443/"


### PR DESCRIPTION
## Description

Moves production Cosmos DB off the free tier. The discount can only be selected at account creation and cannot be toggled on an existing account, so the only path off it is to provision a new account (`cosmos-sudoku-prod2`, **serverless**) and copy the data across during a short maintenance window. Serverless bills per request rather than a flat ~$45-50/mo for 400 RU/s × 2 containers, which fits this workload far better.

This PR contains the repo-side changes plus the operational runbook. **No Azure-side step has been executed.** The old account stays running and untouched as the rollback path.

Reviewing the initial draft against the code turned up three defects that would have caused real damage during execution. All three are fixed here.

### 1. The cutover flipped a config key that nothing reads

`CosmosDbOptions.AccountEndpoint` is bound but read by no code. The `CosmosClient` is built by Aspire's `AddAzureCosmosClient("CosmosDb")` (`Sudoku.Api/Program.cs:36`), which resolves the connection string `ConnectionStrings:CosmosDb` — sourced in production from the Key Vault secret `ConnectionStrings--CosmosDb`, loaded by `AddAzureKeyVault` *after* the App Configuration provider, so Key Vault wins.

Setting `CosmosDb:AccountEndpoint` in App Config would have left the API serving from `cosmos-sudoku-prod`. Post-cutover validation would have looked perfectly clean — because it *was* clean — and the eventual `az cosmosdb delete` of the old account would have been what took production down. The runbook now cuts over via the Key Vault secret and documents the dead config explicitly.

### 2. The delta sync could resurrect deleted data

`DeleteGameCommandHandler`, `DeletePlayerGamesCommandHandler`, and `DeleteProfileCommandHandler` all hard-delete with no tombstone. A `_ts > since` query against the source cannot observe a deletion — the document is simply absent — so the copy made during the bulk pass survived on the destination. Any game or profile deleted between bulk copy and cutover would have reappeared, and a resurrected profile can collide with the alias-uniqueness query in `CosmosDbUserProfileRepository`.

Adds `--prune`, which enumerates both sides and deletes destination documents the source no longer has. Safe because the API is stopped first.

### 3. Two deploy-blocking Bicep properties

`isZoneRedundant: true` was unconditional, but serverless Cosmos is single-region with no AZ support. And `capacity: {}` passed an empty object where `totalThroughputLimit` is invalid for serverless.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Other (please describe): infrastructure / operational tooling

## Changes Made

- `infra/modules/storage.bicep`: gate `isZoneRedundant` on `!cosmosDbServerless`; omit `capacity` entirely via `union()` rather than passing `{}`; add the `EnableServerless` capability and skip the per-container `throughputSettings` resources when serverless.
- `infra/main.bicep`, `infra/params/prod.bicepparam`: add the `cosmosDbServerless` param; point prod at `cosmos-sudoku-prod2` with free tier off. Staging is unaffected — it leaves `cosmosDbServerless` at its `false` default.
- `scripts/migrate-cosmos-data.py` (new): parameterized bulk copy, delta sync, and delete reconciliation. Adds `--prune`; widens the delta boundary from `_ts > since` to `>=` (`_ts` is second-granular, so a document written during the second the bulk copy began, after its partition was scanned, was missed by both passes); strips Cosmos system properties before upserting; derives each container's partition key from `container.read()` rather than hardcoding it.
- `docs/runbooks/cosmos-db-tier-migration.md` (new): phased runbook. Adds a Phase 0 to confirm the Key Vault secret's name and value format, a post-Phase-1 check that prod is still on the old account, a wait for Cosmos data-plane RBAC propagation, and a Phase 6 check that traffic actually moved. The Phase 5 smoke test now leads with loading a **pre-existing** game — the draft told the operator to expect old data to be missing, which would have masked a failed copy.
- `scripts/assign-roles.sh`, `.github/workflows/main.yml`: retarget the new account name.
- `scripts/set-app-config.sh`: keep `CosmosDb:AccountEndpoint` from going stale, but comment that it is inert and the Key Vault secret is authoritative.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

- `dotnet test` — 681 passed, 0 failed. No C# was touched (`git diff main --name-only | grep -c '\.cs$'` → 0).
- `az bicep build --file infra/main.bicep` compiles. The emitted ARM confirms `isZoneRedundant: not(parameters('cosmosDbServerless'))` and `properties: union(createObject(...), variables('cosmosDbCapacity'))`, where `cosmosDbCapacity` is `if(serverless, {}, {capacity:...})`.
- `migrate-cosmos-data.py` was exercised against fake containers reproducing the real timeline (bulk copy → source delete/update/create → delta sync). Confirmed the deleted document **is** resurrected without `--prune`, **is not** with it; that `--dry-run --prune` mutates nothing; that a prune immediately after a fresh copy reports zero orphans; that system properties are stripped; and that `>=` catches an update written during the boundary second.
- The Azure-side phases are not executed here — this environment has no Azure credentials.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation (if necessary)

## Phase 0 result (resolved)

The `ConnectionStrings--CosmosDb` secret holds a **full connection string** with an embedded account key, so the API authenticates with a Cosmos **account key**, not managed identity. The runbook is updated accordingly:

- Cutover carries the new account's endpoint *and* key. The old value must be captured first — Phase 8's account deletion destroys the old key, and with it the rollback path.
- `CosmosDb:UseManagedIdentity = "true"` does **not** select credentials. It is read only at `CosmosDbService.cs:182` to gate container auto-creation. Both the runbook and `set-app-config.sh` now say so, since the flag otherwise reads as a claim about authentication.
- The Cosmos RBAC grants in `assign-roles.sh` are vestigial for the API and so aren't on the cutover's critical path. Left in place — `Sudoku.Functions` may rely on them.
- `disableLocalAuth` must stay `false` on the new account (it is) or key auth breaks instantly.

Phase 6 now verifies the cutover by reading the endpoint that `CosmosDbService.InitializeCosmosDbAsync` logs at startup. A cutover that silently didn't happen produces **no errors**, so watching for exceptions cannot detect it. That check is what gates the irreversible Phase 8 delete.

Follow-up worth doing separately: the managed identities already hold Cosmos Data Contributor, so switching the secret to a bare endpoint URI would let `DefaultAzureCredential` take over and drop the embedded key. Not during this migration — one variable at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
