### PR TITLE
Wire domain event dispatch in CosmosDbGameRepository.SaveAsync

### DIFF
--- a/src/backend/Sudoku.Infrastructure/EventHandling/DomainEventDispatcher.cs
+++ b/src/backend/Sudoku.Infrastructure/EventHandling/DomainEventDispatcher.cs
@@ -10,7 +10,7 @@ public class DomainEventDispatcher(IServiceProvider serviceProvider, ILogger<Dom
     {
         try
         {
-            logger.LogInformation("Dispatching domain event: {EventType}", domainEvent.GetType().Name);
+            logger.LogDebug("Dispatching domain event: {EventType}", domainEvent.GetType().Name);
 
             var handlerType = typeof(IDomainEventHandler<>).MakeGenericType(domainEvent.GetType());
             var handlers = serviceProvider.GetServices(handlerType);
@@ -24,7 +24,7 @@ public class DomainEventDispatcher(IServiceProvider serviceProvider, ILogger<Dom
                 await task;
             }
 
-            logger.LogInformation("Successfully dispatched domain event: {EventType}", domainEvent.GetType().Name);
+            logger.LogDebug("Successfully dispatched domain event: {EventType}", domainEvent.GetType().Name);
         }
         catch (Exception ex)
         {

--- a/src/backend/Sudoku.Infrastructure/Repositories/CosmosDbGameRepository.cs
+++ b/src/backend/Sudoku.Infrastructure/Repositories/CosmosDbGameRepository.cs
@@ -4,12 +4,16 @@ using Sudoku.Application.Specifications;
 using Sudoku.Domain.Entities;
 using Sudoku.Domain.Enums;
 using Sudoku.Domain.ValueObjects;
+using Sudoku.Infrastructure.EventHandling;
 using Sudoku.Infrastructure.Mappers;
 using Sudoku.Infrastructure.Services;
 
 namespace Sudoku.Infrastructure.Repositories;
 
-public class CosmosDbGameRepository(ICosmosDbService cosmosDbService, ILogger<CosmosDbGameRepository> logger) : IGameRepository
+public class CosmosDbGameRepository(
+    ICosmosDbService cosmosDbService,
+    IDomainEventDispatcher eventDispatcher,
+    ILogger<CosmosDbGameRepository> logger) : IGameRepository
 {
     public async Task<SudokuGame?> GetByIdAsync(GameId id)
     {
@@ -97,6 +101,27 @@ public class CosmosDbGameRepository(ICosmosDbService cosmosDbService, ILogger<Co
         {
             logger.LogError(ex, "Error saving game {GameId} to CosmosDB", game.Id.Value);
             throw;
+        }
+
+        await DispatchDomainEventsAsync(game);
+    }
+
+    private async Task DispatchDomainEventsAsync(SudokuGame game)
+    {
+        var domainEvents = game.DomainEvents.ToList();
+
+        // Clear before dispatching: a handler fault must not leave events queued
+        // for re-dispatch on the game's next save.
+        game.ClearDomainEvents();
+
+        try
+        {
+            await eventDispatcher.DispatchAsync(domainEvents);
+        }
+        catch (Exception ex)
+        {
+            // The game is already persisted, so a handler fault must not fail the caller.
+            logger.LogError(ex, "Error dispatching domain events for game {GameId}", game.Id.Value);
         }
     }
 

--- a/src/backend/Tests/Infrastructure/Repositories/CosmosDbGameRepositoryTests.cs
+++ b/src/backend/Tests/Infrastructure/Repositories/CosmosDbGameRepositoryTests.cs
@@ -3,6 +3,8 @@ using Sudoku.Application.Interfaces;
 using Sudoku.Domain.Entities;
 using Sudoku.Domain.Enums;
 using Sudoku.Domain.ValueObjects;
+using Sudoku.Domain.Events;
+using Sudoku.Infrastructure.EventHandling;
 using Sudoku.Infrastructure.Models;
 using Sudoku.Infrastructure.Repositories;
 using Sudoku.Infrastructure.Services;
@@ -14,10 +16,12 @@ namespace UnitTests.Infrastructure.Repositories;
 public class CosmosDbGameRepositoryTests : MoqBaseTestByAbstraction<CosmosDbGameRepository, IGameRepository>
 {
     private readonly Mock<ICosmosDbService> _mockCosmosDbService;
+    private readonly Mock<IDomainEventDispatcher> _mockEventDispatcher;
 
     public CosmosDbGameRepositoryTests()
     {
         _mockCosmosDbService = Container.ResolveMock<ICosmosDbService>().AsMoq();
+        _mockEventDispatcher = Container.ResolveMock<IDomainEventDispatcher>().AsMoq();
     }
 
     protected override void AddContainerCustomizations(Container container)
@@ -161,5 +165,94 @@ public class CosmosDbGameRepositoryTests : MoqBaseTestByAbstraction<CosmosDbGame
 
         // Assert
         _mockCosmosDbService.VerifyUpsertItemAsync(game.Id, displayName.Value, difficulty, Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAsync_ShouldDispatchAccumulatedDomainEvents()
+    {
+        // Arrange
+        var game = GameFactory.CreateEmptyGame();
+        var sut = ResolveSut();
+
+        // Act
+        await sut.SaveAsync(game);
+
+        // Assert
+        _mockEventDispatcher.VerifyDispatched<GameCreatedEvent>(Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAsync_ShouldClearDomainEventsAfterDispatching()
+    {
+        // Arrange
+        var game = GameFactory.CreateEmptyGame();
+        var sut = ResolveSut();
+
+        // Act
+        await sut.SaveAsync(game);
+
+        // Assert
+        game.DomainEvents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SaveAsync_WhenSavedTwice_DoesNotRedispatchTheSameEvents()
+    {
+        // Arrange
+        var game = GameFactory.CreateEmptyGame();
+        var sut = ResolveSut();
+        await sut.SaveAsync(game);
+
+        // Act
+        await sut.SaveAsync(game);
+
+        // Assert
+        _mockEventDispatcher.VerifyDispatchedEventCount(0, Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAsync_WhenDispatcherThrows_DoesNotThrow()
+    {
+        // Arrange
+        var game = GameFactory.CreateEmptyGame();
+        _mockEventDispatcher.SetupDispatchThrows(new InvalidOperationException("Handler blew up"));
+        var sut = ResolveSut();
+
+        // Act
+        var saveAsync = async () => await sut.SaveAsync(game);
+
+        // Assert
+        await saveAsync.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task SaveAsync_WhenDispatcherThrows_LogsError()
+    {
+        // Arrange
+        var game = GameFactory.CreateEmptyGame();
+        _mockEventDispatcher.SetupDispatchThrows(new InvalidOperationException("Handler blew up"));
+        var sut = ResolveSut();
+
+        // Act
+        await sut.SaveAsync(game);
+
+        // Assert
+        Logger.ErrorLogs().ContainsMessage($"Error dispatching domain events for game {game.Id.Value}");
+    }
+
+    [Fact]
+    public async Task SaveAsync_WhenUpsertThrows_DoesNotDispatchDomainEvents()
+    {
+        // Arrange
+        var game = GameFactory.CreateEmptyGame();
+        _mockCosmosDbService.SetupUpsertThrows(new InvalidOperationException("Cosmos is down"));
+        var sut = ResolveSut();
+
+        // Act
+        var saveAsync = async () => await sut.SaveAsync(game);
+
+        // Assert
+        await saveAsync.Should().ThrowAsync<InvalidOperationException>();
+        _mockEventDispatcher.VerifyDispatched<GameCreatedEvent>(Times.Never);
     }
 }

--- a/src/backend/Tests/Mocks/MockCosmosDbServiceExtensions.cs
+++ b/src/backend/Tests/Mocks/MockCosmosDbServiceExtensions.cs
@@ -35,6 +35,13 @@ public static class MockCosmosDbServiceExtensions
                 .ReturnsAsync(documents);
         }
 
+        public void SetupUpsertThrows(Exception ex)
+        {
+            mock
+                .Setup(x => x.UpsertItemAsync(It.IsAny<SudokuGameDocument>(), It.IsAny<string?>()))
+                .ThrowsAsync(ex);
+        }
+
         public void VerifyDeleteItemAsync(string gameId, Func<Times> times)
         {
             mock.Verify(x => x.DeleteItemAsync<SudokuGameDocument>(

--- a/src/backend/Tests/Mocks/MockDomainEventDispatcherExtensions.cs
+++ b/src/backend/Tests/Mocks/MockDomainEventDispatcherExtensions.cs
@@ -1,0 +1,27 @@
+using Sudoku.Domain.Events;
+using Sudoku.Infrastructure.EventHandling;
+
+namespace UnitTests.Mocks;
+
+public static class MockDomainEventDispatcherExtensions
+{
+    extension(Mock<IDomainEventDispatcher> mock)
+    {
+        public void SetupDispatchThrows(Exception ex)
+        {
+            mock
+                .Setup(x => x.DispatchAsync(It.IsAny<IEnumerable<DomainEvent>>()))
+                .ThrowsAsync(ex);
+        }
+
+        public void VerifyDispatched<TEvent>(Func<Times> times) where TEvent : DomainEvent
+        {
+            mock.Verify(x => x.DispatchAsync(It.Is<IEnumerable<DomainEvent>>(events => events.OfType<TEvent>().Any())), times);
+        }
+
+        public void VerifyDispatchedEventCount(int expectedCount, Func<Times> times)
+        {
+            mock.Verify(x => x.DispatchAsync(It.Is<IEnumerable<DomainEvent>>(events => events.Count() == expectedCount)), times);
+        }
+    }
+}


### PR DESCRIPTION
## Description

The domain event pipeline is **registered in DI but never invoked at runtime**. `DomainEventDispatcher` exists and aggregates accumulate events via `AddDomainEvent()`, but no production code calls `IDomainEventDispatcher.DispatchAsync` or reads `aggregate.DomainEvents` — the only callers today are tests and docs. Every `IDomainEventHandler` (`GameCreatedEventHandler`, `MoveMadeEventHandler`, `GameCompletedEventHandler`) is therefore dead code.

This PR closes that gap. It is a **prerequisite for the Game Stats page (#215)**, which needs `GameCompletedEventHandler` to actually fire, but the change is foundational rather than stats-specific and is deliberately split out so it can be reviewed on its own terms.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- `CosmosDbGameRepository` takes `IDomainEventDispatcher`; `SaveAsync` dispatches the aggregate's accumulated `DomainEvents` after a successful upsert. This single point uniformly covers `CompleteGame()` raised inside `MakeMove()`/`RevealHint()`, plus every other aggregate event.
- Events are **cleared before** dispatching, so a handler fault cannot leave them queued for re-dispatch on the game's next save.
- The dispatch call is **contained (log-and-continue)**. `DomainEventDispatcher` keeps its existing rethrow contract — the containment lives at the call site, because by the time events dispatch the game is already persisted, and a handler fault must never fail the operation that persisted it (e.g. a completing move).
- Dropped the dispatcher's two per-event `LogInformation` lines to `LogDebug`.

## Blast radius

This activates all three currently-stubbed handlers. They are log-only no-ops today, so the only runtime behaviour change is **more log volume** — which is exactly why the dispatcher's per-event info logs were demoted to debug: `MoveMadeEvent` fires on *every move*, and App Insights bills on ingestion (see the hint-solver log-flood incident, #359). Worth a second pair of eyes on whether the remaining handler-level `LogInformation` in `MoveMadeEventHandler` should also drop to debug.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

`dotnet test` → 688 passed, 0 failed. Six new tests on `CosmosDbGameRepositoryTests`:

- `SaveAsync` dispatches the aggregate's accumulated domain events
- `SaveAsync` clears domain events after dispatching
- saving twice does not re-dispatch the same events
- a throwing dispatcher does not fail `SaveAsync`, and logs an error
- a failing upsert still throws, and dispatches nothing

DI resolution is already covered: `DependencyInjectionTests` resolves `IGameRepository` from the real container, which now constructs with the dispatcher.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
