### PR TITLE
Demote high-volume Information logs to Debug to cut App Insights ingestion

### DIFF
--- a/src/backend/Sudoku.Application/Handlers/AbandonGameCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/AbandonGameCommandHandler.cs
@@ -25,7 +25,7 @@ public class AbandonGameCommandHandler(IGameRepository gameRepository, ILogger<A
 
             await gameRepository.SaveAsync(game);
 
-            logger.LogInformation("Abandoned game with ID: {GameId}", gameId.Value);
+            logger.LogDebug("Abandoned game with ID: {GameId}", gameId.Value);
             return Result.Success();
         }
         catch (DomainException ex)

--- a/src/backend/Sudoku.Application/Handlers/AddPossibleValueCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/AddPossibleValueCommandHandler.cs
@@ -25,7 +25,7 @@ public class AddPossibleValueCommandHandler(IGameRepository gameRepository, ILog
 
             await gameRepository.SaveAsync(game);
 
-            logger.LogInformation("Added possible value {Value} to game {GameId} at [{Row},{Column}]", 
+            logger.LogDebug("Added possible value {Value} to game {GameId} at [{Row},{Column}]",
                 request.Value, gameId.Value, request.Row, request.Column);
             return Result.Success();
         }

--- a/src/backend/Sudoku.Application/Handlers/ClearPossibleValuesCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/ClearPossibleValuesCommandHandler.cs
@@ -25,7 +25,7 @@ public class ClearPossibleValuesCommandHandler(IGameRepository gameRepository, I
 
             await gameRepository.SaveAsync(game);
 
-            logger.LogInformation("Cleared possible values for game {GameId} at [{Row},{Column}]",
+            logger.LogDebug("Cleared possible values for game {GameId} at [{Row},{Column}]",
                 gameId.Value, request.Row, request.Column);
             return Result.Success();
         }

--- a/src/backend/Sudoku.Application/Handlers/CompleteGameCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/CompleteGameCommandHandler.cs
@@ -25,7 +25,7 @@ public class CompleteGameCommandHandler(IGameRepository gameRepository, ILogger<
 
             await gameRepository.SaveAsync(game);
 
-            logger.LogInformation("Completed game with ID: {GameId}", gameId.Value);
+            logger.LogDebug("Completed game with ID: {GameId}", gameId.Value);
             return Result.Success();
         }
         catch (DomainException ex)

--- a/src/backend/Sudoku.Application/Handlers/CreateGameCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/CreateGameCommandHandler.cs
@@ -39,7 +39,7 @@ public class CreateGameCommandHandler(
 
             await gameRepository.SaveAsync(game);
 
-            logger.LogInformation("Created game {GameId} for profile {ProfileId} with difficulty {Difficulty}",
+            logger.LogDebug("Created game {GameId} for profile {ProfileId} with difficulty {Difficulty}",
                 game.Id.Value, profileId.Value, difficulty.Name);
             return Result<string>.Success(game.Id.Value.ToString());
         }

--- a/src/backend/Sudoku.Application/Handlers/CreateProfileCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/CreateProfileCommandHandler.cs
@@ -27,7 +27,7 @@ public class CreateProfileCommandHandler(
             var profile = Domain.Entities.UserProfile.Create(playerAlias);
             await profileRepository.SaveAsync(profile);
 
-            logger.LogInformation("Created profile {ProfileId} for alias {Alias}", profile.Id, playerAlias.Value);
+            logger.LogDebug("Created profile {ProfileId} for alias {Alias}", profile.Id, playerAlias.Value);
             return Result<ProfileDto>.Success(ProfileDto.FromProfile(profile));
         }
         catch (DomainException ex)

--- a/src/backend/Sudoku.Application/Handlers/DeleteGameCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/DeleteGameCommandHandler.cs
@@ -31,7 +31,7 @@ public class DeleteGameCommandHandler(
 
             await gameRepository.DeleteAsync(gameId);
 
-            logger.LogInformation("Deleted game with ID: {GameId}", gameId.Value);
+            logger.LogDebug("Deleted game with ID: {GameId}", gameId.Value);
             return Result.Success();
         }
         catch (DomainException ex)

--- a/src/backend/Sudoku.Application/Handlers/DeletePlayerGamesCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/DeletePlayerGamesCommandHandler.cs
@@ -22,7 +22,7 @@ public class DeletePlayerGamesCommandHandler(IGameRepository gameRepository, ILo
                 await gameRepository.DeleteAsync(game.Id);
             }
 
-            logger.LogInformation("Deleted {Count} games for profile {ProfileId}", games.Count(), profileId.Value);
+            logger.LogDebug("Deleted {Count} games for profile {ProfileId}", games.Count(), profileId.Value);
             return Result.Success();
         }
         catch (DomainException ex)

--- a/src/backend/Sudoku.Application/Handlers/DeleteProfileCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/DeleteProfileCommandHandler.cs
@@ -34,7 +34,7 @@ public class DeleteProfileCommandHandler(
 
             await profileRepository.DeleteAsync(profile.Id);
 
-            logger.LogInformation("Deleted profile {ProfileId} with alias {Alias}", profile.Id, alias.Value);
+            logger.LogDebug("Deleted profile {ProfileId} with alias {Alias}", profile.Id, alias.Value);
             return Result.Success();
         }
         catch (DomainException ex)

--- a/src/backend/Sudoku.Application/Handlers/GetGameQueryHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/GetGameQueryHandler.cs
@@ -24,7 +24,7 @@ public class GetGameQueryHandler(IGameRepository gameRepository, ILogger<GetGame
 
             var gameDto = GameDto.FromGame(game);
 
-            logger.LogInformation("Retrieved game {GameId}", gameId.Value);
+            logger.LogDebug("Retrieved game {GameId}", gameId.Value);
             return Result<GameDto>.Success(gameDto);
         }
         catch (DomainException ex)

--- a/src/backend/Sudoku.Application/Handlers/GetPlayerGamesByStatusQueryHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/GetPlayerGamesByStatusQueryHandler.cs
@@ -27,7 +27,7 @@ public class GetPlayerGamesByStatusQueryHandler(IGameRepository gameRepository, 
 
             var gameDtos = games.Select(GameDto.FromGame).ToList();
 
-            logger.LogInformation("Retrieved {Count} games with status {Status} for profile {ProfileId}",
+            logger.LogDebug("Retrieved {Count} games with status {Status} for profile {ProfileId}",
                 gameDtos.Count, gameStatus, profileId.Value);
             return Result<List<GameDto>>.Success(gameDtos);
         }

--- a/src/backend/Sudoku.Application/Handlers/GetPlayerGamesQueryHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/GetPlayerGamesQueryHandler.cs
@@ -18,7 +18,7 @@ public class GetPlayerGamesQueryHandler(IGameRepository gameRepository, ILogger<
             var games = await gameRepository.GetByProfileIdAsync(profileId);
             var gameDtos = games.Select(GameDto.FromGame).ToList();
 
-            logger.LogInformation("Retrieved {Count} games for profile {ProfileId}", gameDtos.Count, profileId.Value);
+            logger.LogDebug("Retrieved {Count} games for profile {ProfileId}", gameDtos.Count, profileId.Value);
             return Result<List<GameDto>>.Success(gameDtos);
         }
         catch (DomainException ex)

--- a/src/backend/Sudoku.Application/Handlers/GetPlayerStatsQueryHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/GetPlayerStatsQueryHandler.cs
@@ -47,7 +47,7 @@ public class GetPlayerStatsQueryHandler(
                 .Select(difficulty => BuildDifficultyStats(difficulty, completions, activeGames))
                 .ToList();
 
-            logger.LogInformation(
+            logger.LogDebug(
                 "Retrieved stats for profile {ProfileId}: {GamesPlayed} played, {GamesWon} won",
                 profileId.Value, gamesPlayed, gamesWon);
 

--- a/src/backend/Sudoku.Application/Handlers/MakeMoveCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/MakeMoveCommandHandler.cs
@@ -26,7 +26,7 @@ public class MakeMoveCommandHandler(IGameRepository gameRepository, ILogger<Make
 
             await gameRepository.SaveAsync(game);
 
-            logger.LogInformation("Made move for game {GameId} at [{Row},{Column}] with value {Value}", 
+            logger.LogDebug("Made move for game {GameId} at [{Row},{Column}] with value {Value}",
                 gameId.Value, request.Row, request.Column, request.Value);
             return Result.Success();
         }

--- a/src/backend/Sudoku.Application/Handlers/PauseGameCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/PauseGameCommandHandler.cs
@@ -25,7 +25,7 @@ public class PauseGameCommandHandler(IGameRepository gameRepository, ILogger<Pau
 
             await gameRepository.SaveAsync(game);
 
-            logger.LogInformation("Paused game with ID: {GameId}", gameId.Value);
+            logger.LogDebug("Paused game with ID: {GameId}", gameId.Value);
             return Result.Success();
         }
         catch (DomainException ex)

--- a/src/backend/Sudoku.Application/Handlers/RemovePossibleValueCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/RemovePossibleValueCommandHandler.cs
@@ -25,7 +25,7 @@ public class RemovePossibleValueCommandHandler(IGameRepository gameRepository, I
 
             await gameRepository.SaveAsync(game);
 
-            logger.LogInformation("Removed possible value {Value} from game {GameId} at [{Row},{Column}]",
+            logger.LogDebug("Removed possible value {Value} from game {GameId} at [{Row},{Column}]",
                 request.Value, gameId.Value, request.Row, request.Column);
             return Result.Success();
         }

--- a/src/backend/Sudoku.Application/Handlers/RequestHintCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/RequestHintCommandHandler.cs
@@ -34,7 +34,7 @@ public class RequestHintCommandHandler(
 
             await gameRepository.SaveAsync(game);
 
-            logger.LogInformation("Revealed hint for game {GameId} at [{Row},{Column}] with value {Value}",
+            logger.LogDebug("Revealed hint for game {GameId} at [{Row},{Column}] with value {Value}",
                 gameId.Value, row, column, value);
             return Result.Success();
         }

--- a/src/backend/Sudoku.Application/Handlers/ResetGameCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/ResetGameCommandHandler.cs
@@ -25,7 +25,7 @@ public class ResetGameCommandHandler(IGameRepository gameRepository, ILogger<Res
             
             await gameRepository.SaveAsync(game);
             
-            logger.LogInformation("Reset game with ID: {GameId}", gameId.Value);
+            logger.LogDebug("Reset game with ID: {GameId}", gameId.Value);
             return Result.Success();
         }
         catch (DomainException ex)

--- a/src/backend/Sudoku.Application/Handlers/ResumeGameCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/ResumeGameCommandHandler.cs
@@ -25,7 +25,7 @@ public class ResumeGameCommandHandler(IGameRepository gameRepository, ILogger<Re
 
             await gameRepository.SaveAsync(game);
 
-            logger.LogInformation("Resumed game with ID: {GameId}", gameId.Value);
+            logger.LogDebug("Resumed game with ID: {GameId}", gameId.Value);
             return Result.Success();
         }
         catch (DomainException ex)

--- a/src/backend/Sudoku.Application/Handlers/StartGameCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/StartGameCommandHandler.cs
@@ -25,7 +25,7 @@ public class StartGameCommandHandler(IGameRepository gameRepository, ILogger<Sta
 
             await gameRepository.SaveAsync(game);
 
-            logger.LogInformation("Started game with ID: {GameId}", gameId.Value);
+            logger.LogDebug("Started game with ID: {GameId}", gameId.Value);
             return Result.Success();
         }
         catch (DomainException ex)

--- a/src/backend/Sudoku.Application/Handlers/UndoLastMoveCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/UndoLastMoveCommandHandler.cs
@@ -25,7 +25,7 @@ public class UndoLastMoveCommandHandler(IGameRepository gameRepository, ILogger<
             
             await gameRepository.SaveAsync(game);
             
-            logger.LogInformation("Undid last move for game with ID: {GameId}", gameId.Value);
+            logger.LogDebug("Undid last move for game with ID: {GameId}", gameId.Value);
             return Result.Success();
         }
         catch (NoMoveHistoryException ex)

--- a/src/backend/Sudoku.Application/Handlers/UpdateProfileAliasCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/UpdateProfileAliasCommandHandler.cs
@@ -40,7 +40,7 @@ public class UpdateProfileAliasCommandHandler(
             profile.UpdateAlias(newAlias);
             await profileRepository.SaveAsync(profile);
 
-            logger.LogInformation("Updated alias from {OldAlias} to {NewAlias} for profile {ProfileId}",
+            logger.LogDebug("Updated alias from {OldAlias} to {NewAlias} for profile {ProfileId}",
                 oldAlias.Value, newAlias.Value, profile.Id);
             return Result<ProfileDto>.Success(ProfileDto.FromProfile(profile));
         }

--- a/src/backend/Sudoku.Application/Handlers/ValidateGameQueryHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/ValidateGameQueryHandler.cs
@@ -29,7 +29,7 @@ public class ValidateGameQueryHandler(IGameRepository gameRepository, ILogger<Va
                 Errors: validationResult.Errors
             );
             
-            logger.LogInformation("Validated game with ID: {GameId}, IsValid: {IsValid}", gameId.Value, validationResult.IsValid);
+            logger.LogDebug("Validated game with ID: {GameId}, IsValid: {IsValid}", gameId.Value, validationResult.IsValid);
             return Result<ValidationResultDto>.Success(resultDto);
         }
         catch (DomainException ex)

--- a/src/backend/Sudoku.Infrastructure/Services/CosmosDbService.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/CosmosDbService.cs
@@ -26,7 +26,7 @@ public class CosmosDbService(CosmosClient cosmosClient, IOptions<CosmosDbOptions
         }
         catch (CosmosException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
         {
-            logger.LogInformation("Item with ID {Id} not found for deletion in CosmosDB", id);
+            logger.LogDebug("Item with ID {Id} not found for deletion in CosmosDB", id);
             // Don't throw exception for item not found during delete
         }
         catch (Exception ex)

--- a/src/backend/Sudoku.Infrastructure/Services/PuzzlePoolService.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/PuzzlePoolService.cs
@@ -15,7 +15,7 @@ public class PuzzlePoolService(IPuzzleBlobStorage puzzleBlobStorage, ILogger<Puz
             count++;
         }
 
-        logger.LogInformation("Pool size for {Difficulty}: {Count}", difficulty.Name, count);
+        logger.LogDebug("Pool size for {Difficulty}: {Count}", difficulty.Name, count);
         return count;
     }
 

--- a/src/backend/Tests/Application/Handlers/DeletePlayerGamesCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/DeletePlayerGamesCommandHandlerTests.cs
@@ -49,7 +49,7 @@ public class DeletePlayerGamesCommandHandlerTests : MoqBaseTestByAbstraction<Del
     }
 
     [Fact]
-    public async Task Handle_LogsInformationWithGameCount()
+    public async Task Handle_LogsDebugWithGameCount()
     {
         // Arrange
         var profileId = Guid.NewGuid().ToString();
@@ -66,7 +66,7 @@ public class DeletePlayerGamesCommandHandlerTests : MoqBaseTestByAbstraction<Del
         await sut.Handle(command, CancellationToken.None);
 
         // Assert
-        Logger.InformationLogs().ContainsMessage("Deleted 2 games for profile");
+        Logger.DebugLogs().ContainsMessage("Deleted 2 games for profile");
     }
 
     [Fact]

--- a/src/backend/Tests/Application/Handlers/ResetGameCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/ResetGameCommandHandlerTests.cs
@@ -49,7 +49,7 @@ public class ResetGameCommandHandlerTests : MoqBaseTestByAbstraction<ResetGameCo
     }
 
     [Fact]
-    public async Task Handle_LogsInformationWhenSuccessful()
+    public async Task Handle_LogsDebugWhenSuccessful()
     {
         // Arrange
         var sut = ResolveSut();
@@ -58,7 +58,7 @@ public class ResetGameCommandHandlerTests : MoqBaseTestByAbstraction<ResetGameCo
         await sut.Handle(_cmd, CancellationToken.None);
 
         // Assert
-        Logger.InformationLogs().ContainsMessage("Reset game with ID");
+        Logger.DebugLogs().ContainsMessage("Reset game with ID");
     }
 
     [Fact]

--- a/src/backend/Tests/Application/Handlers/UndoLastMoveCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/UndoLastMoveCommandHandlerTests.cs
@@ -50,7 +50,7 @@ public class UndoLastMoveCommandHandlerTests : MoqBaseTestByAbstraction<UndoLast
     }
 
     [Fact]
-    public async Task Handle_LogsInformationWhenSuccessful()
+    public async Task Handle_LogsDebugWhenSuccessful()
     {
         // Arrange
         var sut = ResolveSut();
@@ -59,7 +59,7 @@ public class UndoLastMoveCommandHandlerTests : MoqBaseTestByAbstraction<UndoLast
         await sut.Handle(_cmd, CancellationToken.None);
 
         // Assert
-        Logger.InformationLogs().ContainsMessage("Undid last move for game with ID");
+        Logger.DebugLogs().ContainsMessage("Undid last move for game with ID");
     }
 
     [Fact]

--- a/src/backend/Tests/Application/Handlers/ValidateGameQueryHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/ValidateGameQueryHandlerTests.cs
@@ -38,7 +38,7 @@ public class ValidateGameQueryHandlerTests : MoqBaseTestByAbstraction<ValidateGa
     }
 
     [Fact]
-    public async Task Handle_LogsInformationWithValidationResult()
+    public async Task Handle_LogsDebugWithValidationResult()
     {
         // Arrange
         _mockGameRepository.SetupGameStarted();
@@ -48,8 +48,8 @@ public class ValidateGameQueryHandlerTests : MoqBaseTestByAbstraction<ValidateGa
         await sut.Handle(_query, CancellationToken.None);
 
         // Assert
-        Logger.InformationLogs().ContainsMessage("Validated game with ID");
-        Logger.InformationLogs().ContainsMessage("IsValid: True");
+        Logger.DebugLogs().ContainsMessage("Validated game with ID");
+        Logger.DebugLogs().ContainsMessage("IsValid: True");
     }
 
     [Fact]


### PR DESCRIPTION
## Description

App Insights bills on log ingestion volume. Every Application-layer command/query handler logged its success path at `Information`, so routine per-request operations (moves, pencil marks, game reads, list reads) shipped to App Insights on every single call — duplicating what OpenTelemetry request tracing already captures. This demotes those success-path logs to `Debug`.

In production the minimum log level is `Information` (Serilog `MinimumLevel.Default` in `Sudoku.Api/appsettings.json`), so anything at `Debug` is filtered out before it reaches App Insights, while anything `Information`+ ships. This is a pure logging-level change with zero behavioral impact — `Debug` logs remain visible locally since `appsettings.Development.json` sets `Default: Debug`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Demoted the success-path `LogInformation` call in 22 `Sudoku.Application/Handlers/*` command/query handlers to `LogDebug` — this brings them in line with the Debug convention already used throughout the Infrastructure repository/service layer and two Application handlers (`GetProfileByAliasQueryHandler`, `GetProfileByIdQueryHandler`) that already followed it.
- Demoted two more inconsistent `Information` logs found during the audit: `CosmosDbService.DeleteItemAsync`'s "not found" branch (its `GetItemAsync` twin was already `Debug`) and `PuzzlePoolService.GetAvailableCountAsync`'s pool-size readout (a metric, not a lifecycle event).
- Updated 4 handler tests whose `Logger.InformationLogs()` assertions needed to become `Logger.DebugLogs()` to match (test names updated accordingly, e.g. `Handle_LogsInformationWhenSuccessful` → `Handle_LogsDebugWhenSuccessful`).
- Left untouched: all `LogWarning`/`LogError` calls, the `GameCreatedEvent`/`GameCompletedEvent` domain event handlers (the actual once-per-game analytics signal), the rare "backstop" completion-recording log in `DeleteGameCommandHandler`, and all puzzle-pool seeding/replenishment/startup logs (low-volume, operationally meaningful background-job signals).

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

`dotnet build` — clean, no new warnings. `dotnet test` — 713/713 passing.

## Screenshots (if applicable)

N/A — logging-level change only.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)