### PR TITLE
Simplify Cosmos cutover to a single copy

### DIFF
--- a/docs/runbooks/cosmos-db-tier-migration.md
+++ b/docs/runbooks/cosmos-db-tier-migration.md
@@ -3,7 +3,7 @@
 | Field | Value |
 |---|---|
 | **Date** | 2026-07-09 |
-| **Status** | Code/config changes staged on branch `feature/cosmos-tier-migration` — not merged. Phase 0 complete (see below). Phases 1-9 not yet executed. |
+| **Status** | Merged to `main` (PR #353). Phase 0 complete. Phases 1-2 executed automatically by CI's `deploy-infra` job on merge. Phases 3-7 not yet run. |
 | **Owner** | Project maintainer |
 | **Related** | [ADR-004 — Cosmos DB as persistence backend](../adr/ADR-004-cosmosdb.md), [.claude/rules/rbac-role-assignments.md](../../.claude/rules/rbac-role-assignments.md) |
 
@@ -24,7 +24,7 @@ These file changes exist on the feature branch and require no further edits. Eve
 
 The `CosmosClient` is constructed by Aspire's `builder.AddAzureCosmosClient("CosmosDb")` (`src/backend/Sudoku.Api/Program.cs:36`), which resolves the **connection string** `ConnectionStrings:CosmosDb`. In production that value comes from the Key Vault secret `ConnectionStrings--CosmosDb` in `kv-xenobiasoft-prod`, loaded by `AddAzureKeyVault` (`Program.cs:28`). Key Vault's configuration provider is registered *after* the App Configuration provider, so it wins.
 
-**The cutover is therefore a Key Vault secret change (Phase 5.3), not an App Config change.** If you had flipped only the App Config key, the cutover would have appeared to succeed, the API would have kept serving from `cosmos-sudoku-prod`, Phase 6 validation would have looked perfectly clean — and Phase 8's `az cosmosdb delete` would have been what finally took production down.
+**The cutover is therefore a Key Vault secret change (Phase 3.4), not an App Config change.** If you had flipped only the App Config key, the cutover would have appeared to succeed, the API would have kept serving from `cosmos-sudoku-prod`, Phase 4 validation would have looked perfectly clean — and Phase 6's `az cosmosdb delete` would have been what finally took production down.
 
 ### The API authenticates with an account key, not managed identity
 
@@ -34,7 +34,7 @@ Phase 0 confirmed the secret holds a **full connection string** of the form `Acc
 - **The Cosmos data-plane RBAC grants in `scripts/assign-roles.sh` are vestigial for the API.** They're harmless, and `Sudoku.Functions` may still depend on them, so leave them in place. But they are not what lets the API read and write.
 - **`disableLocalAuth` must stay `false` on the new account** (it is — `storage.bicep:170`). Setting it `true` would break the API instantly, since key auth would be refused.
 
-Phase 5.3 must therefore carry the **new account's key**, not just its endpoint. And because the key is embedded in the secret, rotating either account's keys out-of-band will break the app until the secret is updated.
+Phase 3.4 must therefore carry the **new account's key**, not just its endpoint. And because the key is embedded in the secret, rotating either account's keys out-of-band will break the app until the secret is updated.
 
 ## Why
 
@@ -99,7 +99,7 @@ Expect to see only the dead `CosmosDb__AccountEndpoint` / `CosmosDb__UseManagedI
    ```
    Load an existing game in the app. It must still work. Also confirm the Functions app started cleanly — its Cosmos client registration reads `ConnectionStrings:CosmosDb`, but `Sudoku.Functions/Program.cs` registers neither a Key Vault nor an App Configuration provider, so where it gets that value is unverified.
 
-5. **Deploy-time fallbacks.** `isZoneRedundant` and `capacity` are already gated on `cosmosDbServerless`. If ARM additionally rejects `enableAutomaticFailover: true` or `enableBurstCapacity: false` on a serverless account, gate those on `!cosmosDbServerless` the same way in `storage.bicep` and redeploy.
+5. **Deploy-time fallbacks.** `isZoneRedundant` and `capacity` are gated on `cosmosDbServerless`. ARM accepted `enableAutomaticFailover: true`, `enableBurstCapacity: false`, and the periodic backup policy on serverless when this ran on 2026-07-09, so no further gating was needed.
 
 ## Phase 2 — Grant access on the new account
 
@@ -116,57 +116,41 @@ Cosmos data-plane role assignments propagate slowly, typically a few minutes. Ve
 az cosmosdb sql role assignment list --account-name cosmos-sudoku-prod2 -g rg-xenobiasoft-sudoku-prod-westus2 -o table
 ```
 
-## Phase 3 — Bulk-copy existing data
+## Phase 3 — Cutover (single copy)
 
-Fetch each account's primary key:
-```
-az cosmosdb keys list --name cosmos-sudoku-prod  -g rg-xenobiasoft-sudoku-prod-westus2 --query primaryMasterKey -o tsv
-az cosmosdb keys list --name cosmos-sudoku-prod2 -g rg-xenobiasoft-sudoku-prod-westus2 --query primaryMasterKey -o tsv
-```
-Then run the bulk copy (add `--dry-run` first for a count-only pass):
-```
-python scripts/migrate-cosmos-data.py \
-  --src-endpoint https://cosmos-sudoku-prod.documents.azure.com:443/ --src-key <old-key> \
-  --dst-endpoint https://cosmos-sudoku-prod2.documents.azure.com:443/ --dst-key <new-key> \
-  --database sudoku --containers games profiles
-```
-It prints a start epoch — **record it**, you'll pass it as `--since` in Phase 5.2.
+This app has one real user and a few dozen documents. There is no concurrent traffic to race and no meaningful copy duration, which removes the reason for a bulk-copy-then-delta-sync sequence: **stop writes, copy once, cut over.** Expect a minute or two of API downtime, at whatever time you like.
 
-Notes:
-- `upsert_item` preserves `id` and the partition key field (`gameId` / `profileId`) exactly, which is all `CosmosDbGameRepository` / `CosmosDbUserProfileRepository` rely on. Cosmos system properties (`_rid`, `_self`, `_etag`, `_attachments`, `_ts`) are stripped before writing; the destination regenerates them.
-- Keys are passed as CLI args or `SRC_KEY`/`DST_KEY` env vars — don't commit them anywhere.
-- The copy reads the source with `read_all_items()`, consuming RU on the old account's 400 RU/s containers. The SDK retries throttles automatically; expect it to be slow rather than to fail.
+The script still supports `--since` for an incremental pass (`--help`), but nothing below uses it, and there is no start epoch to record.
 
-## Phase 4 — Verify the copy
-
-- Compare item counts per container: `SELECT VALUE COUNT(1) FROM c` against both accounts (Data Explorer or SDK). Traffic is still live, so the new account will be slightly behind. That's expected and handled in Phase 5.
-- Spot-check a handful of `games` and `profiles` documents by `id`. Compare **domain fields only** — `_ts`, `_etag`, `_rid`, and `_self` are regenerated by the destination and will always differ, so a byte-for-byte comparison is meaningless.
-- Do **not** cut over yet.
-
-## Phase 5 — Cutover (maintenance window)
-
-Pick a low-traffic time.
-
-**5.1 — Stop writes.** Stop the API App Service so no `MakeMove`/`CreateGame`/profile-update calls land during the sync. A few minutes of API downtime. The Functions and MCP apps don't write to Cosmos and can stay up.
+**3.1 — Stop writes.** Stop the API App Service so no `MakeMove`/`CreateGame`/profile-update calls land mid-copy. The Functions and MCP apps don't touch Cosmos and can stay up.
 ```
 az webapp stop --name XenobiasoftSudokuApi-prod -g rg-xenobiasoft-sudoku-prod-westus2
 ```
 
-**5.2 — Delta sync with delete reconciliation.** Re-run the script with the epoch from Phase 3, plus `--prune`:
+**3.2 — Copy everything.** Fetch both accounts' primary keys:
+```
+az cosmosdb keys list --name cosmos-sudoku-prod  -g rg-xenobiasoft-sudoku-prod-westus2 --query primaryMasterKey -o tsv
+az cosmosdb keys list --name cosmos-sudoku-prod2 -g rg-xenobiasoft-sudoku-prod-westus2 --query primaryMasterKey -o tsv
+```
+Dry-run first, then drop `--dry-run`:
 ```
 python scripts/migrate-cosmos-data.py \
   --src-endpoint https://cosmos-sudoku-prod.documents.azure.com:443/ --src-key <old-key> \
   --dst-endpoint https://cosmos-sudoku-prod2.documents.azure.com:443/ --dst-key <new-key> \
-  --database sudoku --containers games profiles --since <epoch-from-phase-3> --prune
+  --database sudoku --containers games profiles --prune --dry-run
 ```
 
-`--prune` is not optional. `DeleteGameCommandHandler`, `DeletePlayerGamesCommandHandler`, and `DeleteProfileCommandHandler` all hard-delete with no tombstone, so a `--since` delta cannot observe a deletion — the document is simply absent from the source query, and the copy made during Phase 3 survives on the destination. Without `--prune`, any game or profile deleted between the bulk copy and now **reappears** on the new account, and a resurrected profile can collide with the alias-uniqueness query in `CosmosDbUserProfileRepository`. `--prune` enumerates both sides and deletes destination documents the source no longer has. It is only safe because 5.1 stopped writes.
+On a first copy into an empty destination `--prune` finds nothing and reports zero — keep it anyway. It makes the command **idempotent**: re-run it after deleting a game, or run it twice, and the destination converges on the source instead of accumulating orphans. That matters because games and profiles are hard-deleted with no tombstone (`DeleteGameCommandHandler`, `DeletePlayerGamesCommandHandler`, `DeleteProfileCommandHandler`), so a copy alone can never remove anything, and a resurrected profile can collide with the alias-uniqueness query in `CosmosDbUserProfileRepository`.
 
-Run it once with `--dry-run --prune` first and read the list of documents it would delete.
+Notes:
+- `upsert_item` preserves `id` and the partition key field (`gameId` / `profileId`) exactly, which is all `CosmosDbGameRepository` / `CosmosDbUserProfileRepository` rely on. Cosmos system properties (`_rid`, `_self`, `_etag`, `_attachments`, `_ts`) are stripped before writing; the destination regenerates them.
+- Keys can be passed as CLI args or `SRC_KEY`/`DST_KEY` env vars — don't commit them anywhere.
 
-**5.3 — Flip the Key Vault secret.** This is the actual cutover. Phase 0 established the value is a full connection string, so it must carry the new account's **endpoint and key**.
+**3.3 — Verify the copy.** Compare item counts per container (`SELECT VALUE COUNT(1) FROM c`) on both accounts. With writes stopped they must match exactly. Spot-check a couple of documents by `id`, comparing **domain fields only** — `_ts`, `_etag`, `_rid`, and `_self` are regenerated by the destination and always differ, so a byte-for-byte comparison is meaningless.
 
-First record the current value — you need it verbatim to roll back (Phase 7), and once Phase 8 deletes the old account its key dies with it:
+**3.4 — Flip the Key Vault secret.** This is the actual cutover. Phase 0 established the value is a full connection string, so it must carry the new account's **endpoint and key**.
+
+First record the current value — you need it verbatim to roll back (Phase 5), and once Phase 6 deletes the old account its key dies with it:
 ```
 az keyvault secret show --vault-name kv-xenobiasoft-prod \
   --name ConnectionStrings--CosmosDb --query value -o tsv
@@ -186,20 +170,20 @@ Match the old value's exact shape (trailing `;`, any `Database=` segment) rather
 
 Optionally also run `scripts/set-app-config.sh` (manual-only, not part of CI) so the dead `CosmosDb:AccountEndpoint` key isn't left stale. It changes nothing functionally.
 
-**5.4 — Restart the API.**
+**3.5 — Restart the API.**
 ```
 az webapp start --name XenobiasoftSudokuApi-prod -g rg-xenobiasoft-sudoku-prod-westus2
 ```
 The restart is **required**, not merely advisable: the Key Vault configuration provider reads once at startup and does not poll, and the `CosmosClient` is a singleton built from that value at registration time. Nothing picks up the new secret without a process restart.
 
-**5.5 — Smoke test.** The critical check is that **pre-existing data is present under the new account** — that's what proves Phases 3 and 5.2 worked:
+**3.6 — Smoke test.** The critical check is that **pre-existing data is present under the new account** — that's what proves the copy and the cutover both worked:
 
-1. Load a game that existed *before* the migration. It must open normally. If it 404s, the copy or the cutover failed — roll back (Phase 7).
-2. Confirm the profile list and its aliases look right, and that nothing you deleted before the migration has reappeared (this verifies `--prune`).
+1. Load a game that existed *before* the migration. It must open normally. If it 404s, roll back (Phase 5).
+2. Confirm the profile list and its aliases look right.
 3. Create a new game and make a move.
 4. Check Application Insights for `CosmosException` immediately after restart.
 
-## Phase 6 — Post-cutover validation
+## Phase 4 — Post-cutover validation
 
 - **Confirm you are actually on the new account.** The failure mode this runbook exists to prevent is a cutover that silently didn't happen — and a cutover that didn't happen produces *no errors at all*. `CosmosDbService.InitializeCosmosDbAsync` logs the endpoint it connected to (`CosmosDbService.cs:180`), so check it directly:
   ```
@@ -211,13 +195,13 @@ The restart is **required**, not merely advisable: the Key Vault configuration p
 - Confirm the new account's metrics show request charges (serverless: per-operation RU, no throttling).
 - Leave `cosmos-sudoku-prod` **running and untouched** — this is your rollback path.
 
-## Phase 7 — Rollback (if something's wrong post-cutover)
+## Phase 5 — Rollback (if something's wrong post-cutover)
 
-Restore the connection string you recorded in Phase 5.3 — endpoint **and** the old account's key — then restart the API:
+Restore the connection string you recorded in Phase 3.4 — endpoint **and** the old account's key — then restart the API:
 ```
 az keyvault secret set --vault-name kv-xenobiasoft-prod \
   --name ConnectionStrings--CosmosDb \
-  --value "<the exact value captured in Phase 5.3>"
+  --value "<the exact value captured in Phase 3.4>"
 az webapp restart --name XenobiasoftSudokuApi-prod -g rg-xenobiasoft-sudoku-prod-westus2
 ```
 If you didn't capture it, recover the previous version:
@@ -225,20 +209,20 @@ If you didn't capture it, recover the previous version:
 az keyvault secret list-versions --vault-name kv-xenobiasoft-prod --name ConnectionStrings--CosmosDb -o table
 az keyvault secret show --vault-name kv-xenobiasoft-prod --name ConnectionStrings--CosmosDb --version <prior-version-id> --query value -o tsv
 ```
-Confirm the rollback took using the endpoint log line from Phase 6.
+Confirm the rollback took using the endpoint log line from Phase 4.
 
-Any writes that landed on the new account during the failed window must be manually replayed back to the old account (same script, endpoints reversed, with `--since` set to the cutover epoch) before re-attempting. This is the cost of the maintenance-window approach vs. dual-write — keep the window short.
+Any writes that landed on the new account during the failed window must be replayed back to the old account before re-attempting — same script, endpoints reversed, `--prune` off (you want to add to the old account, not reconcile it against a partial copy).
 
-## Phase 8 — Decommission the old account
+## Phase 6 — Decommission the old account
 
-Only after at least 1-2 weeks of clean operation on the new account, and only once Phase 6 has **positively confirmed via the endpoint log line** that traffic is hitting `cosmos-sudoku-prod2`. This is the irreversible step, and the whole point of Phase 6's check is to stop you taking it while the API is quietly still on the old account.
+Only after at least 1-2 weeks of clean operation on the new account, and only once Phase 4 has **positively confirmed via the endpoint log line** that traffic is hitting `cosmos-sudoku-prod2`. This is the irreversible step, and the whole point of Phase 4's check is to stop you taking it while the API is quietly still on the old account.
 
 1. `az cosmosdb delete --name cosmos-sudoku-prod --resource-group rg-xenobiasoft-sudoku-prod-westus2`
 2. This also frees the subscription's one free-tier slot.
 
-After this, Phase 7 rollback is gone: the old account's access key dies with the account, so the connection string you saved is worthless.
+The data here is low-value and easily recreated, so the concern isn't losing games. It's that if the cutover silently didn't take, this command deletes the account production is *actively serving from* — the API starts throwing, the periodic backups are destroyed along with the account, and the symptom (sudden Cosmos errors, unchanged config) points nowhere obvious. Phase 4's one-line log check is what makes this step safe. After it, Phase 5 rollback is gone: the old account's access key dies with the account, so the connection string you saved is worthless.
 
-## Phase 9 — Cleanup
+## Phase 7 — Cleanup
 
 - **Remove the dead Cosmos config.** `CosmosDbOptions.AccountEndpoint`, `.DisableSslValidation`, and `.ConnectionMode` are bound but never read, as is the `CosmosDb__AccountEndpoint` app setting pushed by `compute.bicep` and `functions.bicep`. Deleting them would have prevented the entire class of confusion this runbook's warning section describes.
 - **Decide on Cosmos authentication.** The API uses an account key while `CosmosDb:UseManagedIdentity` reads `true` — a flag that only gates container auto-creation (`CosmosDbService.cs:182`) and has nothing to do with credentials. The managed identities already hold Cosmos Data Contributor via `assign-roles.sh`, so switching the Key Vault secret to a bare endpoint URI would let `DefaultAzureCredential` take over and remove the embedded key entirely. Worth doing as a follow-up, but **not** during this migration — one variable at a time.
@@ -249,7 +233,7 @@ After this, Phase 7 rollback is gone: the old account's access key dies with the
 
 ## Things to double-check before running this for real
 
-- **Phase 0 first.** The name and value format of the `ConnectionStrings--CosmosDb` secret determine Phase 5.3 entirely.
-- Whether Azure accepts the existing backup policy, `enableAutomaticFailover`, and `enableBurstCapacity` on a **serverless** account in `westus2` — confirm at Phase 1 deploy time and gate on `!cosmosDbServerless` if not.
-- Exact current document counts in `games` and `profiles` (Phase 4) before trusting the copy.
+- **Phase 0 first.** The name and value format of the `ConnectionStrings--CosmosDb` secret determine Phase 3.4 entirely. (Done: full connection string with an account key.)
+- ~~Whether Azure accepts the existing backup policy, `enableAutomaticFailover`, and `enableBurstCapacity` on a **serverless** account in `westus2`.~~ Confirmed accepted at Phase 1 deploy time (2026-07-09); no additional `!cosmosDbServerless` gating needed beyond `isZoneRedundant` and `capacity`.
+- Exact current document counts in `games` and `profiles` (Phase 3.3) before trusting the copy.
 - That no other environment or local dev config points at `cosmos-sudoku-prod`'s endpoint directly (checked: the `Development` label in `set-app-config.sh` and `appsettings.Development.json` both point at the Cosmos emulator, `https://localhost:8081/` — local dev is unaffected).

--- a/scripts/migrate-cosmos-data.py
+++ b/scripts/migrate-cosmos-data.py
@@ -5,28 +5,30 @@ See docs/runbooks/cosmos-db-tier-migration.md for the full runbook.
 
 Copies all items (or, with --since, only items changed at or after a given Unix
 epoch timestamp) from every container in a source Cosmos DB database to a
-same-named container in a destination database. Intended usage:
+same-named container in a destination database.
 
-  1. Bulk copy (Phase 3 of the runbook), no --since:
-       python migrate-cosmos-data.py \
-         --src-endpoint https://cosmos-sudoku-prod.documents.azure.com:443/ \
-         --src-key <old-account-primary-key> \
-         --dst-endpoint https://cosmos-sudoku-prod2.documents.azure.com:443/ \
-         --dst-key <new-account-primary-key> \
-         --database sudoku --containers games profiles
+Intended usage — a single full copy with writes stopped (Phase 3 of the runbook):
 
-  2. Delta sync + delete reconciliation during the maintenance window (Phase 5
-     of the runbook), using the epoch timestamp printed at the start of step 1:
-       python migrate-cosmos-data.py ... --since 1783728000 --prune
+    python migrate-cosmos-data.py \
+      --src-endpoint https://cosmos-sudoku-prod.documents.azure.com:443/ \
+      --src-key <old-account-primary-key> \
+      --dst-endpoint https://cosmos-sudoku-prod2.documents.azure.com:443/ \
+      --dst-key <new-account-primary-key> \
+      --database sudoku --containers games profiles --prune
 
---prune deletes destination documents that no longer exist in the source. The
-application hard-deletes games and profiles without leaving a tombstone, so a
---since delta cannot observe a deletion: the document is simply absent from the
-source query, and the copy made during the bulk pass survives. Without --prune,
-anything deleted between the bulk copy and the cutover comes back to life on the
-new account. Only run --prune once writes are stopped (Phase 5.1) — against a
-live source it races traffic and will delete documents the destination should
-keep.
+--prune deletes destination documents that no longer exist in the source, making
+the copy idempotent: re-running converges the destination on the source instead
+of accumulating orphans. This matters because the application hard-deletes games
+and profiles without leaving a tombstone, so a copy alone can never remove
+anything — a document deleted from the source after an earlier copy would
+otherwise survive on the destination forever. Only run --prune once writes are
+stopped; against a live source it races traffic and will delete documents the
+destination should keep.
+
+--since restricts the copy to items with _ts >= the given epoch, for an
+incremental pass against a large source. The single-copy flow above does not
+need it. Note that --since alone cannot observe deletions; pair it with --prune,
+which always enumerates the full source regardless of --since.
 
 Requires: pip install "azure-cosmos>=4.5,<5"
 
@@ -126,11 +128,9 @@ def main():
 
     start_epoch = int(time.time())
     print(f"Migration run started at epoch {start_epoch} ({time.ctime(start_epoch)}).")
-    if args.since is None:
-        print("Record this timestamp — pass it as --since on the delta-sync run before cutover.")
     if args.prune and not args.dry_run:
         print("WARNING: --prune deletes destination documents that are absent from the source.")
-        print("         Writes to the source must already be stopped (runbook Phase 5.1).")
+        print("         Writes to the source must already be stopped (runbook Phase 3.1).")
 
     src_db = CosmosClient(args.src_endpoint, args.src_key).get_database_client(args.database)
     dst_db = CosmosClient(args.dst_endpoint, args.dst_key).get_database_client(args.database)


### PR DESCRIPTION
## Description

Follow-up to #353. The app has one real user and a few dozen documents, so there is no concurrent traffic to race during the migration and no meaningful copy duration. The bulk-copy-then-delta-sync sequence was solving a problem this migration doesn't have.

Collapses the old Phases 3 (bulk copy), 4 (verify), and 5 (cutover) into a single **Phase 3 — Cutover (single copy)**: stop writes, copy once with `--prune`, verify counts, flip the Key Vault secret, restart, smoke test. Phases 6-9 renumber down to 4-7. The `--since` epoch bookkeeping — the fiddliest part of the old runbook — is gone.

`--prune` is kept even though a first copy into an empty destination finds nothing to remove. It makes the copy **idempotent**: because games and profiles are hard-deleted with no tombstone, a copy alone can never remove anything, so re-running without `--prune` would let orphans accumulate on the destination.

Also records what Phases 1 and 2 actually produced when CI ran them on merge of #353.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Other (please describe): operational tooling

## Changes Made

- `docs/runbooks/cosmos-db-tier-migration.md`: merge Phases 3-5 into one cutover phase; renumber 6-9 → 4-7; update every cross-reference.
- Record the Phase 1 deploy result: ARM **accepted** `enableAutomaticFailover: true`, `enableBurstCapacity: false`, and the periodic backup policy on a serverless account, so no gating beyond `isZoneRedundant` and `capacity` was needed. The "things to double-check" entry for this is resolved.
- `scripts/migrate-cosmos-data.py`: docstring now leads with the single-copy flow; `--since` documented as the optional incremental path with a note that it cannot observe deletions on its own. Removes the "record this timestamp" prompt, which no longer applies. **No logic changed.**

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

- Re-ran the fake-container harness against the script after the edits: bulk copy, resurrection-without-`--prune`, removal-with-`--prune`, dry-run leaves the destination untouched, prune-after-fresh-copy reports zero orphans. All pass. Only the docstring and two `print` calls changed.
- `python scripts/migrate-cosmos-data.py --help` works.
- Swept the runbook and script for stale phase references (`Phase 5.x`, `Phase 8`, `Phase 9`, `epoch-from-phase-3`) — none remain.

## Verified live after #353 merged

CI's `deploy-infra` ran Phases 1 and 2 automatically. Confirmed against Azure:

- `cosmos-sudoku-prod2` exists: `capabilities: [EnableServerless]`, `enableFreeTier: false`, `isZoneRedundant: false`, provisioning `Succeeded`.
- Database `sudoku` with containers `games` (`/gameId`) and `profiles` (`/profileId`). No `throughputSettings` resources — `az cosmosdb sql container throughput show` returns `NotFound`, as expected for serverless.
- Three Cosmos data-plane role assignments created by `assign-roles.sh`.
- The predicted config divergence is real and harmless: the API's `CosmosDb__AccountEndpoint` app setting now reads `cosmos-sudoku-prod2` (dead config), while the `ConnectionStrings--CosmosDb` Key Vault secret still points at `cosmos-sudoku-prod`. Production continues to serve from the old account, which is exactly the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
