### PR TITLE
Add Expert difficulty — and make Expert puzzles actually harder than Hard

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: verify
+description: Build, launch, and drive the Sudoku app end-to-end to observe a change actually working (React UI + API + emulators).
+---
+
+# Verifying a change in this repo
+
+## Launch the whole stack (one command)
+
+`Sudoku.AppHost` is an Aspire host that brings up **everything** — Cosmos DB emulator,
+Azurite storage, the API, the Functions pool-seeder, and the React dev server:
+
+```bash
+dotnet run --project src/backend/Sudoku.AppHost
+```
+
+- **Requires Docker running** (it starts the Cosmos + storage emulator containers).
+- Takes ~60–90s cold. Wait on the React dev server rather than sleeping:
+  `until curl -s -o /dev/null http://localhost:5173; do sleep 3; done`
+- React: `http://localhost:5173`. API: `https://localhost:7272` (**self-signed cert** —
+  use `curl -k`, or `ignoreHTTPSErrors: true` / `NODE_TLS_REJECT_UNAUTHORIZED=0`).
+- Aspire dashboard URL + login token are printed in the AppHost stdout.
+- Teardown: kill `Sudoku.AppHost.exe`, then `docker stop <the two containers it named>`.
+  Stop them **by name** — never `docker ps -q | xargs docker stop`.
+
+## Driving the UI
+
+There is no Playwright in the repo. Install it in a scratch dir (not the project — it would
+dirty `package.json`) and drive `http://localhost:5173` headless.
+
+**The app gates on having a profile.** A fresh browser context is a "new player", and
+`SelectDifficultyPage` / `NewGamePage` both redirect to `/` until an alias exists. So the
+first steps of any UI flow are always:
+
+1. Home → click the **Profile** card (goes to `/create-profile`)
+2. Fill the single textbox, click **Begin**
+3. *Then* navigate to `/select-difficulty` etc.
+
+Skip that and you'll silently land back on the home page and your selectors won't match.
+
+## Gotchas worth knowing
+
+- **StrictMode double-fires effects in dev.** `NewGamePage`'s create-game effect has no
+  concurrency guard, so **every new game POSTs twice and creates two games** in dev. This is
+  not difficulty-specific and not a regression — don't chase it as a bug in your change.
+  (A production build won't double-invoke.)
+- **A fresh local puzzle pool is empty**, so the first game per difficulty takes the on-demand
+  generation fallback and is slower than prod (where the blob pool is pre-seeded).
+- Ground truth for a board is the API payload, not the DOM: `GET /api/players/{pid}/games/{id}`
+  → count `cells` where `value === null`.
+
+## Checking generator/difficulty behavior
+
+Don't hand-roll clue counting — the repo has a quality report:
+
+```bash
+dotnet run -c Release --project src/backend/Sudoku.Benchmarks -- --validate --samples 25
+```
+
+Prints unique-solution rate and min/avg/max clue counts per difficulty.

--- a/src/backend/Sudoku.Infrastructure/Services/UniqueSolutionPuzzleGenerator.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/UniqueSolutionPuzzleGenerator.cs
@@ -9,12 +9,16 @@ namespace Sudoku.Infrastructure.Services;
 /// <summary>
 /// An <see cref="IPuzzleGenerator"/> that guarantees every generated puzzle has exactly
 /// one solution. It builds a complete grid with <see cref="BitwiseSolverEngine"/>, then
-/// digs holes symmetrically, keeping a removal only while the puzzle still has a unique
-/// solution (verified via <see cref="BitwiseSolverEngine.CountSolutions"/>).
+/// digs holes, keeping a removal only while the puzzle still has a unique solution
+/// (verified via <see cref="BitwiseSolverEngine.CountSolutions"/>).
+///
+/// Digging runs in two passes: symmetric mirrored pairs first (an aesthetic), then single
+/// cells to reach the target. The second pass is what lets the deeper difficulties actually
+/// hit their band — a symmetric-only dig stalls around 50 empty cells, which would leave
+/// Expert indistinguishable from Hard.
 ///
 /// Empty-cell targets per difficulty mirror the legacy <see cref="PuzzleGenerator"/> so the
-/// two are directly comparable. The target is a ceiling: if uniqueness can't be preserved
-/// all the way to it, generation stops at the last unique state.
+/// two are directly comparable.
 /// </summary>
 public class UniqueSolutionPuzzleGenerator : IPuzzleGenerator
 {
@@ -65,10 +69,23 @@ public class UniqueSolutionPuzzleGenerator : IPuzzleGenerator
 
     private static void DigHoles(int[] grid, int targetEmpty)
     {
-        var positions = ShuffledPositions();
-        var removed = 0;
+        var removed = DigPass(grid, targetEmpty, removed: 0, symmetric: true);
 
-        foreach (var index in positions)
+        // A symmetric pass alone plateaus around 50 empty cells: near the uniqueness limit,
+        // clearing a mirrored pair costs uniqueness roughly twice as often as clearing one
+        // cell, so every surviving pair gets rejected while single cells would still come
+        // out. That leaves the deeper targets permanently short. Symmetry is only an
+        // aesthetic; the clue count is what makes a puzzle hard — so finish one cell at a
+        // time. Shallower difficulties reach their target in the pass above and skip this.
+        if (removed < targetEmpty)
+        {
+            DigPass(grid, targetEmpty, removed, symmetric: false);
+        }
+    }
+
+    private static int DigPass(int[] grid, int targetEmpty, int removed, bool symmetric)
+    {
+        foreach (var index in ShuffledPositions())
         {
             var remaining = targetEmpty - removed;
             if (remaining <= 0)
@@ -85,7 +102,7 @@ public class UniqueSolutionPuzzleGenerator : IPuzzleGenerator
 
             // Remove a symmetric pair when there's room for two; otherwise a single cell.
             // Bounding the group by 'remaining' guarantees we never exceed the target.
-            var group = (index == mirror || grid[mirror] == 0 || remaining < 2)
+            var group = (!symmetric || index == mirror || grid[mirror] == 0 || remaining < 2)
                 ? new[] { index }
                 : new[] { index, mirror };
 
@@ -108,6 +125,8 @@ public class UniqueSolutionPuzzleGenerator : IPuzzleGenerator
                 }
             }
         }
+
+        return removed;
     }
 
     private static SudokuPuzzle BuildPuzzle(int[] grid, GameDifficulty difficulty)

--- a/src/backend/Tests/Infrastructure/Services/UniqueSolutionPuzzleGeneratorTests.cs
+++ b/src/backend/Tests/Infrastructure/Services/UniqueSolutionPuzzleGeneratorTests.cs
@@ -63,14 +63,45 @@ public class UniqueSolutionPuzzleGeneratorTests : MoqBaseTestByAbstraction<Uniqu
         var emptyCells = puzzle.GetEmptyCellCount();
         var (min, max) = ExpectedEmptyBand(difficulty);
 
-        // Target is a ceiling; uniqueness may stop digging early, so allow a lower-bound margin.
         emptyCells.Should().BeLessThanOrEqualTo(max);
         emptyCells.Should().BeGreaterThanOrEqualTo(min - LowerBandMargin);
     }
 
-    // Uniqueness can occasionally halt digging a few cells short of the target; this margin
-    // keeps the band assertion stable without weakening the uniqueness guarantee above.
-    private const int LowerBandMargin = 6;
+    [Fact]
+    public async Task GeneratePuzzleAsync_Expert_DigsPastTheHardBand()
+    {
+        var sut = ResolveSut();
+        var (expertFloor, _) = ExpectedEmptyBand(GameDifficulty.Expert);
+
+        var emptyCells = await GenerateEmptyCellCounts(sut, GameDifficulty.Expert);
+
+        // Regression guard. A symmetric-only dig stalls around 50 empty cells, which left
+        // Expert sitting inside Hard's band (50-53) — the player got a Hard puzzle wearing
+        // an Expert label. Note "Expert digs deeper than Hard on average" would NOT catch
+        // that (it was already true while the bug was live); only clearing the band floor
+        // does. Averaged over a sample so the rare one-cell shortfall can't flake the run.
+        emptyCells.Average().Should().BeGreaterThanOrEqualTo(expertFloor);
+    }
+
+    private static async Task<List<int>> GenerateEmptyCellCounts(IPuzzleGenerator generator, GameDifficulty difficulty)
+    {
+        var counts = new List<int>();
+
+        for (var i = 0; i < SampleSize; i++)
+        {
+            var puzzle = await generator.GeneratePuzzleAsync(difficulty);
+            counts.Add(puzzle.GetEmptyCellCount());
+        }
+
+        return counts;
+    }
+
+    private const int SampleSize = 10;
+
+    // Digging stops at the last state that still has a unique solution, which very
+    // occasionally lands one cell short of the target floor (measured: ~0.2% of Expert
+    // puzzles). This margin absorbs that without letting a genuinely under-dug puzzle pass.
+    private const int LowerBandMargin = 1;
 
     private static (int Min, int Max) ExpectedEmptyBand(GameDifficulty difficulty) => difficulty.Name switch
     {

--- a/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.test.tsx
+++ b/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.test.tsx
@@ -29,11 +29,12 @@ beforeEach(() => {
 });
 
 describe('SelectDifficultyPage', () => {
-  it('renders three difficulty cards', () => {
+  it('renders four difficulty cards', () => {
     renderPage();
     expect(screen.getByRole('button', { name: /Easy/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Medium/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Hard/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Expert/i })).toBeInTheDocument();
   });
 
   it('navigates to /new/Easy when Easy is clicked', async () => {
@@ -55,6 +56,13 @@ describe('SelectDifficultyPage', () => {
     renderPage();
     await user.click(screen.getByRole('button', { name: /Hard/i }));
     expect(mockNavigate).toHaveBeenCalledWith('/new/Hard');
+  });
+
+  it('navigates to /new/Expert when Expert is clicked', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole('button', { name: /Expert/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/new/Expert');
   });
 
   it('navigates to / when the header back affordance is clicked', async () => {

--- a/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.tsx
@@ -8,6 +8,7 @@ const DIFFICULTIES = [
   { name: 'Easy', subtitle: 'A gentle warm-up', dots: '·' },
   { name: 'Medium', subtitle: 'A steady challenge', dots: '··' },
   { name: 'Hard', subtitle: 'For a clear mind', dots: '···' },
+  { name: 'Expert', subtitle: 'For the deep end', dots: '····' },
 ] as const;
 
 export default function SelectDifficultyPage() {


### PR DESCRIPTION
## Description

Lets players select and play an **Expert** game — and makes an Expert puzzle actually harder than a Hard one, which it wasn't.

Two things turned out to be true, and the second is the interesting one:

1. **Expert was already wired end to end.** The domain value object, generator, puzzle-pool seeder, API and the stats page all handled Expert. The only thing missing was a button — `SelectDifficultyPage`'s difficulty list stopped at Hard, so Expert was reachable only by hand-typing `/new/Expert`. The UI half of this PR is one line.

2. **But Expert puzzles weren't actually harder than Hard.** Running the app end to end and sampling the generator showed Expert landing at 49–53 empty cells — *inside Hard's band* (50–53), never once reaching its own 54–58 target. Shipping only the button would have shipped a Hard puzzle wearing an Expert label.

### The generator bug

`DigHoles` only ever removed **symmetric mirrored pairs**. Near the uniqueness limit, clearing two cells at once costs uniqueness roughly twice as often as clearing one, so every surviving pair got rejected and digging stalled around 50 empty cells. Easy/Medium/Hard have shallow enough targets that they never hit that wall; Expert's target sat past it.

Fix: keep the symmetric pass (it's an aesthetic), then finish one cell at a time when it falls short. Shallower difficulties reach their target in the first pass and never enter the second, so their behavior is unchanged.

Measured over 30 puzzles per difficulty:

| Difficulty | Target band | Before | After |
| --- | --- | --- | --- |
| Expert | 54–58 | **0/30 in band** (49–53, avg 53.2) | **30/30 in band** (54–57, avg 55.1) |
| Hard | 50–53 | 30/30 | 30/30 (unchanged) |

Uniqueness stays at **100%** for every difficulty. Expert's floor (54) now sits clear of Hard's ceiling (52), so the bands no longer overlap. Expert generation costs 2.2 ms vs Hard's 0.4 ms — negligible for the pool seeder.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- `SelectDifficultyPage.tsx` — add the fourth (Expert) card. No CSS change needed; the options container is a flex column with a gap.
- `UniqueSolutionPuzzleGenerator.cs` — split `DigHoles` into a symmetric pass followed by a single-cell pass, so deep targets are actually reached.
- `UniqueSolutionPuzzleGeneratorTests.cs` — tighten the band margin and add a regression test.
- `.claude/skills/verify/SKILL.md` — capture the local end-to-end launch recipe (drop this commit if you'd rather not carry it).

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

Verified end to end against the real stack (Aspire: Cosmos + Azurite emulators, API, Functions, React), driven through the browser — created a profile, opened the difficulty page, clicked **Expert**, and confirmed `POST /api/players/{id}/games/Expert` → 201 and a playable board with the header reading "Expert".

**713/713 backend and 180/180 frontend tests pass.**

On the tests specifically: the old band assertion allowed a 6-cell shortfall, which is exactly why this shipped unnoticed — Expert passed anywhere ≥ 48. It's now tightened to 1 (0.2% of Expert puzzles legitimately land one cell short over 500 samples, so 0 would flake), plus a regression test pinning Expert's average past the band floor.

Worth flagging for reviewers: my first attempt at that regression test asserted *"Expert digs deeper than Hard on average"* — which was **already true while the bug was live** (53.2 vs 50.9) and would have caught nothing. It was replaced with an assertion that Expert clears the band floor, and confirmed to genuinely fail against the pre-fix generator (`Expected >= 54.0, but found 53.9`) before being restored to green.

## Screenshots

The difficulty selector now offers four levels; the Expert board loads with an "Expert" header and 3 hints.

## ⚠️ Deploy note — the production Expert pool is stale

The `sudoku-puzzles` blob container currently holds 10 pre-generated Expert puzzles built by the **old** generator, so they're all 49–53 empty. Players would dequeue those too-easy puzzles until the pool naturally cycles.

**After merging, delete the `expert/` blobs in the `sudoku-puzzles` container.** The Event Grid replenish and the nightly seed will regenerate them with the fixed generator. Easy/Medium/Hard pools are unaffected — those difficulties were already in band and their generation is unchanged.

## Not included (pre-existing, happy to fix separately)

- **`NewGamePage` creates two games per start.** StrictMode double-invokes the create effect, which — unlike `loadGame` — has no `useRef` guard. Confirmed on Easy too, so it long predates this PR, but it orphans a game per start and drains the 10-puzzle pool at 2× rate.
- **The benchmarks harness can hang.** `AlgorithmFactory.CreateOldGenerator()` still constructs `StrategyBasedPuzzleSolver` directly, so `--validate` can infinite-loop on the legacy generator — the same solver already swapped out of DI in 354737f. It wedged for hours during this work.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
