### PR TITLE
Add player game stats page (#215)

### DIFF
--- a/infra/modules/storage.bicep
+++ b/infra/modules/storage.bicep
@@ -285,6 +285,46 @@ resource profilesThroughput 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/
   }
 }
 
+// Slim, append-only record of every won game (id = gameId, so writes are idempotent).
+// Outlives the full game document, which the client deletes on solve.
+resource gameCompletionsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-05-15' = {
+  parent: sudokuDatabase
+  name: 'game-completions'
+  properties: {
+    resource: {
+      id: 'game-completions'
+      partitionKey: {
+        paths: ['/profileId']
+        kind: 'Hash'
+        version: 2
+      }
+      indexingPolicy: {
+        indexingMode: 'consistent'
+        automatic: true
+        includedPaths: [{ path: '/*' }]
+        excludedPaths: [{ path: '/"_etag"/?' }]
+      }
+      uniqueKeyPolicy: {
+        uniqueKeys: []
+      }
+      conflictResolutionPolicy: {
+        mode: 'LastWriterWins'
+        conflictResolutionPath: '/_ts'
+      }
+    }
+  }
+}
+
+resource gameCompletionsThroughput 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/throughputSettings@2024-05-15' = if (!cosmosDbServerless) {
+  parent: gameCompletionsContainer
+  name: 'default'
+  properties: {
+    resource: {
+      throughput: 400
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Event Grid system topic — source of BlobDeleted events on this account.
 // The eventSubscription that routes BlobDeleted → PuzzleReplenishFunction

--- a/src/backend/Sudoku.Api/Controllers/StatsController.cs
+++ b/src/backend/Sudoku.Api/Controllers/StatsController.cs
@@ -1,0 +1,37 @@
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Sudoku.Application.DTOs;
+using Sudoku.Application.Queries;
+
+namespace Sudoku.Api.Controllers;
+
+[Route("api/players/{profileId}/stats")]
+[ApiController]
+public class StatsController(IMediator mediator) : BaseGameController(mediator)
+{
+    /// <summary>
+    /// Gets aggregated game statistics for the specified player profile.
+    /// </summary>
+    /// <param name="profileId">The profile ID of the player</param>
+    /// <returns>The player's games played, games won, win rate, and per-difficulty breakdown</returns>
+    /// <remarks>A player with no games is a valid result: zeroed stats, not a 404.</remarks>
+    [HttpGet]
+    [ProducesResponseType(typeof(PlayerStatsDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<PlayerStatsDto>> GetPlayerStatsAsync(string profileId)
+    {
+        if (string.IsNullOrWhiteSpace(profileId))
+        {
+            return BadRequest("Profile ID cannot be null or empty.");
+        }
+
+        var result = await Mediator.Send(new GetPlayerStatsQuery(profileId));
+
+        if (!result.IsSuccess)
+        {
+            return BadRequest(result.Error);
+        }
+
+        return Ok(result.Value);
+    }
+}

--- a/src/backend/Sudoku.Application/DTOs/PlayerStatsDto.cs
+++ b/src/backend/Sudoku.Application/DTOs/PlayerStatsDto.cs
@@ -1,0 +1,14 @@
+namespace Sudoku.Application.DTOs;
+
+public record PlayerStatsDto(
+    int GamesPlayed,
+    int GamesWon,
+    double WinRate,
+    IReadOnlyList<DifficultyStatsDto> ByDifficulty);
+
+public record DifficultyStatsDto(
+    string Difficulty,
+    int GamesPlayed,
+    int GamesWon,
+    TimeSpan? AverageSolveTime,
+    TimeSpan? BestSolveTime);

--- a/src/backend/Sudoku.Application/Handlers/DeleteGameCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/DeleteGameCommandHandler.cs
@@ -2,27 +2,35 @@ using Microsoft.Extensions.Logging;
 using Sudoku.Application.Commands;
 using Sudoku.Application.Common;
 using Sudoku.Application.Interfaces;
+using Sudoku.Application.Models;
+using Sudoku.Domain.Entities;
+using Sudoku.Domain.Enums;
 using Sudoku.Domain.Exceptions;
 using Sudoku.Domain.ValueObjects;
 
 namespace Sudoku.Application.Handlers;
 
-public class DeleteGameCommandHandler(IGameRepository gameRepository, ILogger<DeleteGameCommandHandler> logger) : ICommandHandler<DeleteGameCommand>
+public class DeleteGameCommandHandler(
+    IGameRepository gameRepository,
+    IGameCompletionRepository completionRepository,
+    ILogger<DeleteGameCommandHandler> logger) : ICommandHandler<DeleteGameCommand>
 {
     public async Task<Result> Handle(DeleteGameCommand request, CancellationToken cancellationToken)
     {
         try
         {
             var gameId = GameId.Create(request.GameId);
-            
+
             var game = await gameRepository.GetByIdAsync(gameId);
             if (game == null)
             {
                 return Result.Failure($"Game not found with ID: {request.GameId}");
             }
-            
+
+            await EnsureCompletionRecordedAsync(game);
+
             await gameRepository.DeleteAsync(gameId);
-            
+
             logger.LogInformation("Deleted game with ID: {GameId}", gameId.Value);
             return Result.Success();
         }
@@ -36,5 +44,38 @@ public class DeleteGameCommandHandler(IGameRepository gameRepository, ILogger<De
             logger.LogError(ex, "An unexpected error occurred deleting game");
             return Result.Failure($"An unexpected error occurred: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Backstop for the completion record. The client deletes a game moments after solving it,
+    /// so a completed game must never be deleted without its win being recorded first — this
+    /// closes the gap if <c>GameCompletedEventHandler</c> was skipped or failed. If the write
+    /// throws, the delete is abandoned and the game document survives to be retried.
+    /// </summary>
+    private async Task EnsureCompletionRecordedAsync(SudokuGame game)
+    {
+        if (game.Status != GameStatusEnum.Completed)
+        {
+            return;
+        }
+
+        var existing = await completionRepository.GetByGameIdAsync(game.Id, game.ProfileId);
+        if (existing != null)
+        {
+            return;
+        }
+
+        var completion = new GameCompletion(
+            game.Id.ToString(),
+            game.ProfileId.ToString(),
+            game.Difficulty.Name,
+            game.Statistics.PlayDuration,
+            game.CompletedAt ?? DateTime.UtcNow);
+
+        await completionRepository.UpsertAsync(completion);
+
+        logger.LogInformation(
+            "Backstop recorded completion for game {GameId} (profile {ProfileId}, {Difficulty}) at delete time",
+            completion.GameId, completion.ProfileId, completion.Difficulty);
     }
 }

--- a/src/backend/Sudoku.Application/Handlers/GetPlayerStatsQueryHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/GetPlayerStatsQueryHandler.cs
@@ -78,13 +78,19 @@ public class GetPlayerStatsQueryHandler(
         var won = wins.Count;
         var played = won + active;
 
+        // Truncated to whole seconds: a raw tick average lands on sub-second precision
+        // (averaging 1s and 2s gives 1.5s), which System.Text.Json emits as
+        // "00:00:01.5000000" — breaking the "HH:MM:SS" contract the clients parse.
         TimeSpan? averageSolveTime = won == 0
             ? null
-            : TimeSpan.FromTicks((long)wins.Average(win => win.PlayDuration.Ticks));
+            : TruncateToSeconds(TimeSpan.FromTicks((long)wins.Average(win => win.PlayDuration.Ticks)));
         TimeSpan? bestSolveTime = won == 0
             ? null
-            : wins.Min(win => win.PlayDuration);
+            : TruncateToSeconds(wins.Min(win => win.PlayDuration));
 
         return new DifficultyStatsDto(difficulty.Name, played, won, averageSolveTime, bestSolveTime);
     }
+
+    private static TimeSpan TruncateToSeconds(TimeSpan value) =>
+        TimeSpan.FromSeconds(Math.Floor(value.TotalSeconds));
 }

--- a/src/backend/Sudoku.Application/Handlers/GetPlayerStatsQueryHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/GetPlayerStatsQueryHandler.cs
@@ -1,0 +1,90 @@
+using Microsoft.Extensions.Logging;
+using Sudoku.Application.Common;
+using Sudoku.Application.DTOs;
+using Sudoku.Application.Interfaces;
+using Sudoku.Application.Models;
+using Sudoku.Application.Queries;
+using Sudoku.Domain.Entities;
+using Sudoku.Domain.Enums;
+using Sudoku.Domain.Exceptions;
+using Sudoku.Domain.ValueObjects;
+
+namespace Sudoku.Application.Handlers;
+
+public class GetPlayerStatsQueryHandler(
+    IGameCompletionRepository completionRepository,
+    IGameRepository gameRepository,
+    ILogger<GetPlayerStatsQueryHandler> logger) : IQueryHandler<GetPlayerStatsQuery, PlayerStatsDto>
+{
+    // Fixed order so a difficulty the player has never touched still renders a row.
+    private static readonly GameDifficulty[] Difficulties =
+    [
+        GameDifficulty.Easy,
+        GameDifficulty.Medium,
+        GameDifficulty.Hard,
+        GameDifficulty.Expert
+    ];
+
+    public async Task<Result<PlayerStatsDto>> Handle(GetPlayerStatsQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var profileId = ProfileId.From(request.ProfileId);
+
+            var completions = (await completionRepository.GetByProfileIdAsync(profileId)).ToList();
+
+            // Completed games are deleted by the client, but exclude any transiently-present
+            // completed document so a win isn't counted by both this and its completion record.
+            var activeGames = (await gameRepository.GetByProfileIdAsync(profileId))
+                .Where(game => game.Status != GameStatusEnum.Completed)
+                .ToList();
+
+            var gamesWon = completions.Count;
+            var gamesPlayed = gamesWon + activeGames.Count;
+            var winRate = gamesPlayed == 0 ? 0 : (double)gamesWon / gamesPlayed;
+
+            var byDifficulty = Difficulties
+                .Select(difficulty => BuildDifficultyStats(difficulty, completions, activeGames))
+                .ToList();
+
+            logger.LogInformation(
+                "Retrieved stats for profile {ProfileId}: {GamesPlayed} played, {GamesWon} won",
+                profileId.Value, gamesPlayed, gamesWon);
+
+            return Result<PlayerStatsDto>.Success(new PlayerStatsDto(gamesPlayed, gamesWon, winRate, byDifficulty));
+        }
+        catch (DomainException ex)
+        {
+            logger.LogWarning("Failed to get stats for profile {ProfileId}: {Error}", request.ProfileId, ex.Message);
+            return Result<PlayerStatsDto>.Failure(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An unexpected error occurred getting stats for profile {ProfileId}", request.ProfileId);
+            return Result<PlayerStatsDto>.Failure($"An unexpected error occurred: {ex.Message}");
+        }
+    }
+
+    private static DifficultyStatsDto BuildDifficultyStats(
+        GameDifficulty difficulty,
+        IEnumerable<GameCompletion> completions,
+        IEnumerable<SudokuGame> activeGames)
+    {
+        var wins = completions
+            .Where(completion => string.Equals(completion.Difficulty, difficulty.Name, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        var active = activeGames.Count(game => game.Difficulty == difficulty);
+
+        var won = wins.Count;
+        var played = won + active;
+
+        TimeSpan? averageSolveTime = won == 0
+            ? null
+            : TimeSpan.FromTicks((long)wins.Average(win => win.PlayDuration.Ticks));
+        TimeSpan? bestSolveTime = won == 0
+            ? null
+            : wins.Min(win => win.PlayDuration);
+
+        return new DifficultyStatsDto(difficulty.Name, played, won, averageSolveTime, bestSolveTime);
+    }
+}

--- a/src/backend/Sudoku.Application/Interfaces/IGameCompletionRepository.cs
+++ b/src/backend/Sudoku.Application/Interfaces/IGameCompletionRepository.cs
@@ -1,0 +1,16 @@
+using Sudoku.Application.Models;
+using Sudoku.Domain.ValueObjects;
+
+namespace Sudoku.Application.Interfaces;
+
+public interface IGameCompletionRepository
+{
+    Task<IEnumerable<GameCompletion>> GetByProfileIdAsync(ProfileId profileId);
+    Task<GameCompletion?> GetByGameIdAsync(GameId gameId, ProfileId profileId);
+
+    /// <summary>
+    /// Idempotent upsert keyed by <see cref="GameCompletion.GameId"/>. A duplicate completion
+    /// event or the delete-time backstop writing the same game must not double-count.
+    /// </summary>
+    Task UpsertAsync(GameCompletion completion);
+}

--- a/src/backend/Sudoku.Application/Models/GameCompletion.cs
+++ b/src/backend/Sudoku.Application/Models/GameCompletion.cs
@@ -1,0 +1,13 @@
+namespace Sudoku.Application.Models;
+
+/// <summary>
+/// A compact, durable record of a won game. Written when a game completes and keyed by
+/// <see cref="GameId"/> so writes are idempotent. Survives deletion of the full game
+/// document, which the client issues moments after a puzzle is solved.
+/// </summary>
+public record GameCompletion(
+    string GameId,
+    string ProfileId,
+    string Difficulty,
+    TimeSpan PlayDuration,
+    DateTime CompletedAt);

--- a/src/backend/Sudoku.Application/Queries/GetPlayerStatsQuery.cs
+++ b/src/backend/Sudoku.Application/Queries/GetPlayerStatsQuery.cs
@@ -1,0 +1,6 @@
+using Sudoku.Application.Common;
+using Sudoku.Application.DTOs;
+
+namespace Sudoku.Application.Queries;
+
+public record GetPlayerStatsQuery(string ProfileId) : IQuery<PlayerStatsDto>;

--- a/src/backend/Sudoku.Domain/Entities/SudokuGame.cs
+++ b/src/backend/Sudoku.Domain/Entities/SudokuGame.cs
@@ -472,10 +472,12 @@ public class SudokuGame : AggregateRoot
 
     public void CompleteGame()
     {
-        Status = GameStatusEnum.Completed;
-        CompletedAt = DateTime.UtcNow;
+        var completedAt = DateTime.UtcNow;
 
-        AddDomainEvent(new GameCompletedEvent(Id, Statistics));
+        Status = GameStatusEnum.Completed;
+        CompletedAt = completedAt;
+
+        AddDomainEvent(new GameCompletedEvent(Id, ProfileId, Difficulty, Statistics, completedAt));
     }
 }
 

--- a/src/backend/Sudoku.Domain/Events/GameEvents.cs
+++ b/src/backend/Sudoku.Domain/Events/GameEvents.cs
@@ -10,7 +10,12 @@ public record GamePausedEvent(GameId GameId) : DomainEvent;
 
 public record GameResumedEvent(GameId GameId) : DomainEvent;
 
-public record GameCompletedEvent(GameId GameId, GameStatistics Statistics) : DomainEvent;
+public record GameCompletedEvent(
+    GameId GameId,
+    ProfileId ProfileId,
+    GameDifficulty Difficulty,
+    GameStatistics Statistics,
+    DateTime CompletedAt) : DomainEvent;
 
 public record GameAbandonedEvent(GameId GameId) : DomainEvent;
 

--- a/src/backend/Sudoku.Infrastructure/Configuration/InfrastructureServiceCollectionExtensions.cs
+++ b/src/backend/Sudoku.Infrastructure/Configuration/InfrastructureServiceCollectionExtensions.cs
@@ -73,6 +73,7 @@ public static class InfrastructureServiceCollectionExtensions
         {
             services.AddScoped<ICosmosDbService, CosmosDbService>();
             services.AddScoped<IGameRepository, CosmosDbGameRepository>();
+            services.AddScoped<IGameCompletionRepository, CosmosDbGameCompletionRepository>();
             services.AddScoped<IUserProfileRepository, CosmosDbUserProfileRepository>();
             services.AddScoped<IPuzzleRepository, InMemoryPuzzleRepository>();
 

--- a/src/backend/Sudoku.Infrastructure/EventHandling/GameCompletedEventHandler.cs
+++ b/src/backend/Sudoku.Infrastructure/EventHandling/GameCompletedEventHandler.cs
@@ -1,21 +1,28 @@
 using Microsoft.Extensions.Logging;
+using Sudoku.Application.Interfaces;
+using Sudoku.Application.Models;
 using Sudoku.Domain.Events;
 
 namespace Sudoku.Infrastructure.EventHandling;
 
-public class GameCompletedEventHandler(ILogger<GameCompletedEventHandler> logger) : IDomainEventHandler<GameCompletedEvent>
+public class GameCompletedEventHandler(
+    IGameCompletionRepository completionRepository,
+    ILogger<GameCompletedEventHandler> logger) : IDomainEventHandler<GameCompletedEvent>
 {
     public async Task HandleAsync(GameCompletedEvent domainEvent)
     {
-        logger.LogInformation("Game completed: {GameId}", domainEvent.GameId.Value);
+        // GameStatistics is mutable and captured on the event by reference, so read it now.
+        var completion = new GameCompletion(
+            domainEvent.GameId.ToString(),
+            domainEvent.ProfileId.ToString(),
+            domainEvent.Difficulty.Name,
+            domainEvent.Statistics.PlayDuration,
+            domainEvent.CompletedAt);
 
-        // Here you could:
-        // - Send completion notifications
-        // - Update player statistics
-        // - Award achievements
-        // - Send to leaderboards
-        // - Trigger analytics
+        await completionRepository.UpsertAsync(completion);
 
-        await Task.CompletedTask;
+        logger.LogInformation(
+            "Recorded completion for game {GameId} (profile {ProfileId}, {Difficulty})",
+            completion.GameId, completion.ProfileId, completion.Difficulty);
     }
 }

--- a/src/backend/Sudoku.Infrastructure/Models/GameCompletionDocument.cs
+++ b/src/backend/Sudoku.Infrastructure/Models/GameCompletionDocument.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace Sudoku.Infrastructure.Models;
+
+public class GameCompletionDocument
+{
+    [JsonProperty("id")]           public string Id { get; set; } = string.Empty;
+    [JsonProperty("gameId")]       public string GameId { get; set; } = string.Empty;
+    [JsonProperty("profileId")]    public string ProfileId { get; set; } = string.Empty;
+    [JsonProperty("difficulty")]   public string Difficulty { get; set; } = string.Empty;
+    [JsonProperty("playDuration")] public TimeSpan PlayDuration { get; set; }
+    [JsonProperty("completedAt")]  public DateTime CompletedAt { get; set; }
+}

--- a/src/backend/Sudoku.Infrastructure/Repositories/CosmosDbGameCompletionRepository.cs
+++ b/src/backend/Sudoku.Infrastructure/Repositories/CosmosDbGameCompletionRepository.cs
@@ -27,7 +27,11 @@ public class CosmosDbGameCompletionRepository(
             var queryDefinition = new QueryDefinition(sqlQuery).WithParameter("@profileId", profileId.ToString());
             var documents = new List<GameCompletionDocument>();
 
-            using var iterator = _container!.GetItemQueryIterator<GameCompletionDocument>(queryDefinition);
+            // A player's completions all live in their own partition, so scope the query to it
+            // rather than letting Cosmos fan out cross-partition.
+            var queryOptions = new QueryRequestOptions { PartitionKey = new PartitionKey(profileId.ToString()) };
+
+            using var iterator = _container!.GetItemQueryIterator<GameCompletionDocument>(queryDefinition, requestOptions: queryOptions);
             while (iterator.HasMoreResults)
             {
                 var response = await iterator.ReadNextAsync();

--- a/src/backend/Sudoku.Infrastructure/Repositories/CosmosDbGameCompletionRepository.cs
+++ b/src/backend/Sudoku.Infrastructure/Repositories/CosmosDbGameCompletionRepository.cs
@@ -1,0 +1,122 @@
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Sudoku.Application.Interfaces;
+using Sudoku.Application.Models;
+using Sudoku.Domain.ValueObjects;
+using Sudoku.Infrastructure.Configuration;
+using Sudoku.Infrastructure.Models;
+
+namespace Sudoku.Infrastructure.Repositories;
+
+public class CosmosDbGameCompletionRepository(
+    CosmosClient cosmosClient,
+    IOptions<CosmosDbOptions> options,
+    ILogger<CosmosDbGameCompletionRepository> logger) : IGameCompletionRepository
+{
+    private const string CompletionsContainerName = "game-completions";
+    private Container? _container;
+
+    public async Task<IEnumerable<GameCompletion>> GetByProfileIdAsync(ProfileId profileId)
+    {
+        try
+        {
+            await EnsureContainerAsync();
+
+            var sqlQuery = "SELECT * FROM c WHERE c.profileId = @profileId ORDER BY c.completedAt DESC";
+            var queryDefinition = new QueryDefinition(sqlQuery).WithParameter("@profileId", profileId.ToString());
+            var documents = new List<GameCompletionDocument>();
+
+            using var iterator = _container!.GetItemQueryIterator<GameCompletionDocument>(queryDefinition);
+            while (iterator.HasMoreResults)
+            {
+                var response = await iterator.ReadNextAsync();
+                documents.AddRange(response);
+            }
+
+            return documents.Select(ToDomain).ToList();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error retrieving game completions for profile {ProfileId}", profileId);
+            throw;
+        }
+    }
+
+    public async Task<GameCompletion?> GetByGameIdAsync(GameId gameId, ProfileId profileId)
+    {
+        try
+        {
+            await EnsureContainerAsync();
+
+            var response = await _container!.ReadItemAsync<GameCompletionDocument>(
+                gameId.ToString(), new PartitionKey(profileId.ToString()));
+
+            return ToDomain(response.Resource);
+        }
+        catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error retrieving game completion {GameId}", gameId);
+            throw;
+        }
+    }
+
+    public async Task UpsertAsync(GameCompletion completion)
+    {
+        try
+        {
+            await EnsureContainerAsync();
+
+            var document = ToDocument(completion);
+
+            await _container!.UpsertItemAsync(document, new PartitionKey(document.ProfileId));
+
+            logger.LogDebug("Upserted game completion {GameId}", completion.GameId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error upserting game completion {GameId}", completion.GameId);
+            throw;
+        }
+    }
+
+    private static GameCompletionDocument ToDocument(GameCompletion completion) => new()
+    {
+        Id = completion.GameId,
+        GameId = completion.GameId,
+        ProfileId = completion.ProfileId,
+        Difficulty = completion.Difficulty,
+        PlayDuration = completion.PlayDuration,
+        CompletedAt = completion.CompletedAt
+    };
+
+    private static GameCompletion ToDomain(GameCompletionDocument document) => new(
+        document.GameId,
+        document.ProfileId,
+        document.Difficulty,
+        document.PlayDuration,
+        document.CompletedAt);
+
+    private async Task EnsureContainerAsync()
+    {
+        if (_container != null) return;
+
+        if (options.Value.AutoCreateContainers)
+        {
+            var dbResponse = await cosmosClient.CreateDatabaseIfNotExistsAsync(options.Value.DatabaseName);
+            var containerProperties = new ContainerProperties(CompletionsContainerName, "/profileId");
+            var containerResponse = await dbResponse.Database.CreateContainerIfNotExistsAsync(containerProperties);
+            _container = containerResponse.Container;
+        }
+        else
+        {
+            var database = cosmosClient.GetDatabase(options.Value.DatabaseName);
+            _container = database.GetContainer(CompletionsContainerName);
+            await _container.ReadContainerAsync();
+        }
+    }
+}

--- a/src/backend/Tests/API/DependencyInjectionTests.cs
+++ b/src/backend/Tests/API/DependencyInjectionTests.cs
@@ -168,6 +168,7 @@ public class DependencyInjectionTests
         {
             typeof(IMediator),
             typeof(IGameRepository),
+            typeof(IGameCompletionRepository),
             typeof(IPuzzleRepository),
             typeof(IPuzzleGenerator),
             typeof(IPuzzleSolver),

--- a/src/backend/Tests/API/StatsControllerTests.cs
+++ b/src/backend/Tests/API/StatsControllerTests.cs
@@ -1,0 +1,87 @@
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Sudoku.Api.Controllers;
+using Sudoku.Application.Common;
+using Sudoku.Application.DTOs;
+using Sudoku.Application.Queries;
+
+namespace UnitTests.API;
+
+public class StatsControllerTests : BaseGameControllerTests<StatsController>
+{
+    [Fact]
+    public async Task GetPlayerStatsAsync_WithValidProfileId_ReturnsOkWithStats()
+    {
+        // Arrange
+        var profileId = Guid.NewGuid().ToString();
+        var stats = CreateTestStats();
+        SetupStatsQuery(Result<PlayerStatsDto>.Success(stats));
+
+        // Act
+        var result = await Sut.GetPlayerStatsAsync(profileId);
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.Value.Should().BeAssignableTo<PlayerStatsDto>().Subject.Should().BeEquivalentTo(stats);
+    }
+
+    [Fact]
+    public async Task GetPlayerStatsAsync_WithValidProfileId_SendsQueryWithThatProfileId()
+    {
+        // Arrange
+        var profileId = Guid.NewGuid().ToString();
+        SetupStatsQuery(Result<PlayerStatsDto>.Success(CreateTestStats()));
+
+        // Act
+        await Sut.GetPlayerStatsAsync(profileId);
+
+        // Assert
+        MockMediator.Verify(
+            x => x.Send(It.Is<GetPlayerStatsQuery>(q => q.ProfileId == profileId), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task GetPlayerStatsAsync_WithEmptyProfileId_ReturnsBadRequest(string profileId)
+    {
+        // Act
+        var result = await Sut.GetPlayerStatsAsync(profileId);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetPlayerStatsAsync_WhenResultIsFailure_ReturnsBadRequest()
+    {
+        // Arrange
+        SetupStatsQuery(Result<PlayerStatsDto>.Failure("Something went wrong"));
+
+        // Act
+        var result = await Sut.GetPlayerStatsAsync(Guid.NewGuid().ToString());
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    private void SetupStatsQuery(Result<PlayerStatsDto> result)
+    {
+        MockMediator
+            .Setup(x => x.Send(It.IsAny<GetPlayerStatsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+    }
+
+    private static PlayerStatsDto CreateTestStats() => new(
+        GamesPlayed: 3,
+        GamesWon: 2,
+        WinRate: 2d / 3d,
+        ByDifficulty:
+        [
+            new DifficultyStatsDto("Easy", 2, 2, TimeSpan.FromMinutes(6), TimeSpan.FromMinutes(4)),
+            new DifficultyStatsDto("Medium", 1, 0, null, null),
+            new DifficultyStatsDto("Hard", 0, 0, null, null),
+            new DifficultyStatsDto("Expert", 0, 0, null, null)
+        ]);
+}

--- a/src/backend/Tests/Application/Handlers/DeleteGameCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/DeleteGameCommandHandlerTests.cs
@@ -4,8 +4,10 @@ using Microsoft.Extensions.Logging;
 using Sudoku.Application.Commands;
 using Sudoku.Application.Common;
 using Sudoku.Application.Interfaces;
+using Sudoku.Application.Models;
 using Sudoku.Domain.Entities;
 using Sudoku.Domain.ValueObjects;
+using UnitTests.Helpers.Factories;
 using Handler = Sudoku.Application.Handlers.DeleteGameCommandHandler;
 
 namespace UnitTests.Application.Handlers;
@@ -14,11 +16,13 @@ namespace UnitTests.Application.Handlers;
 public class DeleteGameCommandHandlerTests : MoqBaseTestByAbstraction<Handler, ICommandHandler<DeleteGameCommand>>
 {
     private readonly Mock<IGameRepository> _mockGameRepository;
+    private readonly Mock<IGameCompletionRepository> _mockCompletionRepository;
     private readonly Mock<ILogger<Handler>> _mockLogger;
 
     public DeleteGameCommandHandlerTests()
     {
         _mockGameRepository = Container.ResolveMock<IGameRepository>().AsMoq();
+        _mockCompletionRepository = Container.ResolveMock<IGameCompletionRepository>().AsMoq();
         _mockLogger = Container.ResolveMock<ILogger<Handler>>().AsMoq();
     }
 
@@ -43,6 +47,84 @@ public class DeleteGameCommandHandlerTests : MoqBaseTestByAbstraction<Handler, I
 
         // Assert
         result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_WhenGameIsCompletedAndHasNoRecord_UpsertsCompletionRecordBeforeDeleting()
+    {
+        // Arrange — the backstop: a won game must never be deleted without its win being recorded.
+        var game = GameFactory.CreateCompletedGame();
+        _mockGameRepository.SetupGetById(game);
+        _mockCompletionRepository.SetupCompletionNotFound();
+        var sut = ResolveSut();
+
+        // Act
+        await sut.Handle(new DeleteGameCommand(game.Id.ToString()), CancellationToken.None);
+
+        // Assert
+        _mockCompletionRepository.VerifyUpserted(
+            new GameCompletion(
+                game.Id.ToString(),
+                game.ProfileId.ToString(),
+                game.Difficulty.Name,
+                game.Statistics.PlayDuration,
+                game.CompletedAt!.Value),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenGameIsCompletedAndRecordAlreadyExists_DoesNotWriteAgain()
+    {
+        // Arrange — the event handler already recorded this win
+        var game = GameFactory.CreateCompletedGame();
+        _mockGameRepository.SetupGetById(game);
+        _mockCompletionRepository.SetupCompletionExists(new GameCompletion(
+            game.Id.ToString(),
+            game.ProfileId.ToString(),
+            game.Difficulty.Name,
+            game.Statistics.PlayDuration,
+            game.CompletedAt!.Value));
+        var sut = ResolveSut();
+
+        // Act
+        await sut.Handle(new DeleteGameCommand(game.Id.ToString()), CancellationToken.None);
+
+        // Assert
+        _mockCompletionRepository.VerifyNeverUpserted();
+    }
+
+    [Fact]
+    public async Task Handle_WhenGameIsNotCompleted_DoesNotWriteACompletionRecord()
+    {
+        // Arrange
+        var game = GameFactory.CreateGameInProgress();
+        _mockGameRepository.SetupGetById(game);
+        _mockCompletionRepository.SetupCompletionNotFound();
+        var sut = ResolveSut();
+
+        // Act
+        await sut.Handle(new DeleteGameCommand(game.Id.ToString()), CancellationToken.None);
+
+        // Assert
+        _mockCompletionRepository.VerifyNeverUpserted();
+    }
+
+    [Fact]
+    public async Task Handle_WhenGameIsCompletedAndCompletionWriteFails_DoesNotDeleteTheGame()
+    {
+        // Arrange — abandoning the delete preserves the game document so the win can be retried.
+        var game = GameFactory.CreateCompletedGame();
+        _mockGameRepository.SetupGetById(game);
+        _mockCompletionRepository.SetupCompletionNotFound();
+        _mockCompletionRepository.SetupUpsertThrows(new InvalidOperationException("Cosmos is down"));
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(new DeleteGameCommand(game.Id.ToString()), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        _mockGameRepository.VerifyDeleteNeverCalled();
     }
 
     private static SudokuGame CreateTestGame()

--- a/src/backend/Tests/Application/Handlers/GetPlayerStatsQueryHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/GetPlayerStatsQueryHandlerTests.cs
@@ -107,6 +107,26 @@ public class GetPlayerStatsQueryHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WhenAverageLandsOnSubSecondPrecision_TruncatesItToWholeSeconds()
+    {
+        // Arrange — averaging 1s and 2s gives 1.5s, which System.Text.Json would emit as
+        // "00:00:01.5000000", breaking the "HH:MM:SS" contract the clients parse.
+        _mockCompletionRepository.SetupGetByProfileId([
+            Completion("Hard", TimeSpan.FromSeconds(1)),
+            Completion("Hard", TimeSpan.FromSeconds(2))
+        ]);
+        _mockGameRepository.SetupGetByProfileId([]);
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(new GetPlayerStatsQuery(_profileId), CancellationToken.None);
+
+        // Assert
+        result.Value.ByDifficulty.Single(d => d.Difficulty == "Hard")
+            .AverageSolveTime.Should().Be(TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
     public async Task Handle_WithNoWinsAtADifficulty_ReturnsNullSolveTimesForThatDifficulty()
     {
         // Arrange — an in-progress Expert game, but no Expert win

--- a/src/backend/Tests/Application/Handlers/GetPlayerStatsQueryHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/GetPlayerStatsQueryHandlerTests.cs
@@ -1,0 +1,223 @@
+using DepenMock.Moq;
+using Sudoku.Application.Common;
+using Sudoku.Application.DTOs;
+using Sudoku.Application.Handlers;
+using Sudoku.Application.Interfaces;
+using Sudoku.Application.Models;
+using Sudoku.Application.Queries;
+using Sudoku.Domain.Entities;
+using Sudoku.Domain.ValueObjects;
+using UnitTests.Helpers.Factories;
+
+namespace UnitTests.Application.Handlers;
+
+public class GetPlayerStatsQueryHandlerTests
+    : MoqBaseTestByAbstraction<GetPlayerStatsQueryHandler, IQueryHandler<GetPlayerStatsQuery, PlayerStatsDto>>
+{
+    private readonly Mock<IGameCompletionRepository> _mockCompletionRepository;
+    private readonly Mock<IGameRepository> _mockGameRepository;
+    private readonly string _profileId = Guid.NewGuid().ToString();
+
+    public GetPlayerStatsQueryHandlerTests()
+    {
+        _mockCompletionRepository = Container.ResolveMock<IGameCompletionRepository>().AsMoq();
+        _mockGameRepository = Container.ResolveMock<IGameRepository>().AsMoq();
+    }
+
+    [Fact]
+    public async Task Handle_WithWinsAndActiveGames_CalculatesGamesPlayedAsWinsPlusActiveGames()
+    {
+        // Arrange — 3 wins + 2 games still in progress
+        _mockCompletionRepository.SetupGetByProfileId([
+            Completion("Easy", TimeSpan.FromMinutes(5)),
+            Completion("Easy", TimeSpan.FromMinutes(7)),
+            Completion("Hard", TimeSpan.FromMinutes(20))
+        ]);
+        _mockGameRepository.SetupGetByProfileId([
+            GameFactory.CreateGameWithDifficulty(GameDifficulty.Easy),
+            GameFactory.CreateGameWithDifficulty(GameDifficulty.Medium)
+        ]);
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(new GetPlayerStatsQuery(_profileId), CancellationToken.None);
+
+        // Assert
+        result.Value.Should().BeEquivalentTo(new { GamesPlayed = 5, GamesWon = 3 });
+    }
+
+    [Fact]
+    public async Task Handle_WithWinsAndActiveGames_CalculatesWinRateAsWinsOverGamesPlayed()
+    {
+        // Arrange — 1 win, 3 active → 1/4
+        _mockCompletionRepository.SetupGetByProfileId([Completion("Easy", TimeSpan.FromMinutes(5))]);
+        _mockGameRepository.SetupGetByProfileId([
+            GameFactory.CreateGameWithDifficulty(GameDifficulty.Easy),
+            GameFactory.CreateGameWithDifficulty(GameDifficulty.Easy),
+            GameFactory.CreateGameWithDifficulty(GameDifficulty.Easy)
+        ]);
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(new GetPlayerStatsQuery(_profileId), CancellationToken.None);
+
+        // Assert
+        result.Value.WinRate.Should().Be(0.25);
+    }
+
+    [Fact]
+    public async Task Handle_WithCompletedGameDocumentStillPresent_ExcludesItFromGamesPlayed()
+    {
+        // Arrange — the client deletes solved games, but a transiently-present completed
+        // document must not be counted alongside its own completion record.
+        _mockCompletionRepository.SetupGetByProfileId([Completion("Easy", TimeSpan.FromMinutes(5))]);
+        _mockGameRepository.SetupGetByProfileId([GameFactory.CreateCompletedGame()]);
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(new GetPlayerStatsQuery(_profileId), CancellationToken.None);
+
+        // Assert
+        result.Value.Should().BeEquivalentTo(new { GamesPlayed = 1, GamesWon = 1, WinRate = 1.0 });
+    }
+
+    [Fact]
+    public async Task Handle_WithMultipleWinsAtOneDifficulty_CalculatesAverageAndBestSolveTime()
+    {
+        // Arrange
+        _mockCompletionRepository.SetupGetByProfileId([
+            Completion("Medium", TimeSpan.FromMinutes(10)),
+            Completion("Medium", TimeSpan.FromMinutes(20))
+        ]);
+        _mockGameRepository.SetupGetByProfileId([]);
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(new GetPlayerStatsQuery(_profileId), CancellationToken.None);
+
+        // Assert
+        result.Value.ByDifficulty.Single(d => d.Difficulty == "Medium")
+            .Should().BeEquivalentTo(new
+            {
+                GamesPlayed = 2,
+                GamesWon = 2,
+                AverageSolveTime = TimeSpan.FromMinutes(15),
+                BestSolveTime = TimeSpan.FromMinutes(10)
+            });
+    }
+
+    [Fact]
+    public async Task Handle_WithNoWinsAtADifficulty_ReturnsNullSolveTimesForThatDifficulty()
+    {
+        // Arrange — an in-progress Expert game, but no Expert win
+        _mockCompletionRepository.SetupGetByProfileId([Completion("Easy", TimeSpan.FromMinutes(5))]);
+        _mockGameRepository.SetupGetByProfileId([GameFactory.CreateGameWithDifficulty(GameDifficulty.Expert)]);
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(new GetPlayerStatsQuery(_profileId), CancellationToken.None);
+
+        // Assert
+        result.Value.ByDifficulty.Single(d => d.Difficulty == "Expert")
+            .Should().BeEquivalentTo(new
+            {
+                GamesPlayed = 1,
+                GamesWon = 0,
+                AverageSolveTime = (TimeSpan?)null,
+                BestSolveTime = (TimeSpan?)null
+            });
+    }
+
+    [Fact]
+    public async Task Handle_WithAnyPlayer_ReturnsAllFourDifficultiesInFixedOrder()
+    {
+        // Arrange
+        _mockCompletionRepository.SetupGetByProfileId([]);
+        _mockGameRepository.SetupGetByProfileId([]);
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(new GetPlayerStatsQuery(_profileId), CancellationToken.None);
+
+        // Assert
+        result.Value.ByDifficulty.Select(d => d.Difficulty)
+            .Should().Equal("Easy", "Medium", "Hard", "Expert");
+    }
+
+    [Fact]
+    public async Task Handle_WithNoGamesAtAll_ReturnsZeroedStatsWithoutDividingByZero()
+    {
+        // Arrange
+        _mockCompletionRepository.SetupGetByProfileId([]);
+        _mockGameRepository.SetupGetByProfileId([]);
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(new GetPlayerStatsQuery(_profileId), CancellationToken.None);
+
+        // Assert
+        result.Value.Should().BeEquivalentTo(new { GamesPlayed = 0, GamesWon = 0, WinRate = 0.0 });
+    }
+
+    [Fact]
+    public async Task Handle_WithNoGamesAtAll_ReturnsSuccess()
+    {
+        // Arrange — an empty player is a valid result, not an error
+        _mockCompletionRepository.SetupGetByProfileId([]);
+        _mockGameRepository.SetupGetByProfileId([]);
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(new GetPlayerStatsQuery(_profileId), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_WithInvalidProfileId_ReturnsFailure()
+    {
+        // Arrange
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(new GetPlayerStatsQuery("not-a-guid"), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_WhenCompletionRepositoryThrows_ReturnsFailure()
+    {
+        // Arrange
+        const string exceptionMessage = "Cosmos is down";
+        _mockCompletionRepository.SetupGetByProfileIdThrows(new Exception(exceptionMessage));
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(new GetPlayerStatsQuery(_profileId), CancellationToken.None);
+
+        // Assert
+        result.Error.Should().Be($"An unexpected error occurred: {exceptionMessage}");
+    }
+
+    [Fact]
+    public async Task Handle_WhenGameRepositoryThrows_ReturnsFailure()
+    {
+        // Arrange
+        const string exceptionMessage = "Cosmos is down";
+        _mockCompletionRepository.SetupGetByProfileId([]);
+        _mockGameRepository.SetupGetByProfileIdThrows(new Exception(exceptionMessage));
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(new GetPlayerStatsQuery(_profileId), CancellationToken.None);
+
+        // Assert
+        result.Error.Should().Be($"An unexpected error occurred: {exceptionMessage}");
+    }
+
+    private GameCompletion Completion(string difficulty, TimeSpan playDuration) =>
+        new(Guid.NewGuid().ToString(), _profileId, difficulty, playDuration, DateTime.UtcNow);
+}

--- a/src/backend/Tests/Domain/SudokuGameCompletionTests.cs
+++ b/src/backend/Tests/Domain/SudokuGameCompletionTests.cs
@@ -1,0 +1,57 @@
+using Sudoku.Domain.Entities;
+using Sudoku.Domain.Enums;
+using Sudoku.Domain.Events;
+using Sudoku.Domain.ValueObjects;
+using UnitTests.Helpers.Factories;
+
+namespace UnitTests.Domain;
+
+public class SudokuGameCompletionTests : MoqBaseTestByType<SudokuGame>
+{
+    [Fact]
+    public void CompleteGame_WhenCalled_SetsStatusToCompleted()
+    {
+        // Arrange
+        var sut = GameFactory.CreateGameWithDifficulty(GameDifficulty.Hard);
+
+        // Act
+        sut.CompleteGame();
+
+        // Assert
+        sut.Status.Should().Be(GameStatusEnum.Completed);
+    }
+
+    [Fact]
+    public void CompleteGame_WhenCalled_RaisesGameCompletedEventWithTheProfileAndDifficulty()
+    {
+        // Arrange — the stats pipeline reads these off the event, so they must be carried on it.
+        var sut = GameFactory.CreateGameWithDifficulty(GameDifficulty.Hard);
+
+        // Act
+        sut.CompleteGame();
+
+        // Assert
+        sut.DomainEvents.OfType<GameCompletedEvent>().Single()
+            .Should().BeEquivalentTo(new
+            {
+                GameId = sut.Id,
+                ProfileId = sut.ProfileId,
+                Difficulty = GameDifficulty.Hard,
+                Statistics = sut.Statistics
+            });
+    }
+
+    [Fact]
+    public void CompleteGame_WhenCalled_RaisesGameCompletedEventWhoseCompletedAtMatchesTheGame()
+    {
+        // Arrange
+        var sut = GameFactory.CreateGameWithDifficulty(GameDifficulty.Easy);
+
+        // Act
+        sut.CompleteGame();
+
+        // Assert
+        sut.DomainEvents.OfType<GameCompletedEvent>().Single()
+            .CompletedAt.Should().Be(sut.CompletedAt!.Value);
+    }
+}

--- a/src/backend/Tests/Infrastructure/EventHandling/GameCompletedEventHandlerTests.cs
+++ b/src/backend/Tests/Infrastructure/EventHandling/GameCompletedEventHandlerTests.cs
@@ -1,3 +1,6 @@
+using DepenMock.Moq;
+using Sudoku.Application.Interfaces;
+using Sudoku.Application.Models;
 using Sudoku.Domain.Events;
 using Sudoku.Domain.ValueObjects;
 using Sudoku.Infrastructure.EventHandling;
@@ -6,71 +9,88 @@ namespace UnitTests.Infrastructure.EventHandling;
 
 public class GameCompletedEventHandlerTests : MoqBaseTestByAbstraction<GameCompletedEventHandler, IDomainEventHandler<GameCompletedEvent>>
 {
+    private readonly Mock<IGameCompletionRepository> _mockCompletionRepository;
+
+    public GameCompletedEventHandlerTests()
+    {
+        _mockCompletionRepository = Container.ResolveMock<IGameCompletionRepository>().AsMoq();
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithValidEvent_UpsertsCompletionRecordFromTheEvent()
+    {
+        // Arrange
+        var domainEvent = CreateEvent(GameDifficulty.Hard, TimeSpan.FromMinutes(12));
+        var expected = new GameCompletion(
+            domainEvent.GameId.ToString(),
+            domainEvent.ProfileId.ToString(),
+            "Hard",
+            TimeSpan.FromMinutes(12),
+            domainEvent.CompletedAt);
+        var sut = ResolveSut();
+
+        // Act
+        await sut.HandleAsync(domainEvent);
+
+        // Assert
+        _mockCompletionRepository.VerifyUpserted(expected, Times.Once);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithSameEventTwice_UpsertsTheSameGameIdBothTimes()
+    {
+        // Arrange — the upsert is keyed by gameId, so a duplicate event cannot double-count.
+        var domainEvent = CreateEvent(GameDifficulty.Easy, TimeSpan.FromMinutes(3));
+        var sut = ResolveSut();
+
+        // Act
+        await sut.HandleAsync(domainEvent);
+        await sut.HandleAsync(domainEvent);
+
+        // Assert
+        _mockCompletionRepository.VerifyUpsertedGame(domainEvent.GameId.ToString(), () => Times.Exactly(2));
+    }
+
     [Fact]
     public async Task HandleAsync_WithValidEvent_LogsInformation()
     {
         // Arrange
-        var gameId = GameId.New();
-        var statistics = GameStatistics.Create();
-        var domainEvent = new GameCompletedEvent(gameId, statistics);
-
+        var domainEvent = CreateEvent(GameDifficulty.Medium, TimeSpan.FromMinutes(7));
         var sut = ResolveSut();
 
         // Act
         await sut.HandleAsync(domainEvent);
 
         // Assert
-        Logger.InformationLogs().ContainsMessage("Game completed");
+        Logger.InformationLogs().ContainsMessage($"Recorded completion for game {domainEvent.GameId}");
     }
 
     [Fact]
-    public async Task HandleAsync_WithValidEvent_CompletesSuccessfully()
+    public async Task HandleAsync_WhenRepositoryThrows_PropagatesException()
     {
-        // Arrange
-        var gameId = GameId.New();
-        var statistics = GameStatistics.Create();
-        var domainEvent = new GameCompletedEvent(gameId, statistics);
-
+        // Arrange — the caller (CosmosDbGameRepository.SaveAsync) contains the fault; the
+        // handler itself must not silently swallow a failed write.
+        var domainEvent = CreateEvent(GameDifficulty.Expert, TimeSpan.FromMinutes(30));
+        _mockCompletionRepository.SetupUpsertThrows(new InvalidOperationException("Cosmos is down"));
         var sut = ResolveSut();
 
         // Act
-        Func<Task> act = async () => await sut.HandleAsync(domainEvent);
+        var handleAsync = async () => await sut.HandleAsync(domainEvent);
 
         // Assert
-        await act.Should().NotThrowAsync();
+        await handleAsync.Should().ThrowAsync<InvalidOperationException>();
     }
 
-    [Fact]
-    public async Task HandleAsync_WithValidEvent_LogsCorrectGameId()
+    private static GameCompletedEvent CreateEvent(GameDifficulty difficulty, TimeSpan playDuration)
     {
-        // Arrange
-        var gameId = GameId.New();
         var statistics = GameStatistics.Create();
-        var domainEvent = new GameCompletedEvent(gameId, statistics);
+        statistics.UpdatePlayDuration(playDuration);
 
-        var sut = ResolveSut();
-
-        // Act
-        await sut.HandleAsync(domainEvent);
-
-        // Assert
-        Logger.InformationLogs().ContainsMessage(gameId.Value.ToString());
-    }
-
-    [Fact]
-    public async Task HandleAsync_WithDifferentGameId_LogsCorrectGameId()
-    {
-        // Arrange
-        var gameId = GameId.New();
-        var statistics = GameStatistics.Create();
-        var domainEvent = new GameCompletedEvent(gameId, statistics);
-
-        var sut = ResolveSut();
-
-        // Act
-        await sut.HandleAsync(domainEvent);
-
-        // Assert
-        Logger.InformationLogs().ContainsMessage(gameId.Value.ToString());
+        return new GameCompletedEvent(
+            GameId.New(),
+            ProfileId.New(),
+            difficulty,
+            statistics,
+            DateTime.UtcNow);
     }
 }

--- a/src/backend/Tests/Mocks/MockGameCompletionRepositoryExtensions.cs
+++ b/src/backend/Tests/Mocks/MockGameCompletionRepositoryExtensions.cs
@@ -1,0 +1,66 @@
+using Sudoku.Application.Interfaces;
+using Sudoku.Application.Models;
+using Sudoku.Domain.ValueObjects;
+
+namespace UnitTests.Mocks;
+
+public static class MockGameCompletionRepositoryExtensions
+{
+    extension(Mock<IGameCompletionRepository> mock)
+    {
+        public void SetupGetByProfileId(IEnumerable<GameCompletion> completions)
+        {
+            mock
+                .Setup(x => x.GetByProfileIdAsync(It.IsAny<ProfileId>()))
+                .ReturnsAsync(completions.ToList());
+        }
+
+        public void SetupGetByProfileIdThrows(Exception ex)
+        {
+            mock
+                .Setup(x => x.GetByProfileIdAsync(It.IsAny<ProfileId>()))
+                .ThrowsAsync(ex);
+        }
+
+        public void SetupCompletionExists(GameCompletion completion)
+        {
+            mock
+                .Setup(x => x.GetByGameIdAsync(It.IsAny<GameId>(), It.IsAny<ProfileId>()))
+                .ReturnsAsync(completion);
+        }
+
+        public void SetupCompletionNotFound()
+        {
+            mock
+                .Setup(x => x.GetByGameIdAsync(It.IsAny<GameId>(), It.IsAny<ProfileId>()))
+                .ReturnsAsync((GameCompletion?)null);
+        }
+
+        public void SetupUpsertThrows(Exception ex)
+        {
+            mock
+                .Setup(x => x.UpsertAsync(It.IsAny<GameCompletion>()))
+                .ThrowsAsync(ex);
+        }
+
+        public void VerifyUpserted(GameCompletion expected, Func<Times> times)
+        {
+            mock.Verify(x => x.UpsertAsync(It.Is<GameCompletion>(completion =>
+                completion.GameId == expected.GameId &&
+                completion.ProfileId == expected.ProfileId &&
+                completion.Difficulty == expected.Difficulty &&
+                completion.PlayDuration == expected.PlayDuration &&
+                completion.CompletedAt == expected.CompletedAt)), times);
+        }
+
+        public void VerifyUpsertedGame(string gameId, Func<Times> times)
+        {
+            mock.Verify(x => x.UpsertAsync(It.Is<GameCompletion>(completion => completion.GameId == gameId)), times);
+        }
+
+        public void VerifyNeverUpserted()
+        {
+            mock.Verify(x => x.UpsertAsync(It.IsAny<GameCompletion>()), Times.Never);
+        }
+    }
+}

--- a/src/backend/Tests/Mocks/MockGameRepositoryExtensions.cs
+++ b/src/backend/Tests/Mocks/MockGameRepositoryExtensions.cs
@@ -19,6 +19,13 @@ public static class MockGameRepositoryExtensions
                 .ReturnsAsync(game);
         }
 
+        public void SetupGetById(SudokuGame game)
+        {
+            mock
+                .Setup(x => x.GetByIdAsync(It.IsAny<GameId>()))
+                .ReturnsAsync(game);
+        }
+
         public void SetupGameNotFound()
         {
             mock
@@ -113,6 +120,11 @@ public static class MockGameRepositoryExtensions
         public void VerifySaveNeverCalled()
         {
             mock.Verify(x => x.SaveAsync(It.IsAny<SudokuGame>()), Times.Never);
+        }
+
+        public void VerifyDeleteNeverCalled()
+        {
+            mock.Verify(x => x.DeleteAsync(It.IsAny<GameId>()), Times.Never);
         }
     }
 }

--- a/src/frontend/Sudoku.React/src/App.tsx
+++ b/src/frontend/Sudoku.React/src/App.tsx
@@ -6,6 +6,7 @@ import CreateProfilePage from './pages/CreateProfilePage';
 import ProfilePage from './pages/ProfilePage';
 import SelectDifficultyPage from './pages/SelectDifficultyPage';
 import GameListPage from './pages/GameListPage';
+import StatsPage from './pages/StatsPage';
 import { ThemeProvider } from './hooks/ThemeProvider';
 import './App.css';
 
@@ -21,6 +22,7 @@ export default function App() {
           <Route path="/profile" element={<ProfilePage />} />
           <Route path="/select-difficulty" element={<SelectDifficultyPage />} />
           <Route path="/games" element={<GameListPage />} />
+          <Route path="/stats" element={<StatsPage />} />
         </Routes>
       </BrowserRouter>
     </ThemeProvider>

--- a/src/frontend/Sudoku.React/src/api/apiClient.ts
+++ b/src/frontend/Sudoku.React/src/api/apiClient.ts
@@ -1,4 +1,4 @@
-import type { GameModel, ProfileModel } from '../types';
+import type { GameModel, PlayerStatsModel, ProfileModel } from '../types';
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
 
@@ -64,6 +64,9 @@ export const apiClient = {
 
   getGames: (profileId: string): Promise<GameModel[]> =>
     request(`/api/players/${profileId}/games`),
+
+  getPlayerStats: (profileId: string): Promise<PlayerStatsModel> =>
+    request(`/api/players/${profileId}/stats`),
 
   getGame: (profileId: string, gameId: string): Promise<GameModel> =>
     request(`/api/players/${profileId}/games/${gameId}`),

--- a/src/frontend/Sudoku.React/src/components/GameThumbnail.tsx
+++ b/src/frontend/Sudoku.React/src/components/GameThumbnail.tsx
@@ -1,4 +1,5 @@
 import type { GameModel } from '../types';
+import { formatDuration } from '../utils/timeUtils';
 import styles from './GameThumbnail.module.css';
 
 interface GameThumbnailProps {
@@ -7,17 +8,10 @@ interface GameThumbnailProps {
   onDelete: (game: GameModel) => void;
 }
 
-function formatDuration(playDuration: string | undefined): string {
-  if (!playDuration) return '00:00';
-  const [h = 0, m = 0, s = 0] = playDuration.split(':').map(Number);
-  const pad = (v: number) => v.toString().padStart(2, '0');
-  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
-}
-
 export default function GameThumbnail({ game, onSelect, onDelete }: GameThumbnailProps) {
   const rows = Array.from({ length: 9 }, (_, r) => r);
   const cols = Array.from({ length: 9 }, (_, c) => c);
-  const meta = `${formatDuration(game.statistics?.playDuration)} · ${game.statistics?.totalMoves ?? 0} moves`;
+  const meta = `${formatDuration(game.statistics?.playDuration, '00:00')} · ${game.statistics?.totalMoves ?? 0} moves`;
 
   return (
     <div className={styles.savedGameCard}>

--- a/src/frontend/Sudoku.React/src/hooks/useStatsService.ts
+++ b/src/frontend/Sudoku.React/src/hooks/useStatsService.ts
@@ -1,0 +1,44 @@
+import { useState, useCallback, useRef } from 'react';
+import { apiClient } from '../api/apiClient';
+import type { PlayerStatsModel } from '../types';
+
+export interface UseStatsServiceReturn {
+  stats: PlayerStatsModel | null;
+  isLoading: boolean;
+  error: string | null;
+  isLoaded: boolean;
+  loadStats: (profileId: string) => Promise<void>;
+}
+
+export function useStatsService(): UseStatsServiceReturn {
+  const [stats, setStats] = useState<PlayerStatsModel | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const loadingRef = useRef(false);
+
+  const loadStats = useCallback(async (profileId: string) => {
+    if (!profileId) return;
+
+    // Use ref to prevent concurrent calls since state updates are async
+    if (loadingRef.current) return;
+
+    loadingRef.current = true;
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      setStats(await apiClient.getPlayerStats(profileId));
+      setIsLoaded(true);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to load stats';
+      setError(errorMessage);
+      setIsLoaded(true); // Still mark as loaded even on error
+    } finally {
+      loadingRef.current = false;
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { stats, isLoading, error, isLoaded, loadStats };
+}

--- a/src/frontend/Sudoku.React/src/pages/HomePage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/HomePage.tsx
@@ -69,6 +69,20 @@ export default function HomePage() {
           <button
             type="button"
             className={styles.card}
+            onClick={() => navigate('/stats')}
+            disabled={!isInitialized}
+            aria-disabled={!isInitialized}
+          >
+            <span className={styles.cardText}>
+              <span className={styles.cardTitle}>Stats</span>
+              <span className={styles.cardSubtitle}>Track your progress</span>
+            </span>
+            <i className={`fa-solid fa-arrow-right ${styles.arrowAccent}`} />
+          </button>
+
+          <button
+            type="button"
+            className={styles.card}
             onClick={() => navigate(isInitialized ? '/profile' : '/create-profile')}
           >
             <span className={styles.cardText}>

--- a/src/frontend/Sudoku.React/src/pages/StatsPage.module.css
+++ b/src/frontend/Sudoku.React/src/pages/StatsPage.module.css
@@ -1,0 +1,136 @@
+.container {
+  animation: sd-fadeup 0.4s ease both;
+}
+
+.title {
+  font-family: 'Newsreader', serif;
+  font-weight: 500;
+  font-size: clamp(28px, 8vw, 36px);
+  line-height: 1.1;
+  margin: 8px 0 24px 0;
+  color: var(--ink);
+}
+
+.status {
+  color: var(--ink-soft);
+}
+
+.errorStatus {
+  color: var(--error);
+}
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  padding: 48px 0;
+  text-align: center;
+}
+
+.emptyText {
+  font-family: 'Newsreader', serif;
+  font-style: italic;
+  font-size: 19px;
+  color: var(--ink-soft);
+  margin: 0;
+}
+
+.startButton {
+  padding: 14px 22px;
+  border: none;
+  border-radius: 12px;
+  background-color: var(--accent);
+  color: var(--accent-ink);
+  font-family: inherit;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 6px 18px var(--shadow);
+  transition: transform 0.15s ease;
+}
+
+.startButton:hover {
+  transform: translateY(-1px);
+}
+
+/* Headline KPI tiles — the VictoryDisplay stat pattern, laid out as a row of cards. */
+.tiles {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 11px;
+  margin-bottom: 32px;
+}
+
+.tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 18px 8px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background-color: var(--surface);
+}
+
+.tileValue {
+  font-family: 'Newsreader', serif;
+  font-size: 28px;
+  color: var(--ink);
+}
+
+.tileCaption {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 11px;
+  text-align: center;
+  color: var(--ink-soft);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+  margin: 0 0 12px 0;
+}
+
+.breakdown {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 15px;
+}
+
+.table th,
+.table td {
+  padding: 12px 8px;
+  text-align: right;
+  border-bottom: 1px solid var(--line);
+}
+
+.table thead th {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-soft);
+}
+
+.table th:first-child,
+.table td:first-child {
+  text-align: left;
+}
+
+.table tbody td {
+  color: var(--ink);
+}
+
+.difficulty {
+  font-weight: 600;
+  color: var(--ink);
+}

--- a/src/frontend/Sudoku.React/src/pages/StatsPage.test.tsx
+++ b/src/frontend/Sudoku.React/src/pages/StatsPage.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import StatsPage from './StatsPage';
+import { makeDifficultyStats, makePlayerStats } from '../test/helpers';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockUsePlayerService = vi.fn();
+const mockUseStatsService = vi.fn();
+
+vi.mock('../hooks/usePlayerService', () => ({
+  usePlayerService: () => mockUsePlayerService(),
+}));
+vi.mock('../hooks/useStatsService', () => ({
+  useStatsService: () => mockUseStatsService(),
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/stats']}>
+      <StatsPage />
+    </MemoryRouter>
+  );
+}
+
+const loadStats = vi.fn();
+
+function statsService(overrides: Record<string, unknown> = {}) {
+  return { stats: null, isLoaded: true, isLoading: false, error: null, loadStats, ...overrides };
+}
+
+function difficultyRow(difficulty: string) {
+  return screen.getByRole('row', { name: new RegExp(`^${difficulty}`, 'i') });
+}
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+  loadStats.mockClear();
+  mockUsePlayerService.mockReturnValue({ isNewPlayer: false, isInitialized: true, playerAlias: 'test-user', profileId: 'profile-test-user' });
+  mockUseStatsService.mockReturnValue(statsService());
+});
+
+describe('StatsPage', () => {
+  it('loads stats for the current profile on mount', () => {
+    renderPage();
+    expect(loadStats).toHaveBeenCalledWith('profile-test-user');
+  });
+
+  it('redirects a player with no profile away from the page', () => {
+    mockUsePlayerService.mockReturnValue({ isNewPlayer: true, isInitialized: false, playerAlias: null, profileId: null });
+    renderPage();
+    expect(mockNavigate).toHaveBeenCalledWith('/');
+  });
+
+  it('shows loading state', () => {
+    mockUseStatsService.mockReturnValue(statsService({ isLoaded: false, isLoading: true }));
+    renderPage();
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+  });
+
+  it('shows error state', () => {
+    mockUseStatsService.mockReturnValue(statsService({ isLoaded: false, error: 'Network error' }));
+    renderPage();
+    expect(screen.getByText(/Failed to load stats/i)).toBeInTheDocument();
+  });
+
+  it('shows an empty state when the player has no games', () => {
+    mockUseStatsService.mockReturnValue(statsService({ stats: makePlayerStats({ gamesPlayed: 0 }) }));
+    renderPage();
+    expect(screen.getByText(/no games yet/i)).toBeInTheDocument();
+  });
+
+  it('shows the three headline KPI tiles', () => {
+    mockUseStatsService.mockReturnValue(statsService({
+      stats: makePlayerStats({ gamesPlayed: 12, gamesWon: 7, winRate: 7 / 12 }),
+    }));
+
+    renderPage();
+
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+    expect(screen.getByText('58%')).toBeInTheDocument();
+  });
+
+  it('shows solve times for a difficulty the player has won at', () => {
+    mockUseStatsService.mockReturnValue(statsService({
+      stats: makePlayerStats({
+        gamesPlayed: 5,
+        gamesWon: 4,
+        winRate: 0.8,
+        byDifficulty: [
+          makeDifficultyStats({
+            difficulty: 'Easy',
+            gamesPlayed: 5,
+            gamesWon: 4,
+            averageSolveTime: '00:06:12',
+            bestSolveTime: '00:04:30',
+          }),
+        ],
+      }),
+    }));
+
+    renderPage();
+
+    const row = difficultyRow('Easy');
+    expect(within(row).getByText('06:12')).toBeInTheDocument();
+    expect(within(row).getByText('04:30')).toBeInTheDocument();
+  });
+
+  it('shows a dash for a difficulty the player has no wins at', () => {
+    mockUseStatsService.mockReturnValue(statsService({
+      stats: makePlayerStats({
+        gamesPlayed: 1,
+        gamesWon: 0,
+        winRate: 0,
+        byDifficulty: [
+          makeDifficultyStats({ difficulty: 'Expert', gamesPlayed: 1, gamesWon: 0 }),
+        ],
+      }),
+    }));
+
+    renderPage();
+
+    const row = difficultyRow('Expert');
+    expect(within(row).getAllByText('—')).toHaveLength(2);
+  });
+
+  it('renders a row for every difficulty, including untouched ones', () => {
+    mockUseStatsService.mockReturnValue(statsService({
+      stats: makePlayerStats({ gamesPlayed: 1, gamesWon: 1, winRate: 1 }),
+    }));
+
+    renderPage();
+
+    ['Easy', 'Medium', 'Hard', 'Expert'].forEach(difficulty => {
+      expect(difficultyRow(difficulty)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/frontend/Sudoku.React/src/pages/StatsPage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/StatsPage.tsx
@@ -1,0 +1,87 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { usePlayerService } from '../hooks/usePlayerService';
+import { useStatsService } from '../hooks/useStatsService';
+import { formatDuration } from '../utils/timeUtils';
+import Layout from '../components/Layout';
+import styles from './StatsPage.module.css';
+
+export default function StatsPage() {
+  const navigate = useNavigate();
+  const { isNewPlayer, profileId } = usePlayerService();
+  const { stats, isLoaded, isLoading, error, loadStats } = useStatsService();
+
+  useEffect(() => {
+    if (isNewPlayer) { navigate('/'); return; }
+    if (profileId) loadStats(profileId);
+  }, [isNewPlayer, profileId, loadStats, navigate]);
+
+  const winRate = stats ? `${Math.round(stats.winRate * 100)}%` : '0%';
+  const isEmpty = isLoaded && !error && stats?.gamesPlayed === 0;
+
+  return (
+    <Layout>
+      <div className={styles.container}>
+        <h1 className={styles.title}>Stats</h1>
+
+        {isLoading && <p className={styles.status}>Loading…</p>}
+        {error && <p className={styles.errorStatus}>Failed to load stats. Please try again.</p>}
+
+        {isEmpty && (
+          <div className={styles.emptyState}>
+            <p className={styles.emptyText}>no games yet</p>
+            <button type="button" className={styles.startButton} onClick={() => navigate('/select-difficulty')}>
+              Start a game
+            </button>
+          </div>
+        )}
+
+        {stats && !error && !isEmpty && (
+          <>
+            <div className={styles.tiles}>
+              <div className={styles.tile}>
+                <div className={`${styles.tileValue} tnum`}>{stats.gamesPlayed}</div>
+                <div className={styles.tileCaption}>Games played</div>
+              </div>
+              <div className={styles.tile}>
+                <div className={`${styles.tileValue} tnum`}>{stats.gamesWon}</div>
+                <div className={styles.tileCaption}>Games won</div>
+              </div>
+              <div className={styles.tile}>
+                <div className={`${styles.tileValue} tnum`}>{winRate}</div>
+                <div className={styles.tileCaption}>Win rate</div>
+              </div>
+            </div>
+
+            <section className={styles.breakdown} aria-labelledby="by-difficulty">
+              <h2 id="by-difficulty" className={styles.eyebrow}>By difficulty</h2>
+
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th scope="col">Difficulty</th>
+                    <th scope="col">Played</th>
+                    <th scope="col">Won</th>
+                    <th scope="col">Avg</th>
+                    <th scope="col">Best</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {stats.byDifficulty.map(row => (
+                    <tr key={row.difficulty}>
+                      <th scope="row" className={styles.difficulty}>{row.difficulty}</th>
+                      <td className="tnum">{row.gamesPlayed}</td>
+                      <td className="tnum">{row.gamesWon}</td>
+                      <td className="tnum">{formatDuration(row.averageSolveTime)}</td>
+                      <td className="tnum">{formatDuration(row.bestSolveTime)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+          </>
+        )}
+      </div>
+    </Layout>
+  );
+}

--- a/src/frontend/Sudoku.React/src/test/helpers.ts
+++ b/src/frontend/Sudoku.React/src/test/helpers.ts
@@ -1,4 +1,4 @@
-import type { CellModel, GameModel, GameStatisticsModel } from '../types';
+import type { CellModel, DifficultyStatsModel, GameModel, GameStatisticsModel, PlayerStatsModel } from '../types';
 
 export function makeCell(overrides: Partial<CellModel> = {}): CellModel {
   return {
@@ -33,6 +33,32 @@ export function make81Cells(overrides: Partial<CellModel>[] = []): CellModel[] {
     }
   }
   return cells;
+}
+
+export function makeDifficultyStats(overrides: Partial<DifficultyStatsModel> = {}): DifficultyStatsModel {
+  return {
+    difficulty: 'Easy',
+    gamesPlayed: 0,
+    gamesWon: 0,
+    averageSolveTime: null,
+    bestSolveTime: null,
+    ...overrides,
+  };
+}
+
+export function makePlayerStats(overrides: Partial<PlayerStatsModel> = {}): PlayerStatsModel {
+  return {
+    gamesPlayed: 0,
+    gamesWon: 0,
+    winRate: 0,
+    byDifficulty: [
+      makeDifficultyStats({ difficulty: 'Easy' }),
+      makeDifficultyStats({ difficulty: 'Medium' }),
+      makeDifficultyStats({ difficulty: 'Hard' }),
+      makeDifficultyStats({ difficulty: 'Expert' }),
+    ],
+    ...overrides,
+  };
 }
 
 export function makeGame(overrides: Partial<GameModel> = {}): GameModel {

--- a/src/frontend/Sudoku.React/src/types/index.ts
+++ b/src/frontend/Sudoku.React/src/types/index.ts
@@ -49,3 +49,20 @@ export interface GameModel {
   cells: CellModel[];
   moveHistory: MoveHistoryModel[];
 }
+
+export interface DifficultyStatsModel {
+  difficulty: string;
+  gamesPlayed: number;
+  gamesWon: number;
+  /** "HH:MM:SS", or null when the player has no wins at this difficulty. */
+  averageSolveTime: string | null;
+  bestSolveTime: string | null;
+}
+
+export interface PlayerStatsModel {
+  gamesPlayed: number;
+  gamesWon: number;
+  /** 0–1. Zero when the player has no games. */
+  winRate: number;
+  byDifficulty: DifficultyStatsModel[];
+}

--- a/src/frontend/Sudoku.React/src/utils/timeUtils.test.ts
+++ b/src/frontend/Sudoku.React/src/utils/timeUtils.test.ts
@@ -10,6 +10,19 @@ describe('formatDuration', () => {
     expect(formatDuration('01:06:12')).toBe('1:06:12');
   });
 
+  // .NET serializes TimeSpan in the "c" format, so these are shapes the backend really emits.
+  it('truncates the fractional seconds .NET emits for sub-second precision', () => {
+    expect(formatDuration('00:00:01.5000000')).toBe('00:01');
+  });
+
+  it('folds the day prefix .NET emits past 24h into the hours segment', () => {
+    expect(formatDuration('1.01:00:00')).toBe('25:00:00');
+  });
+
+  it('handles a day prefix and fractional seconds together', () => {
+    expect(formatDuration('2.03:04:05.1234567')).toBe('51:04:05');
+  });
+
   it('returns an em dash for a null duration', () => {
     expect(formatDuration(null)).toBe('—');
   });

--- a/src/frontend/Sudoku.React/src/utils/timeUtils.test.ts
+++ b/src/frontend/Sudoku.React/src/utils/timeUtils.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { formatDuration } from './timeUtils';
+
+describe('formatDuration', () => {
+  it('drops the hours segment when there are no hours', () => {
+    expect(formatDuration('00:06:12')).toBe('06:12');
+  });
+
+  it('keeps the hours segment when there are hours', () => {
+    expect(formatDuration('01:06:12')).toBe('1:06:12');
+  });
+
+  it('returns an em dash for a null duration', () => {
+    expect(formatDuration(null)).toBe('—');
+  });
+
+  it('returns the caller-supplied fallback when one is given', () => {
+    expect(formatDuration(undefined, '00:00')).toBe('00:00');
+  });
+
+  it('returns the fallback for an unparseable duration', () => {
+    expect(formatDuration('not-a-duration')).toBe('—');
+  });
+});

--- a/src/frontend/Sudoku.React/src/utils/timeUtils.ts
+++ b/src/frontend/Sudoku.React/src/utils/timeUtils.ts
@@ -1,0 +1,17 @@
+export const EM_DASH = '—';
+
+/**
+ * Formats a backend TimeSpan ("HH:MM:SS") for display. Hours are dropped when zero.
+ * A missing duration — a difficulty with no wins, say — renders as `fallback`.
+ */
+export function formatDuration(playDuration: string | null | undefined, fallback: string = EM_DASH): string {
+  if (!playDuration) return fallback;
+
+  const [h = 0, m = 0, s = 0] = playDuration.split(':').map(Number);
+
+  if ([h, m, s].some(Number.isNaN)) return fallback;
+
+  const pad = (v: number) => v.toString().padStart(2, '0');
+
+  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
+}

--- a/src/frontend/Sudoku.React/src/utils/timeUtils.ts
+++ b/src/frontend/Sudoku.React/src/utils/timeUtils.ts
@@ -1,17 +1,26 @@
 export const EM_DASH = '—';
 
+// .NET serializes TimeSpan in the "c" format: [d.]hh:mm:ss[.fffffff] — so a duration
+// past 24h carries a day prefix ("1.01:00:00") and sub-second precision carries a
+// fractional tail ("00:00:01.5000000"). Both must parse, not just plain "HH:MM:SS".
+const TIMESPAN_PATTERN = /^(?:(\d+)\.)?(\d{1,2}):(\d{2}):(\d{2})(?:\.\d+)?$/;
+
 /**
- * Formats a backend TimeSpan ("HH:MM:SS") for display. Hours are dropped when zero.
- * A missing duration — a difficulty with no wins, say — renders as `fallback`.
+ * Formats a backend TimeSpan for display as `[H:]MM:SS`. Hours are dropped when zero and
+ * days fold into the hours segment. Sub-second precision is truncated.
+ * A missing or unparseable duration — a difficulty with no wins, say — renders as `fallback`.
  */
 export function formatDuration(playDuration: string | null | undefined, fallback: string = EM_DASH): string {
   if (!playDuration) return fallback;
 
-  const [h = 0, m = 0, s = 0] = playDuration.split(':').map(Number);
+  const match = TIMESPAN_PATTERN.exec(playDuration.trim());
+  if (!match) return fallback;
 
-  if ([h, m, s].some(Number.isNaN)) return fallback;
+  const [, days, hours, minutes, seconds] = match;
+  const totalHours = Number(days ?? 0) * 24 + Number(hours);
+  const pad = (v: string) => v.padStart(2, '0');
 
-  const pad = (v: number) => v.toString().padStart(2, '0');
-
-  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
+  return totalHours > 0
+    ? `${totalHours}:${pad(minutes)}:${pad(seconds)}`
+    : `${pad(minutes)}:${pad(seconds)}`;
 }


### PR DESCRIPTION
## Description

Implements the Game Stats page from [#215](https://github.com/Xenobiasoft/sudoku/issues/215) (spec: `docs/specs/game-stats-page.md`). Builds on #360, which wired up domain event dispatch — without it `GameCompletedEventHandler` never fires.

**Wins were being destroyed.** The React client deletes a solved game moments after completion (`GamePage.tsx:139`), and `DeleteGameCommandHandler` hard-deletes the Cosmos document. The server therefore retained **zero record of wins** — stats scanned from game documents would always read zero.

The fix materializes a compact **completion record** `{ gameId, profileId, difficulty, playDuration, completedAt }` when a game completes, in a new `game-completions` container. The heavy game document is still deleted exactly as today; the slim record survives and feeds the new stats page. Records are keyed by `gameId`, so writes are idempotent — neither a duplicate completion event nor the delete-time backstop can double-count a win.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- **Domain** — enriched `GameCompletedEvent` with `ProfileId`, `Difficulty`, `CompletedAt` (all already in scope in `CompleteGame()`).
- **Application** — `GameCompletion` read model, `IGameCompletionRepository`, `PlayerStatsDto`/`DifficultyStatsDto`, `GetPlayerStatsQuery` + handler. `DeleteGameCommandHandler` gains the **delete-time backstop**: it will not delete a `Completed` game without a completion record existing first, and abandons the delete if that write fails, so the game document survives to be retried.
- **Infrastructure** — implemented `GameCompletedEventHandler` (was a log-only stub carrying a literal `// - Update player statistics` TODO); `CosmosDbGameCompletionRepository` + `GameCompletionDocument`, following the `profiles` container pattern; DI registration.
- **API** — `StatsController`: `GET api/players/{profileId}/stats`. An empty player is a valid `200` with zeroed stats, not a `404`.
- **Infra** — `game-completions` container in `storage.bicep` (partition key `/profileId`, throughput block conditional on `!cosmosDbServerless`). **No RBAC change needed** — `assign-roles.sh` grants Cosmos Data Contributor at *account* scope, which already covers a new container.
- **Frontend** — `StatsPage` (three KPI tiles + per-difficulty table), `useStatsService`, `apiClient.getPlayerStats`, `/stats` route, Home "Stats" card. Extracted `formatDuration` from `GameThumbnail` into `utils/timeUtils.ts` and widened it for `null` (renders `—`); `GameThumbnail` passes its existing `'00:00'` fallback explicitly, so the games list is unchanged.

**Games played** = wins + the player's non-completed games. A completed document still in flight is excluded from the denominator so it isn't counted twice alongside its own completion record.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

Backend `dotnet test` → **711 passed, 0 failed** (+23). Frontend `npm run test` → **176 passed** (22 files). `npm run build` clean; `npm run lint` adds no new problems (the 4 errors in `GamePage.tsx`/`useGameService.test.ts` pre-exist on `main`).

New coverage: query-handler aggregation (win-rate math, per-difficulty avg/best, `null` on no-win difficulties, empty player, completed-doc exclusion, both exception paths), event-handler write + idempotency, all four backstop cases, the enriched domain-event payload, and the controller.

### Verified end-to-end against the real app

Ran the Aspire host (Cosmos emulator) and drove the actual HTTP flow:

- Fresh profile → `200` with zeroed stats and all four difficulty rows (not an error).
- Won 6 games across difficulties. Stats read back **before any deletion** already showed the wins — confirming the primary `GameCompletedEventHandler` path fires through the dispatch wired in #360.
- Play duration flows end to end: two Expert wins at `00:25:40` and `00:31:10` aggregate to **avg `00:28:25`, best `00:25:40`**.
- **The core fix:** deleted a completed game → it disappears from the games list, but the win survives in stats with its solve times intact.
- `game-completions` container auto-created in dev; response JSON keys match `PlayerStatsModel` exactly.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary) — the spec still reads "Design — not yet implemented"; happy to flip its status on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
