### PR TITLE
Fix hint-path solver infinite loop flooding App Insights

### DIFF
--- a/src/backend/Sudoku.Infrastructure/Configuration/InfrastructureServiceCollectionExtensions.cs
+++ b/src/backend/Sudoku.Infrastructure/Configuration/InfrastructureServiceCollectionExtensions.cs
@@ -82,7 +82,7 @@ public static class InfrastructureServiceCollectionExtensions
         private IServiceCollection AddPuzzleServices()
         {
             services.AddScoped<IPuzzleGenerator, UniqueSolutionPuzzleGenerator>();
-            services.AddScoped<IPuzzleSolver, StrategyBasedPuzzleSolver>();
+            services.AddScoped<IPuzzleSolver, BitwiseBacktrackingPuzzleSolver>();
 
             typeof(SolverStrategy).Assembly
                 .GetTypes()

--- a/src/backend/Sudoku.Infrastructure/Services/StrategyBasedPuzzleSolver.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/StrategyBasedPuzzleSolver.cs
@@ -37,9 +37,10 @@ public class StrategyBasedPuzzleSolver(IEnumerable<SolverStrategy> strategies, I
                     break;
                 }
 
-                changesMade = await ApplyStrategies();
+                var strategiesMadeChanges = await ApplyStrategies();
+                var bruteForceMadeChanges = TryBruteForceMethod();
 
-                changesMade = TryBruteForceMethod();
+                changesMade = strategiesMadeChanges || bruteForceMadeChanges;
             }
             catch (InvalidPuzzleException)
             {
@@ -81,12 +82,11 @@ public class StrategyBasedPuzzleSolver(IEnumerable<SolverStrategy> strategies, I
     {
         logger.LogDebug("Solving with BruteForce technique");
         _puzzle.PopulatePossibleValues();
-        SetCellWithFewestPossibleValues();
 
-        return true;
+        return SetCellWithFewestPossibleValues();
     }
 
-    private void SetCellWithFewestPossibleValues()
+    private bool SetCellWithFewestPossibleValues()
     {
         var rnd = Random.Shared;
         var cell = _puzzle.Cells
@@ -97,12 +97,14 @@ public class StrategyBasedPuzzleSolver(IEnumerable<SolverStrategy> strategies, I
         if (cell == null)
         {
             logger.LogWarning("No cell with possible values found, puzzle might be solved or invalid.");
-            return;
+            return false;
         }
 
         var value = cell.PossibleValues.ElementAt(rnd.Next(cell.PossibleValues.Count));
         logger.LogDebug("Setting cell at ({Row}, {Column}) to {Value}", cell.Row, cell.Column, value);
         cell.SetValue(value);
+
+        return true;
     }
 
     private Task SaveAsync()

--- a/src/backend/Tests/Helpers/Factories/PuzzleFactory.cs
+++ b/src/backend/Tests/Helpers/Factories/PuzzleFactory.cs
@@ -39,6 +39,16 @@ public static class PuzzleFactory
         return PopulateCells(SolvedPuzzle);
     }
 
+    /// <summary>
+    /// A duplicate-free (valid) but unsolvable grid: every empty cell has zero candidates,
+    /// so a solver can make no progress. Used to prove the solver terminates instead of
+    /// looping forever re-logging "no cell with possible values".
+    /// </summary>
+    public static SudokuPuzzle GetUnsolvableStuckPuzzle()
+    {
+        return PopulateCells(UnsolvableStuckPuzzle);
+    }
+
     public static int?[,] RotateGrid(int?[,] values)
     {
         var grid = new int?[9, 9];
@@ -142,6 +152,19 @@ public static class PuzzleFactory
         { null, 6, null, null, null, null, 2, 8, null },
         { null, null, null, 4, 1, 9, null, null, 5 },
         { null, null, null, null, 8, null, null, 7 ,9}
+    };
+
+    private static readonly int?[,] UnsolvableStuckPuzzle =
+    {
+        { 3, 4, 5, 6, 7, 8, 9, 1, 2 },
+        { 9, 6, 7, 3, 4, 1, 5, 8, null }, // (1,8) has no legal value
+        { 2, 8, 1, 5, 9, null, 4, 3, 6 }, // (2,5) has no legal value
+        { 4, 1, 2, 7, 8, 5, 6, 9, 3 },
+        { 6, 3, 8, 9, 1, 2, 7, 4, 5 },
+        { 7, 5, 9, 4, 3, 6, 1, 2, 8 },
+        { 1, 7, 3, 8, 5, 9, 2, 6, 4 },
+        { 8, 9, 4, 2, 6, 3, null, 5, 7 }, // (7,6) has no legal value
+        { 5, 2, 6, 1, null, 4, 8, null, 9 } // (8,4) and (8,7) have no legal value
     };
 
     private static readonly int?[,] SolvedPuzzle =

--- a/src/backend/Tests/Infrastructure/Services/StrategyBasedPuzzleSolverTests.cs
+++ b/src/backend/Tests/Infrastructure/Services/StrategyBasedPuzzleSolverTests.cs
@@ -3,6 +3,7 @@ using Sudoku.Application.Interfaces;
 using Sudoku.Domain.Exceptions;
 using Sudoku.Domain.ValueObjects;
 using Sudoku.Infrastructure.Services;
+using Sudoku.Infrastructure.Services.Strategies;
 using UnitTests.Helpers.Factories;
 
 namespace UnitTests.Infrastructure.Services;
@@ -61,6 +62,27 @@ public class StrategyBasedPuzzleSolverTests : MoqBaseTestByAbstraction<StrategyB
         result.Should().NotBeNull();
         result.IsValid().Should().BeTrue();
         result.GetEmptyCellCount().Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SolvePuzzle_WhenBruteForceCannotFillAnyCell_TerminatesAndLogsWarningOnce()
+    {
+        // Arrange
+        // With no strategies, only the brute-force fallback runs. The grid is valid
+        // (duplicate-free) but unsolvable: every empty cell has zero candidates. Before
+        // the fix, brute force always reported progress, so the loop never exited and
+        // re-logged the same warning forever. Correct code makes one pass and stops; the
+        // short guard fails fast (instead of hanging CI) if the loop is reintroduced.
+        var puzzle = PuzzleFactory.GetUnsolvableStuckPuzzle();
+        var sut = new StrategyBasedPuzzleSolver(Array.Empty<SolverStrategy>(), _puzzleRepository.Object, Logger);
+
+        // Act
+        var solveTask = sut.SolvePuzzle(puzzle!);
+        var finished = await Task.WhenAny(solveTask, Task.Delay(TimeSpan.FromSeconds(2)));
+
+        // Assert
+        finished.Should().BeSameAs(solveTask, "the solver must terminate when no cell can be filled");
+        Logger.WarningLogs().Count(m => m.Contains("No cell with possible values found")).Should().Be(1);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

An App Insights cost spike (starting July 6) traced entirely to **log ingestion**, not queries — App Insights bills on data ingested. A single warning, *"No cell with possible values found, puzzle might be solved or invalid."*, was written **~12M times/day (~13 GB)**, dwarfing all other telemetry (which stayed flat).

Root cause: the hint feature (#218) resolves `IPuzzleSolver`, which DI bound to `StrategyBasedPuzzleSolver`. Its brute-force fallback `TryBruteForceMethod()` **always returned `true`**, so `SolveLoop()` never terminated on a board it couldn't finish — it spun forever, re-logging that warning every iteration.

Note: puzzle *generation* already uses the new `UniqueSolutionPuzzleGenerator`; only the hint path still used the old solver. A `BitwiseBacktrackingPuzzleSolver` already existed, documented as a drop-in for this interface, but was never wired up.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Bind `IPuzzleSolver` to `BitwiseBacktrackingPuzzleSolver` (deterministic, no logging/loop/repository round-trips) instead of `StrategyBasedPuzzleSolver`. This removes the old solver from the hint path — the root-cause fix.
- Make the brute-force fallback return whether it actually placed a cell, so the solve loop terminates instead of reporting false progress. Defense-in-depth for `StrategyBasedPuzzleSolver`, which is still used by the benchmarks project.
- Add a regression test using a valid-but-unsolvable grid (every empty cell has zero candidates), with a short timeout guard so a reintroduced loop fails fast rather than hanging CI.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

Full backend suite: **682 passed, 0 failed**. New regression test runs in ~160 ms.

## Screenshots (if applicable)

Daily `AppTraces` ingestion (billed MB), from Log Analytics:

| Date | AppTraces billed |
|------|------------------|
| Jul 5 (normal) | ~10 MB |
| Jul 6 | 2,739 MB |
| Jul 7 | 7,171 MB |
| Jul 9 | 8,729 MB |

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

## Follow-ups (not in this PR)

- The `SolverStrategy` types are still auto-registered in DI but are now only consumed by `StrategyBasedPuzzleSolver` in benchmarks; consider removing the app-side registrations.
- `StrategyBasedPuzzleSolver`'s *strategy* pipeline can still loop on genuinely unsolvable input (separate from the brute-force fix here). It's no longer on any production path, so this is low priority.
- Consider an ingestion cap / sampling rule so a future hot-loop log can't run up the bill again.
