### PR TITLE
Trim derivable Commands section from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,47 +2,6 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Commands
-
-### Build & Run
-```bash
-# Build entire solution
-dotnet build
-
-# Run REST API
-dotnet run --project src/backend/Sudoku.Api
-
-# Run React frontend (requires API running separately)
-cd src/frontend/Sudoku.React
-npm install
-npm run dev
-```
-
-### Testing
-```bash
-# Run all tests
-dotnet test
-
-# Run a single test class
-dotnet test --filter "FullyQualifiedName~SudokuGameTests"
-
-# Run a single test method
-dotnet test --filter "FullyQualifiedName~SudokuGameTests.MakeMoveValidMoveRaisesEvent"
-
-# Watch mode
-dotnet watch test
-
-# React tests
-npm run test           # run once
-npm run test:watch     # watch mode
-npm run test:coverage  # with coverage
-```
-
-### Linting
-```bash
-npm run lint           # React frontend only
-```
-
 ## Architecture
 
 This solution follows **Clean Architecture** with **DDD** and **CQRS** across six backend projects and one frontend project.


### PR DESCRIPTION
## Description

Removes the `## Commands` section from the root `CLAUDE.md`. Those entries (`dotnet build`, `dotnet test`, `dotnet run`, the standard `--filter FullyQualifiedName~` form, and the `npm run dev/test/lint` scripts) are standard tool invocations or `package.json` scripts a session can re-derive from the codebase, so they were dead weight loaded into every session's context. Everything non-derivable (architecture, DepenMock testing patterns, Result-pattern rationale) is kept.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Removed the `## Commands` section (Build & Run, Testing, Linting blocks — 41 lines) from `CLAUDE.md`
- Reduces always-loaded session context by ~240 est. tokens with no loss of non-derivable guidance

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

_Docs-only change; no code affected._

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation (if necessary)