### PR TITLE
Add read-only commands to permission allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,13 @@
 {
+  "permissions": {
+    "allow": [
+      "mcp__azure-appinsights__query_logs",
+      "Bash(dotnet test *)",
+      "Bash(dotnet test)",
+      "Bash(dotnet build *)",
+      "Bash(dotnet build)"
+    ]
+  },
   "hooks": {
     "Notification": [
       {


### PR DESCRIPTION
## Description

Adds a `permissions.allow` block to `.claude/settings.json` to reduce Claude Code permission prompts for commands used frequently in this repo. Derived from scanning recent session transcripts for high-frequency read-only calls.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Other (please describe): Developer tooling / Claude Code configuration

## Changes Made

- Added `permissions.allow` to `.claude/settings.json` (previously had no `permissions` block; existing `hooks` preserved).
- Allowlisted `mcp__azure-appinsights__query_logs` — the most-used read-only MCP call (App Insights log queries).
- Allowlisted `dotnet test` and `dotnet build` (bare + `*` forms). These build/run code so they aren't strictly read-only, but are added as an accepted convenience tradeoff since they're the most frequent prompt sources.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

N/A — configuration-only change (JSON allowlist); no application code affected.

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)