### PR TITLE
Phase 1/6: BoardSize value object (16x16 Sudoku spec)

### DIFF
--- a/scripts/set-app-config.sh
+++ b/scripts/set-app-config.sh
@@ -68,7 +68,6 @@ push_production() {
     # Sudoku Game Settings
     # -------------------------------------------------------------------------
     set_key "$LABEL" "Sudoku:Game:DefaultDifficulty"                         "Medium"
-    set_key "$LABEL" "Sudoku:Game:MaxHintsPerGame"                           "3"
     set_key "$LABEL" "Sudoku:Game:AutoSaveIntervalSeconds"                   "30"
     set_key "$LABEL" "Sudoku:Game:EnableStatistics"                          "true"
     set_key "$LABEL" "Sudoku:UI:DefaultTheme"                                "Light"
@@ -131,7 +130,6 @@ push_development() {
     # Sudoku Game Settings (same as production)
     # -------------------------------------------------------------------------
     set_key "$LABEL" "Sudoku:Game:DefaultDifficulty"                         "Medium"
-    set_key "$LABEL" "Sudoku:Game:MaxHintsPerGame"                           "3"
     set_key "$LABEL" "Sudoku:Game:AutoSaveIntervalSeconds"                   "30"
     set_key "$LABEL" "Sudoku:Game:EnableStatistics"                          "true"
     set_key "$LABEL" "Sudoku:UI:DefaultTheme"                                "Light"

--- a/src/backend/Sudoku.Application/DTOs/GameDto.cs
+++ b/src/backend/Sudoku.Application/DTOs/GameDto.cs
@@ -25,7 +25,7 @@ public record GameDto(
             game.DisplayName.Value,
             game.Difficulty.Name,
             game.Status.ToString(),
-            GameStatisticsDto.FromGameStatistics(game.Statistics),
+            GameStatisticsDto.FromGameStatistics(game.Statistics, game.Size),
             game.CreatedAt,
             game.StartedAt,
             game.CompletedAt,
@@ -45,14 +45,14 @@ public record GameStatisticsDto(
     TimeSpan PlayDuration,
     double AccuracyPercentage)
 {
-    public static GameStatisticsDto FromGameStatistics(GameStatistics statistics)
+    public static GameStatisticsDto FromGameStatistics(GameStatistics statistics, BoardSize size)
     {
         return new GameStatisticsDto(
             statistics.TotalMoves,
             statistics.ValidMoves,
             statistics.InvalidMoves,
             statistics.HintsUsed,
-            statistics.HintsRemaining,
+            statistics.HintsRemainingFor(size),
             statistics.PlayDuration,
             statistics.AccuracyPercentage
         );

--- a/src/backend/Sudoku.Application/Handlers/CreateGameCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/CreateGameCommandHandler.cs
@@ -35,7 +35,7 @@ public class CreateGameCommandHandler(
                 return Result<string>.Failure($"No puzzle available for difficulty: {difficulty.Name}");
             }
 
-            var game = SudokuGame.Create(profileId, displayName, difficulty, puzzle.Cells);
+            var game = SudokuGame.Create(profileId, displayName, difficulty, BoardSize.Nine, puzzle.Cells);
 
             await gameRepository.SaveAsync(game);
 

--- a/src/backend/Sudoku.Application/Handlers/RequestHintCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/RequestHintCommandHandler.cs
@@ -54,10 +54,10 @@ public class RequestHintCommandHandler(
     {
         var cells = game.GetCells()
             .Select(c => c.IsLocked
-                ? Cell.CreateFixed(c.Row, c.Column, c.Value!.Value)
-                : Cell.CreateEmpty(c.Row, c.Column))
+                ? Cell.CreateFixed(c.Row, c.Column, c.Value!.Value, game.Size)
+                : Cell.CreateEmpty(c.Row, c.Column, game.Size))
             .ToList();
 
-        return SudokuPuzzle.Create(game.Id.Value.ToString(), game.Difficulty, cells);
+        return SudokuPuzzle.Create(game.Id.Value.ToString(), game.Difficulty, game.Size, cells);
     }
 }

--- a/src/backend/Sudoku.Benchmarks/PuzzleParser.cs
+++ b/src/backend/Sudoku.Benchmarks/PuzzleParser.cs
@@ -24,10 +24,10 @@ public static class PuzzleParser
             var ch = board[i];
 
             cells.Add(ch is >= '1' and <= '9'
-                ? Cell.CreateFixed(row, column, ch - '0')
-                : Cell.CreateEmpty(row, column));
+                ? Cell.CreateFixed(row, column, ch - '0', BoardSize.Nine)
+                : Cell.CreateEmpty(row, column, BoardSize.Nine));
         }
 
-        return SudokuPuzzle.Create(GameId.New(), difficulty, cells);
+        return SudokuPuzzle.Create(GameId.New(), difficulty, BoardSize.Nine, cells);
     }
 }

--- a/src/backend/Sudoku.Domain/Entities/SudokuGame.cs
+++ b/src/backend/Sudoku.Domain/Entities/SudokuGame.cs
@@ -9,6 +9,7 @@ public class SudokuGame : AggregateRoot
     public ProfileId ProfileId { get; private set; }
     public PlayerAlias DisplayName { get; private set; }
     public GameDifficulty Difficulty { get; private set; }
+    public BoardSize Size { get; private set; }
     public GameStatusEnum Status { get; private set; }
     public GameStatistics Statistics { get; private set; }
     public DateTime CreatedAt { get; private set; }
@@ -23,7 +24,7 @@ public class SudokuGame : AggregateRoot
         _moveHistory = [];
     }
 
-    public static SudokuGame Create(ProfileId profileId, PlayerAlias displayName, GameDifficulty difficulty, IEnumerable<Cell> initialCells)
+    public static SudokuGame Create(ProfileId profileId, PlayerAlias displayName, GameDifficulty difficulty, BoardSize size, IEnumerable<Cell> initialCells)
     {
         var game = new SudokuGame
         {
@@ -31,6 +32,7 @@ public class SudokuGame : AggregateRoot
             ProfileId = profileId,
             DisplayName = displayName,
             Difficulty = difficulty,
+            Size = size,
             Status = GameStatusEnum.NotStarted,
             Statistics = GameStatistics.Create(),
             CreatedAt = DateTime.UtcNow
@@ -38,7 +40,7 @@ public class SudokuGame : AggregateRoot
 
         game._cells.AddRange(initialCells);
 
-        game.AddDomainEvent(new GameCreatedEvent(game.Id, profileId, displayName, difficulty));
+        game.AddDomainEvent(new GameCreatedEvent(game.Id, profileId, displayName, difficulty, size));
         return game;
     }
 
@@ -47,6 +49,7 @@ public class SudokuGame : AggregateRoot
         ProfileId profileId,
         PlayerAlias displayName,
         GameDifficulty difficulty,
+        BoardSize size,
         GameStatusEnum statusEnum,
         GameStatistics statistics,
         IEnumerable<Cell> cells,
@@ -62,6 +65,7 @@ public class SudokuGame : AggregateRoot
             ProfileId = profileId,
             DisplayName = displayName,
             Difficulty = difficulty,
+            Size = size,
             Status = statusEnum,
             Statistics = statistics,
             CreatedAt = createdAt,
@@ -133,7 +137,7 @@ public class SudokuGame : AggregateRoot
             throw new GameNotInProgressException($"Cannot reveal a hint in {Status} state");
         }
 
-        if (Statistics.HintsUsed >= GameStatistics.MaxHints)
+        if (Statistics.HintsUsed >= Size.MaxHints)
         {
             throw new HintLimitReachedException();
         }
@@ -149,7 +153,7 @@ public class SudokuGame : AggregateRoot
             ?? throw new NoAvailableCellsForHintException();
 
         var index = _cells.FindIndex(c => c.Row == target.Row && c.Column == target.Column);
-        _cells[index] = Cell.CreateHint(target.Row, target.Column, correctValue);
+        _cells[index] = Cell.CreateHint(target.Row, target.Column, correctValue, Size);
 
         Statistics.RecordHint();
 
@@ -261,7 +265,7 @@ public class SudokuGame : AggregateRoot
 
             if (cell.IsHint)
             {
-                _cells[i] = Cell.CreateEmpty(cell.Row, cell.Column);
+                _cells[i] = Cell.CreateEmpty(cell.Row, cell.Column, Size);
             }
             else
             {
@@ -292,7 +296,7 @@ public class SudokuGame : AggregateRoot
         var isValid = true;
 
         // Validate rows
-        for (int row = 0; row < 9; row++)
+        for (int row = 0; row < Size.Size; row++)
         {
             var rowValues = _cells.Where(c => c.Row == row && c.HasValue)
                                  .Select(c => c.Value!.Value)
@@ -306,7 +310,7 @@ public class SudokuGame : AggregateRoot
         }
 
         // Validate columns
-        for (int column = 0; column < 9; column++)
+        for (int column = 0; column < Size.Size; column++)
         {
             var columnValues = _cells.Where(c => c.Column == column && c.HasValue)
                                     .Select(c => c.Value!.Value)
@@ -319,20 +323,20 @@ public class SudokuGame : AggregateRoot
             }
         }
 
-        // Validate 3x3 boxes
-        for (int boxRow = 0; boxRow < 9; boxRow += 3)
+        // Validate boxes
+        for (int boxRow = 0; boxRow < Size.Size; boxRow += Size.BoxSize)
         {
-            for (int boxColumn = 0; boxColumn < 9; boxColumn += 3)
+            for (int boxColumn = 0; boxColumn < Size.Size; boxColumn += Size.BoxSize)
             {
-                var boxValues = _cells.Where(c => c.Row >= boxRow && c.Row < boxRow + 3 &&
-                                                 c.Column >= boxColumn && c.Column < boxColumn + 3 &&
+                var boxValues = _cells.Where(c => c.Row >= boxRow && c.Row < boxRow + Size.BoxSize &&
+                                                 c.Column >= boxColumn && c.Column < boxColumn + Size.BoxSize &&
                                                  c.HasValue)
                                      .Select(c => c.Value!.Value)
                                      .ToList();
 
                 if (boxValues.Count != boxValues.Distinct().Count())
                 {
-                    errors.Add($"Box at position ({boxRow / 3 + 1}, {boxColumn / 3 + 1}) contains duplicate values");
+                    errors.Add($"Box at position ({boxRow / Size.BoxSize + 1}, {boxColumn / Size.BoxSize + 1}) contains duplicate values");
                     isValid = false;
                 }
             }
@@ -421,46 +425,46 @@ public class SudokuGame : AggregateRoot
 
     private bool IsValidForBox(int row, int column, int value)
     {
-        var boxRow = row / 3 * 3;
-        var boxColumn = column / 3 * 3;
+        var boxRow = row / Size.BoxSize * Size.BoxSize;
+        var boxColumn = column / Size.BoxSize * Size.BoxSize;
 
-        return _cells.Where(c => c.Row >= boxRow && c.Row < boxRow + 3 && c.Column >= boxColumn && c.Column < boxColumn + 3 && c.HasValue).All(c => c.Value != value);
+        return _cells.Where(c => c.Row >= boxRow && c.Row < boxRow + Size.BoxSize && c.Column >= boxColumn && c.Column < boxColumn + Size.BoxSize && c.HasValue).All(c => c.Value != value);
     }
 
     private bool IsValidPuzzle()
     {
-        for (int row = 0; row < 9; row++)
+        for (int row = 0; row < Size.Size; row++)
         {
             var rowValues = _cells.Where(c => c.Row == row && c.HasValue)
                                  .Select(c => c.Value!.Value)
                                  .ToList();
-            if (rowValues.Count != 9 || rowValues.Distinct().Count() != 9)
+            if (rowValues.Count != Size.Size || rowValues.Distinct().Count() != Size.Size)
             {
                 return false;
             }
         }
 
-        for (int column = 0; column < 9; column++)
+        for (int column = 0; column < Size.Size; column++)
         {
             var columnValues = _cells.Where(c => c.Column == column && c.HasValue)
                                     .Select(c => c.Value!.Value)
                                     .ToList();
-            if (columnValues.Count != 9 || columnValues.Distinct().Count() != 9)
+            if (columnValues.Count != Size.Size || columnValues.Distinct().Count() != Size.Size)
             {
                 return false;
             }
         }
 
-        for (int boxRow = 0; boxRow < 9; boxRow += 3)
+        for (int boxRow = 0; boxRow < Size.Size; boxRow += Size.BoxSize)
         {
-            for (int boxColumn = 0; boxColumn < 9; boxColumn += 3)
+            for (int boxColumn = 0; boxColumn < Size.Size; boxColumn += Size.BoxSize)
             {
-                var boxValues = _cells.Where(c => c.Row >= boxRow && c.Row < boxRow + 3 &&
-                                                 c.Column >= boxColumn && c.Column < boxColumn + 3 &&
+                var boxValues = _cells.Where(c => c.Row >= boxRow && c.Row < boxRow + Size.BoxSize &&
+                                                 c.Column >= boxColumn && c.Column < boxColumn + Size.BoxSize &&
                                                  c.HasValue)
                                      .Select(c => c.Value!.Value)
                                      .ToList();
-                if (boxValues.Count != 9 || boxValues.Distinct().Count() != 9)
+                if (boxValues.Count != Size.Size || boxValues.Distinct().Count() != Size.Size)
                 {
                     return false;
                 }
@@ -477,7 +481,7 @@ public class SudokuGame : AggregateRoot
         Status = GameStatusEnum.Completed;
         CompletedAt = completedAt;
 
-        AddDomainEvent(new GameCompletedEvent(Id, ProfileId, Difficulty, Statistics, completedAt));
+        AddDomainEvent(new GameCompletedEvent(Id, ProfileId, Difficulty, Statistics, completedAt, Size));
     }
 }
 

--- a/src/backend/Sudoku.Domain/Entities/SudokuPuzzle.cs
+++ b/src/backend/Sudoku.Domain/Entities/SudokuPuzzle.cs
@@ -9,18 +9,20 @@ public class SudokuPuzzle : ICloneable
 
     public string PuzzleId { get; }
     public GameDifficulty Difficulty { get; }
+    public BoardSize Size { get; }
     public IReadOnlyList<Cell> Cells => _cells.AsReadOnly();
 
-    private SudokuPuzzle(string puzzleId, GameDifficulty difficulty, IEnumerable<Cell> cells)
+    private SudokuPuzzle(string puzzleId, GameDifficulty difficulty, BoardSize size, IEnumerable<Cell> cells)
     {
         PuzzleId = puzzleId;
         Difficulty = difficulty;
+        Size = size;
         _cells = cells.ToList();
     }
 
-    public static SudokuPuzzle Create(string puzzleId, GameDifficulty difficulty, IEnumerable<Cell> cells)
+    public static SudokuPuzzle Create(string puzzleId, GameDifficulty difficulty, BoardSize size, IEnumerable<Cell> cells)
     {
-        var puzzle = new SudokuPuzzle(puzzleId, difficulty, cells);
+        var puzzle = new SudokuPuzzle(puzzleId, difficulty, size, cells);
 
         if (!puzzle.IsValid())
         {
@@ -37,14 +39,14 @@ public class SudokuPuzzle : ICloneable
 
     public bool IsValid()
     {
-        if (_cells.Count != 81)
+        if (_cells.Count != Size.CellCount)
         {
             return false;
         }
 
-        for (var row = 0; row < 9; row++)
+        for (var row = 0; row < Size.Size; row++)
         {
-            for (var column = 0; column < 9; column++)
+            for (var column = 0; column < Size.Size; column++)
             {
                 if (!_cells.Any(c => c.Row == row && c.Column == column))
                 {
@@ -59,7 +61,7 @@ public class SudokuPuzzle : ICloneable
     private bool IsValidSudoku()
     {
         // Check rows
-        for (var row = 0; row < 9; row++)
+        for (var row = 0; row < Size.Size; row++)
         {
             var usedValues = new HashSet<int>();
             var rowCells = GetRowCells(row).Where(c => c.HasValue);
@@ -73,8 +75,8 @@ public class SudokuPuzzle : ICloneable
             }
         }
 
-        // Check columns  
-        for (var column = 0; column < 9; column++)
+        // Check columns
+        for (var column = 0; column < Size.Size; column++)
         {
             var usedValues = new HashSet<int>();
             var columnCells = GetColumnCells(column).Where(c => c.HasValue);
@@ -88,10 +90,10 @@ public class SudokuPuzzle : ICloneable
             }
         }
 
-        // Check 3x3 boxes
-        for (var boxRow = 0; boxRow < 3; boxRow++)
+        // Check boxes
+        for (var boxRow = 0; boxRow < Size.BoxSize; boxRow++)
         {
-            for (var boxColumn = 0; boxColumn < 3; boxColumn++)
+            for (var boxColumn = 0; boxColumn < Size.BoxSize; boxColumn++)
             {
                 var usedValues = new HashSet<int>();
                 var boxCells = GetMiniGridCells(boxRow, boxColumn).Where(c => c.HasValue);
@@ -109,14 +111,12 @@ public class SudokuPuzzle : ICloneable
         return true;
     }
 
-    private const int MinimumCluesForUniqueSolution = 17; // Based on Sudoku rules, 17 is the minimum number of clues required for a puzzle to have a unique solution.
-
     public bool HasUniqueSolution()
     {
         // This is a simplified check - in a real implementation, you'd want a more sophisticated solver
         // For now, we'll assume that puzzles with a reasonable number of fixed cells have unique solutions
         var fixedCells = _cells.Count(c => c.IsFixed);
-        return fixedCells >= MinimumCluesForUniqueSolution;
+        return fixedCells >= Size.MinimumClues;
     }
 
     public int GetFixedCellCount() => _cells.Count(c => c.IsFixed);
@@ -135,8 +135,8 @@ public class SudokuPuzzle : ICloneable
 
     public IEnumerable<Cell> GetMiniGridCells(int boxRow, int boxColumn)
     {
-        return _cells.Where(c => c.Row >= boxRow * 3 && c.Row < (boxRow + 1) * 3 &&
-                                 c.Column >= boxColumn * 3 && c.Column < (boxColumn + 1) * 3)
+        return _cells.Where(c => c.Row >= boxRow * Size.BoxSize && c.Row < (boxRow + 1) * Size.BoxSize &&
+                                 c.Column >= boxColumn * Size.BoxSize && c.Column < (boxColumn + 1) * Size.BoxSize)
                      .OrderBy(c => c.Row).ThenBy(c => c.Column);
     }
 
@@ -151,13 +151,13 @@ public class SudokuPuzzle : ICloneable
             }
             var rowValues = GetRowCells(cell.Row).Where(c => c.HasValue).Select(c => c.Value!.Value).ToHashSet();
             var columnValues = GetColumnCells(cell.Column).Where(c => c.HasValue).Select(c => c.Value!.Value).ToHashSet();
-            var miniGridValues = GetMiniGridCells(cell.Row / 3, cell.Column / 3)
+            var miniGridValues = GetMiniGridCells(cell.Row / Size.BoxSize, cell.Column / Size.BoxSize)
                 .Where(c => c.HasValue)
                 .Select(c => c.Value!.Value)
                 .ToHashSet();
             var usedValues = rowValues.Union(columnValues).Union(miniGridValues);
             cell.PossibleValues.Clear();
-            cell.PossibleValues.AddRange(Enumerable.Range(1, 9).Where(v => !usedValues.Contains(v)).ToList());
+            cell.PossibleValues.AddRange(Size.AllValues.Where(v => !usedValues.Contains(v)).ToList());
         }
     }
 
@@ -169,8 +169,8 @@ public class SudokuPuzzle : ICloneable
     {
         // Deep clone all cells
         var clonedCells = _cells.Select(cell => cell.DeepCopy()).ToList();
-        
+
         // Create a new puzzle instance using the private constructor
-        return new SudokuPuzzle(PuzzleId, Difficulty, clonedCells);
+        return new SudokuPuzzle(PuzzleId, Difficulty, Size, clonedCells);
     }
 }

--- a/src/backend/Sudoku.Domain/Events/GameEvents.cs
+++ b/src/backend/Sudoku.Domain/Events/GameEvents.cs
@@ -1,6 +1,6 @@
 namespace Sudoku.Domain.Events;
 
-public record GameCreatedEvent(GameId GameId, ProfileId ProfileId, PlayerAlias DisplayName, GameDifficulty Difficulty) : DomainEvent;
+public record GameCreatedEvent(GameId GameId, ProfileId ProfileId, PlayerAlias DisplayName, GameDifficulty Difficulty, BoardSize Size) : DomainEvent;
 
 public record GameStartedEvent(GameId GameId) : DomainEvent;
 
@@ -15,7 +15,8 @@ public record GameCompletedEvent(
     ProfileId ProfileId,
     GameDifficulty Difficulty,
     GameStatistics Statistics,
-    DateTime CompletedAt) : DomainEvent;
+    DateTime CompletedAt,
+    BoardSize Size) : DomainEvent;
 
 public record GameAbandonedEvent(GameId GameId) : DomainEvent;
 

--- a/src/backend/Sudoku.Domain/Exceptions/InvalidBoardSizeException.cs
+++ b/src/backend/Sudoku.Domain/Exceptions/InvalidBoardSizeException.cs
@@ -1,0 +1,3 @@
+namespace Sudoku.Domain.Exceptions;
+
+public class InvalidBoardSizeException(string message) : DomainException(message);

--- a/src/backend/Sudoku.Domain/ValueObjects/BoardSize.cs
+++ b/src/backend/Sudoku.Domain/ValueObjects/BoardSize.cs
@@ -1,0 +1,33 @@
+using Sudoku.Domain.Exceptions;
+
+namespace Sudoku.Domain.ValueObjects;
+
+public record BoardSize
+{
+    public static readonly BoardSize Nine = new(9, 3, 17, 3);
+    public static readonly BoardSize Sixteen = new(16, 4, 55, 6);
+
+    public int Size { get; }
+    public int BoxSize { get; }
+    public int MinimumClues { get; }
+    public int MaxHints { get; }
+    public int CellCount => Size * Size;
+    public IEnumerable<int> AllValues => Enumerable.Range(1, Size);
+
+    private BoardSize(int size, int boxSize, int minimumClues, int maxHints)
+    {
+        Size = size;
+        BoxSize = boxSize;
+        MinimumClues = minimumClues;
+        MaxHints = maxHints;
+    }
+
+    public static BoardSize FromValue(int value) => value switch
+    {
+        9 => Nine,
+        16 => Sixteen,
+        _ => throw new InvalidBoardSizeException($"Invalid board size: {value}")
+    };
+
+    public override string ToString() => $"{Size}x{Size}";
+}

--- a/src/backend/Sudoku.Domain/ValueObjects/Cell.cs
+++ b/src/backend/Sudoku.Domain/ValueObjects/Cell.cs
@@ -9,6 +9,7 @@ public record Cell
     public int? Value { get; private set; }
     public bool IsFixed { get; }
     public bool IsHint { get; }
+    public BoardSize Size { get; }
     public bool HasValue => Value.HasValue;
 
     /// <summary>
@@ -18,21 +19,21 @@ public record Cell
     public bool IsLocked => IsFixed || IsHint;
     public HashSet<int> PossibleValues { get; private set; } = new();
 
-    private Cell(int row, int column, int? value, bool isFixed, bool isHint = false)
+    private Cell(int row, int column, int? value, bool isFixed, BoardSize size, bool isHint = false)
     {
-        if (row < 0 || row > 8)
+        if (row < 0 || row > size.Size - 1)
         {
-            throw new InvalidCellPositionException($"Row must be between 0 and 8, got: {row}");
+            throw new InvalidCellPositionException($"Row must be between 0 and {size.Size - 1}, got: {row}");
         }
 
-        if (column < 0 || column > 8)
+        if (column < 0 || column > size.Size - 1)
         {
-            throw new InvalidCellPositionException($"Column must be between 0 and 8, got: {column}");
+            throw new InvalidCellPositionException($"Column must be between 0 and {size.Size - 1}, got: {column}");
         }
 
-        if (value.HasValue && (value.Value < 1 || value.Value > 9))
+        if (value.HasValue && (value.Value < 1 || value.Value > size.Size))
         {
-            throw new InvalidCellValueException($"Cell value must be between 1 and 9, got: {value.Value}");
+            throw new InvalidCellValueException($"Cell value must be between 1 and {size.Size}, got: {value.Value}");
         }
 
         Row = row;
@@ -40,30 +41,31 @@ public record Cell
         Value = value;
         IsFixed = isFixed;
         IsHint = isHint;
+        Size = size;
     }
 
-    public static Cell Create(int row, int column, int? value = null, bool isFixed = false, bool isHint = false)
+    public static Cell Create(int row, int column, BoardSize size, int? value = null, bool isFixed = false, bool isHint = false)
     {
-        return new Cell(row, column, value, isFixed, isHint);
+        return new Cell(row, column, value, isFixed, size, isHint);
     }
 
-    public static Cell CreateFixed(int row, int column, int value)
+    public static Cell CreateFixed(int row, int column, int value, BoardSize size)
     {
-        return new Cell(row, column, value, true);
+        return new Cell(row, column, value, true, size);
     }
 
-    public static Cell CreateEmpty(int row, int column)
+    public static Cell CreateEmpty(int row, int column, BoardSize size)
     {
-        return new Cell(row, column, null, false);
+        return new Cell(row, column, null, false, size);
     }
 
     /// <summary>
     /// Creates a cell revealed by a hint: it holds the correct value and is locked so the player
     /// cannot change it, but it is distinct from an original clue (<see cref="IsFixed"/> stays false).
     /// </summary>
-    public static Cell CreateHint(int row, int column, int value)
+    public static Cell CreateHint(int row, int column, int value, BoardSize size)
     {
-        return new Cell(row, column, value, isFixed: false, isHint: true);
+        return new Cell(row, column, value, isFixed: false, size, isHint: true);
     }
 
     public void SetValue(int value)
@@ -73,9 +75,9 @@ public record Cell
             throw new CellIsFixedException($"Cannot modify fixed cell at position ({Row}, {Column})");
         }
 
-        if (value < 1 || value > 9)
+        if (value < 1 || value > Size.Size)
         {
-            throw new InvalidCellValueException($"Cell value must be between 1 and 9, got: {value}");
+            throw new InvalidCellValueException($"Cell value must be between 1 and {Size.Size}, got: {value}");
         }
 
         Value = value;
@@ -91,9 +93,9 @@ public record Cell
 
         if (value.HasValue)
         {
-            if (value.Value < 1 || value.Value > 9)
+            if (value.Value < 1 || value.Value > Size.Size)
             {
-                throw new InvalidCellValueException($"Cell value must be between 1 and 9, got: {value.Value}");
+                throw new InvalidCellValueException($"Cell value must be between 1 and {Size.Size}, got: {value.Value}");
             }
         }
 
@@ -127,9 +129,9 @@ public record Cell
             throw new CellAlreadyHasValueException($"Cannot add possible values to cell with a definite value at position ({Row}, {Column})");
         }
 
-        if (value < 1 || value > 9)
+        if (value < 1 || value > Size.Size)
         {
-            throw new InvalidCellValueException($"Possible value must be between 1 and 9, got: {value}");
+            throw new InvalidCellValueException($"Possible value must be between 1 and {Size.Size}, got: {value}");
         }
 
         if (!PossibleValues.Contains(value))
@@ -145,9 +147,9 @@ public record Cell
             throw new CellIsFixedException($"Cannot modify fixed cell at position ({Row}, {Column})");
         }
 
-        if (value < 1 || value > 9)
+        if (value < 1 || value > Size.Size)
         {
-            throw new InvalidCellValueException($"Possible value must be between 1 and 9, got: {value}");
+            throw new InvalidCellValueException($"Possible value must be between 1 and {Size.Size}, got: {value}");
         }
 
         PossibleValues.Remove(value);
@@ -170,13 +172,13 @@ public record Cell
 
     public Cell DeepCopy()
     {
-        var clonedCell = new Cell(Row, Column, Value, IsFixed, IsHint);
+        var clonedCell = new Cell(Row, Column, Value, IsFixed, Size, IsHint);
 
         foreach (var possibleValue in PossibleValues)
         {
             clonedCell.PossibleValues.Add(possibleValue);
         }
-        
+
         return clonedCell;
     }
 }

--- a/src/backend/Sudoku.Domain/ValueObjects/GameStatistics.cs
+++ b/src/backend/Sudoku.Domain/ValueObjects/GameStatistics.cs
@@ -2,9 +2,6 @@ namespace Sudoku.Domain.ValueObjects;
 
 public record GameStatistics
 {
-    /// <summary>Maximum number of hints a player may use per game (all difficulties).</summary>
-    public const int MaxHints = 3;
-
     public int TotalMoves { get; private set; }
     public int ValidMoves { get; private set; }
     public int InvalidMoves { get; private set; }
@@ -59,7 +56,8 @@ public record GameStatistics
 
     public double AccuracyPercentage => TotalMoves > 0 ? (double)ValidMoves / TotalMoves * 100 : 0;
 
-    public int HintsRemaining => Math.Max(0, MaxHints - HintsUsed);
+    /// <summary>Hints remaining, given the calling game's board-size allowance (<see cref="BoardSize.MaxHints"/>).</summary>
+    public int HintsRemainingFor(BoardSize size) => Math.Max(0, size.MaxHints - HintsUsed);
 
     public bool HasMoves => TotalMoves > 0;
 }

--- a/src/backend/Sudoku.Infrastructure/Mappers/SudokuGameMapper.cs
+++ b/src/backend/Sudoku.Infrastructure/Mappers/SudokuGameMapper.cs
@@ -53,6 +53,7 @@ public static class SudokuGameMapper
             profileId,
             displayName,
             difficulty,
+            BoardSize.Nine,
             document.Status,
             document.Statistics.ToDomain(),
             document.Cells.Select(ToDomain).ToList(),
@@ -82,7 +83,7 @@ public static class SudokuGameMapper
 
     private static Cell ToDomain(this CellDocument document)
     {
-        var cell = Cell.Create(document.Row, document.Column, document.Value, document.IsFixed, document.IsHint);
+        var cell = Cell.Create(document.Row, document.Column, BoardSize.Nine, document.Value, document.IsFixed, document.IsHint);
 
         // Set possible values using reflection since there's no public setter
         var cellType = typeof(Cell);

--- a/src/backend/Sudoku.Infrastructure/Repositories/AzureBlobPuzzleRepository.cs
+++ b/src/backend/Sudoku.Infrastructure/Repositories/AzureBlobPuzzleRepository.cs
@@ -81,7 +81,7 @@ public class AzureBlobPuzzleRepository(
     private static SudokuPuzzle MapToPuzzle(SudokuPuzzleDocument document)
     {
         var difficulty = GameDifficulty.FromName(document.Difficulty);
-        var cells = document.Cells.Select(c => Cell.Create(c.Row, c.Column, c.Value, c.IsFixed));
-        return SudokuPuzzle.Create(document.PuzzleId, difficulty, cells);
+        var cells = document.Cells.Select(c => Cell.Create(c.Row, c.Column, BoardSize.Nine, c.Value, c.IsFixed));
+        return SudokuPuzzle.Create(document.PuzzleId, difficulty, BoardSize.Nine, cells);
     }
 }

--- a/src/backend/Sudoku.Infrastructure/Services/PuzzleGenerator.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/PuzzleGenerator.cs
@@ -40,9 +40,9 @@ public class PuzzleGenerator(IPuzzleSolver puzzleSolver) : IPuzzleGenerator
     private async Task<SudokuPuzzle> GenerateEmptyPuzzleAsync()
     {
         var cells = Enumerable.Range(0, 81)
-            .Select(i => Cell.CreateEmpty(i / 9, i % 9))
+            .Select(i => Cell.CreateEmpty(i / 9, i % 9, BoardSize.Nine))
             .ToList();
-        var puzzle = SudokuPuzzle.Create(GameId.New(), GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create(GameId.New(), GameDifficulty.Easy, BoardSize.Nine, cells);
         return await Task.FromResult(puzzle);
     }
 
@@ -84,11 +84,11 @@ public class PuzzleGenerator(IPuzzleSolver puzzleSolver) : IPuzzleGenerator
     private SudokuPuzzle LockCompletedCells(SudokuPuzzle puzzle)
     {
         var cells = puzzle.Cells.Select(cell => cell.Value.HasValue
-                ? Cell.CreateFixed(cell.Row, cell.Column, cell.Value.Value)
-                : Cell.CreateEmpty(cell.Row, cell.Column))
+                ? Cell.CreateFixed(cell.Row, cell.Column, cell.Value.Value, puzzle.Size)
+                : Cell.CreateEmpty(cell.Row, cell.Column, puzzle.Size))
             .ToList();
 
-        return SudokuPuzzle.Create(puzzle.PuzzleId, puzzle.Difficulty, cells);
+        return SudokuPuzzle.Create(puzzle.PuzzleId, puzzle.Difficulty, puzzle.Size, cells);
     }
 
     private (int Row, int Col)[] GetRandomCellCoordinates()

--- a/src/backend/Sudoku.Infrastructure/Services/Solvers/BitwiseSolverGridMapper.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/Solvers/BitwiseSolverGridMapper.cs
@@ -30,9 +30,9 @@ public static class BitwiseSolverGridMapper
         var cells = puzzle.Cells.Select(cell =>
         {
             var value = grid[cell.Row * 9 + cell.Column];
-            return Cell.Create(cell.Row, cell.Column, value == 0 ? null : value, cell.IsFixed);
+            return Cell.Create(cell.Row, cell.Column, puzzle.Size, value == 0 ? null : value, cell.IsFixed);
         }).ToList();
 
-        return SudokuPuzzle.Create(puzzle.PuzzleId, puzzle.Difficulty, cells);
+        return SudokuPuzzle.Create(puzzle.PuzzleId, puzzle.Difficulty, puzzle.Size, cells);
     }
 }

--- a/src/backend/Sudoku.Infrastructure/Services/UniqueSolutionPuzzleGenerator.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/UniqueSolutionPuzzleGenerator.cs
@@ -136,12 +136,12 @@ public class UniqueSolutionPuzzleGenerator : IPuzzleGenerator
             {
                 int row = i / 9, column = i % 9;
                 return grid[i] == 0
-                    ? Cell.CreateEmpty(row, column)
-                    : Cell.CreateFixed(row, column, grid[i]);
+                    ? Cell.CreateEmpty(row, column, BoardSize.Nine)
+                    : Cell.CreateFixed(row, column, grid[i], BoardSize.Nine);
             })
             .ToList();
 
-        return SudokuPuzzle.Create(GameId.New(), difficulty, cells);
+        return SudokuPuzzle.Create(GameId.New(), difficulty, BoardSize.Nine, cells);
     }
 
     private static int GetTargetEmptyCount(GameDifficulty difficulty) => difficulty.Name switch

--- a/src/backend/Tests/API/BaseGameControllerTests.cs
+++ b/src/backend/Tests/API/BaseGameControllerTests.cs
@@ -26,7 +26,7 @@ public abstract class BaseGameControllerTests<TControllerType> : MoqBaseTestByTy
             "TestPlayer",
             difficulty,
             "NotStarted",
-            new GameStatisticsDto(0, 0, 0, 0, GameStatistics.MaxHints, TimeSpan.Zero, 0.0),
+            new GameStatisticsDto(0, 0, 0, 0, BoardSize.Nine.MaxHints, TimeSpan.Zero, 0.0),
             DateTime.UtcNow,
             null,
             null,

--- a/src/backend/Tests/Application/DTOs/GameDtoTests.cs
+++ b/src/backend/Tests/Application/DTOs/GameDtoTests.cs
@@ -138,7 +138,7 @@ public class GameDtoTests : MoqBaseTestByType<GameDto>
         dto.Statistics.ValidMoves.Should().Be(game.Statistics.ValidMoves);
         dto.Statistics.InvalidMoves.Should().Be(game.Statistics.InvalidMoves);
         dto.Statistics.HintsUsed.Should().Be(game.Statistics.HintsUsed);
-        dto.Statistics.HintsRemaining.Should().Be(game.Statistics.HintsRemaining);
+        dto.Statistics.HintsRemaining.Should().Be(game.Statistics.HintsRemainingFor(game.Size));
         dto.Statistics.PlayDuration.Should().Be(game.Statistics.PlayDuration);
         dto.Statistics.AccuracyPercentage.Should().Be(game.Statistics.AccuracyPercentage);
     }
@@ -189,10 +189,10 @@ public class GameDtoTests : MoqBaseTestByType<GameDto>
         {
             for (int j = 0; j < 9; j++)
             {
-                cells.Add(Cell.CreateEmpty(i, j));
+                cells.Add(Cell.CreateEmpty(i, j, BoardSize.Nine));
             }
         }
 
-        return SudokuGame.Create(withProfileId, displayName, difficulty, cells);
+        return SudokuGame.Create(withProfileId, displayName, difficulty, BoardSize.Nine, cells);
     }
 }

--- a/src/backend/Tests/Application/Handlers/CreateGameCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/CreateGameCommandHandlerTests.cs
@@ -191,10 +191,10 @@ public class CreateGameCommandHandlerTests : MoqBaseTestByAbstraction<CreateGame
         {
             for (var j = 0; j < 9; j++)
             {
-                cells.Add(Cell.CreateEmpty(i, j));
+                cells.Add(Cell.CreateEmpty(i, j, BoardSize.Nine));
             }
         }
 
-        return SudokuPuzzle.Create("test-puzzle-id", GameDifficulty.Medium, cells);
+        return SudokuPuzzle.Create("test-puzzle-id", GameDifficulty.Medium, BoardSize.Nine, cells);
     }
 }

--- a/src/backend/Tests/Application/Handlers/DeleteGameCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/DeleteGameCommandHandlerTests.cs
@@ -138,10 +138,10 @@ public class DeleteGameCommandHandlerTests : MoqBaseTestByAbstraction<Handler, I
         {
             for (int j = 0; j < 9; j++)
             {
-                cells.Add(Cell.CreateEmpty(i, j));
+                cells.Add(Cell.CreateEmpty(i, j, BoardSize.Nine));
             }
         }
 
-        return SudokuGame.Create(profileId, displayName, difficulty, cells);
+        return SudokuGame.Create(profileId, displayName, difficulty, BoardSize.Nine, cells);
     }
 }

--- a/src/backend/Tests/Application/Handlers/DeletePlayerGamesCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/DeletePlayerGamesCommandHandlerTests.cs
@@ -25,6 +25,7 @@ public class DeletePlayerGamesCommandHandlerTests : MoqBaseTestByAbstraction<Del
         container.AddCustomizations(new PlayerAliasGenerator());
         container.AddCustomizations(new GameDifficultyGenerator());
         container.AddCustomizations(new CellGenerator());
+        container.AddCustomizations(new BoardSizeGenerator());
     }
 
     [Fact]

--- a/src/backend/Tests/Application/Handlers/GetGameQueryHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/GetGameQueryHandlerTests.cs
@@ -191,10 +191,10 @@ public class GetGameQueryHandlerTests : MoqBaseTestByAbstraction<GetGameQueryHan
         {
             for (int j = 0; j < 9; j++)
             {
-                cells.Add(Cell.CreateEmpty(i, j));
+                cells.Add(Cell.CreateEmpty(i, j, BoardSize.Nine));
             }
         }
 
-        return SudokuGame.Create(profileId, displayName, difficulty, cells);
+        return SudokuGame.Create(profileId, displayName, difficulty, BoardSize.Nine, cells);
     }
 }

--- a/src/backend/Tests/Application/Handlers/MakeMoveCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/MakeMoveCommandHandlerTests.cs
@@ -236,9 +236,9 @@ public class MakeMoveCommandHandlerTests : MoqBaseTestByAbstraction<MakeMoveComm
         var profileId = ProfileId.New();
         var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Medium;
-        var cells = InitializeCells((i, j) => Cell.CreateEmpty(i, j));
+        var cells = InitializeCells((i, j) => Cell.CreateEmpty(i, j, BoardSize.Nine));
 
-        var game = SudokuGame.Create(profileId, displayName, difficulty, cells);
+        var game = SudokuGame.Create(profileId, displayName, difficulty, BoardSize.Nine, cells);
         game.StartGame();
         return game;
     }
@@ -255,12 +255,12 @@ public class MakeMoveCommandHandlerTests : MoqBaseTestByAbstraction<MakeMoveComm
             for (int j = 0; j < 9; j++)
             {
                 // Create a cell with value 5 at position (0, 1) to create a duplicate scenario
-                var cell = i == 0 && j == 1 ? Cell.Create(i, j, 5, false) : Cell.CreateEmpty(i, j);
+                var cell = i == 0 && j == 1 ? Cell.Create(i, j, BoardSize.Nine, 5, false) : Cell.CreateEmpty(i, j, BoardSize.Nine);
                 cells.Add(cell);
             }
         }
 
-        var game = SudokuGame.Create(profileId, displayName, difficulty, cells);
+        var game = SudokuGame.Create(profileId, displayName, difficulty, BoardSize.Nine, cells);
         game.StartGame();
         return game;
     }

--- a/src/backend/Tests/Application/Handlers/ResetGameCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/ResetGameCommandHandlerTests.cs
@@ -33,6 +33,7 @@ public class ResetGameCommandHandlerTests : MoqBaseTestByAbstraction<ResetGameCo
         container.AddCustomizations(new CellGenerator());
         container.AddCustomizations(new GameDifficultyGenerator());
         container.AddCustomizations(new PlayerAliasGenerator());
+        container.AddCustomizations(new BoardSizeGenerator());
     }
 
     [Fact]

--- a/src/backend/Tests/Domain/CellTests.cs
+++ b/src/backend/Tests/Domain/CellTests.cs
@@ -17,7 +17,7 @@ public class CellTests : MoqBaseTestByType<Cell>
         bool isFixed = true;
 
         // Act
-        var cell = Cell.Create(row, column, value, isFixed);
+        var cell = Cell.Create(row, column, BoardSize.Nine, value, isFixed);
 
         // Assert
         cell.Row.Should().Be(row);
@@ -36,7 +36,7 @@ public class CellTests : MoqBaseTestByType<Cell>
         int value = 7;
 
         // Act
-        var cell = Cell.CreateFixed(row, column, value);
+        var cell = Cell.CreateFixed(row, column, value, BoardSize.Nine);
 
         // Assert
         cell.Row.Should().Be(row);
@@ -54,7 +54,7 @@ public class CellTests : MoqBaseTestByType<Cell>
         int column = 5;
 
         // Act
-        var cell = Cell.CreateEmpty(row, column);
+        var cell = Cell.CreateEmpty(row, column, BoardSize.Nine);
 
         // Assert
         cell.Row.Should().Be(row);
@@ -71,7 +71,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void Create_WithInvalidRow_ThrowsInvalidCellPositionException(int row, int column)
     {
         // Act
-        Action act = () => Cell.Create(row, column);
+        Action act = () => Cell.Create(row, column, BoardSize.Nine);
 
         // Assert
         act.Should().Throw<InvalidCellPositionException>()
@@ -85,7 +85,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void Create_WithInvalidColumn_ThrowsInvalidCellPositionException(int row, int column)
     {
         // Act
-        Action act = () => Cell.Create(row, column);
+        Action act = () => Cell.Create(row, column, BoardSize.Nine);
 
         // Assert
         act.Should().Throw<InvalidCellPositionException>()
@@ -99,7 +99,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void Create_WithInvalidValue_ThrowsInvalidCellValueException(int value)
     {
         // Act
-        Action act = () => Cell.Create(5, 5, value);
+        Action act = () => Cell.Create(5, 5, BoardSize.Nine, value);
 
         // Assert
         act.Should().Throw<InvalidCellValueException>()
@@ -110,7 +110,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void SetValue_OnNonFixedCell_UpdatesValue()
     {
         // Arrange
-        var cell = Cell.Create(5, 5);
+        var cell = Cell.Create(5, 5, BoardSize.Nine);
 
         // Act
         cell.SetValue(7);
@@ -124,7 +124,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void SetValue_OnFixedCell_ThrowsCellIsFixedException()
     {
         // Arrange
-        var cell = Cell.CreateFixed(5, 5, 7);
+        var cell = Cell.CreateFixed(5, 5, 7, BoardSize.Nine);
 
         // Act
         Action act = () => cell.SetValue(8);
@@ -141,7 +141,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void SetValue_WithInvalidValue_ThrowsInvalidCellValueException(int value)
     {
         // Arrange
-        var cell = Cell.Create(5, 5);
+        var cell = Cell.Create(5, 5, BoardSize.Nine);
 
         // Act
         Action act = () => cell.SetValue(value);
@@ -155,7 +155,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void SetValue_WithNullableInt_OnNonFixedCell_UpdatesValue()
     {
         // Arrange
-        var cell = Cell.Create(5, 5);
+        var cell = Cell.Create(5, 5, BoardSize.Nine);
 
         // Act
         cell.SetValue((int?)7);
@@ -169,7 +169,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void SetValue_WithNullableInt_OnFixedCell_ThrowsCellIsFixedException()
     {
         // Arrange
-        var cell = Cell.CreateFixed(5, 5, 7);
+        var cell = Cell.CreateFixed(5, 5, 7, BoardSize.Nine);
 
         // Act
         Action act = () => cell.SetValue((int?)8);
@@ -183,7 +183,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void SetValue_WithNullValue_ClearsValue()
     {
         // Arrange
-        var cell = Cell.Create(5, 5, 7);
+        var cell = Cell.Create(5, 5, BoardSize.Nine, 7);
 
         // Act
         cell.SetValue((int?)null);
@@ -197,7 +197,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void SetValue_WithNullValue_OnFixedCell_ThrowsCellIsFixedException()
     {
         // Arrange
-        var cell = Cell.CreateFixed(5, 5, 7);
+        var cell = Cell.CreateFixed(5, 5, 7, BoardSize.Nine);
 
         // Act
         Action act = () => cell.SetValue((int?)null);
@@ -214,7 +214,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void SetValue_WithNullableInt_WithInvalidValue_ThrowsInvalidCellValueException(int value)
     {
         // Arrange
-        var cell = Cell.Create(5, 5);
+        var cell = Cell.Create(5, 5, BoardSize.Nine);
 
         // Act
         Action act = () => cell.SetValue((int?)value);
@@ -228,7 +228,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void ClearValue_OnNonFixedCell_ClearsValue()
     {
         // Arrange
-        var cell = Cell.Create(5, 5, 7);
+        var cell = Cell.Create(5, 5, BoardSize.Nine, 7);
 
         // Act
         cell.ClearValue();
@@ -242,7 +242,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void ClearValue_OnFixedCell_ThrowsCellIsFixedException()
     {
         // Arrange
-        var cell = Cell.CreateFixed(5, 5, 7);
+        var cell = Cell.CreateFixed(5, 5, 7, BoardSize.Nine);
 
         // Act
         Action act = () => cell.ClearValue();
@@ -256,7 +256,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void ToString_WithValue_ReturnsValueAsString()
     {
         // Arrange
-        var cell = Cell.Create(5, 5, 7);
+        var cell = Cell.Create(5, 5, BoardSize.Nine, 7);
 
         // Act
         var result = cell.ToString();
@@ -269,7 +269,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void ToString_WithoutValue_ReturnsDot()
     {
         // Arrange
-        var cell = Cell.CreateEmpty(5, 5);
+        var cell = Cell.CreateEmpty(5, 5, BoardSize.Nine);
 
         // Act
         var result = cell.ToString();
@@ -284,7 +284,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void AddPossibleValue_OnEmptyCell_AddsPossibleValue()
     {
         // Arrange
-        var cell = Cell.CreateEmpty(5, 5);
+        var cell = Cell.CreateEmpty(5, 5, BoardSize.Nine);
 
         // Act
         cell.AddPossibleValue(7);
@@ -297,7 +297,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void AddPossibleValue_WithExistingValue_DoesNotAddDuplicate()
     {
         // Arrange
-        var cell = Cell.CreateEmpty(5, 5);
+        var cell = Cell.CreateEmpty(5, 5, BoardSize.Nine);
         cell.AddPossibleValue(7);
 
         // Act
@@ -311,7 +311,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void AddPossibleValue_WithMultipleValues_AddsPossibleValues()
     {
         // Arrange
-        var cell = Cell.CreateEmpty(5, 5);
+        var cell = Cell.CreateEmpty(5, 5, BoardSize.Nine);
 
         // Act
         cell.AddPossibleValue(3);
@@ -330,7 +330,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void AddPossibleValue_WithInvalidValue_ThrowsInvalidCellValueException(int value)
     {
         // Arrange
-        var cell = Cell.CreateEmpty(5, 5);
+        var cell = Cell.CreateEmpty(5, 5, BoardSize.Nine);
 
         // Act
         Action act = () => cell.AddPossibleValue(value);
@@ -344,7 +344,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void AddPossibleValue_OnFixedCell_ThrowsCellIsFixedException()
     {
         // Arrange
-        var cell = Cell.CreateFixed(5, 5, 7);
+        var cell = Cell.CreateFixed(5, 5, 7, BoardSize.Nine);
 
         // Act
         Action act = () => cell.AddPossibleValue(3);
@@ -358,7 +358,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void AddPossibleValue_OnCellWithValue_ThrowsCellAlreadyHasValueException()
     {
         // Arrange
-        var cell = Cell.Create(5, 5, 7);
+        var cell = Cell.Create(5, 5, BoardSize.Nine, 7);
 
         // Act
         Action act = () => cell.AddPossibleValue(3);
@@ -372,7 +372,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void RemovePossibleValue_WithExistingValue_RemovesPossibleValue()
     {
         // Arrange
-        var cell = Cell.CreateEmpty(5, 5);
+        var cell = Cell.CreateEmpty(5, 5, BoardSize.Nine);
         cell.AddPossibleValue(3);
         cell.AddPossibleValue(7);
 
@@ -387,7 +387,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void RemovePossibleValue_WithNonExistingValue_DoesNothing()
     {
         // Arrange
-        var cell = Cell.CreateEmpty(5, 5);
+        var cell = Cell.CreateEmpty(5, 5, BoardSize.Nine);
         cell.AddPossibleValue(7);
 
         // Act
@@ -404,7 +404,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void RemovePossibleValue_WithInvalidValue_ThrowsInvalidCellValueException(int value)
     {
         // Arrange
-        var cell = Cell.CreateEmpty(5, 5);
+        var cell = Cell.CreateEmpty(5, 5, BoardSize.Nine);
         cell.AddPossibleValue(7);
 
         // Act
@@ -419,7 +419,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void RemovePossibleValue_OnFixedCell_ThrowsCellIsFixedException()
     {
         // Arrange
-        var cell = Cell.CreateFixed(5, 5, 7);
+        var cell = Cell.CreateFixed(5, 5, 7, BoardSize.Nine);
 
         // Act
         Action act = () => cell.RemovePossibleValue(3);
@@ -433,7 +433,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void ClearPossibleValues_WithValues_ClearsPossibleValues()
     {
         // Arrange
-        var cell = Cell.CreateEmpty(5, 5);
+        var cell = Cell.CreateEmpty(5, 5, BoardSize.Nine);
         cell.AddPossibleValue(3);
         cell.AddPossibleValue(7);
         cell.AddPossibleValue(9);
@@ -449,7 +449,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void ClearPossibleValues_WithNoValues_DoesNothing()
     {
         // Arrange
-        var cell = Cell.CreateEmpty(5, 5);
+        var cell = Cell.CreateEmpty(5, 5, BoardSize.Nine);
 
         // Act
         cell.ClearPossibleValues();
@@ -462,7 +462,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void ClearPossibleValues_OnFixedCell_ThrowsCellIsFixedException()
     {
         // Arrange
-        var cell = Cell.CreateFixed(5, 5, 7);
+        var cell = Cell.CreateFixed(5, 5, 7, BoardSize.Nine);
 
         // Act
         Action act = () => cell.ClearPossibleValues();
@@ -476,7 +476,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void SetValue_ClearsPossibleValues()
     {
         // Arrange
-        var cell = Cell.CreateEmpty(5, 5);
+        var cell = Cell.CreateEmpty(5, 5, BoardSize.Nine);
         cell.AddPossibleValue(3);
         cell.AddPossibleValue(7);
 
@@ -492,7 +492,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void SetValue_WithNullableInt_ClearsPossibleValuesWhenValueIsSet()
     {
         // Arrange
-        var cell = Cell.CreateEmpty(5, 5);
+        var cell = Cell.CreateEmpty(5, 5, BoardSize.Nine);
         cell.AddPossibleValue(3);
         cell.AddPossibleValue(7);
 
@@ -508,7 +508,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void SetValue_WithNullableInt_DoesNotClearPossibleValuesWhenValueIsNull()
     {
         // Arrange
-        var cell = Cell.Create(5, 5, 9);
+        var cell = Cell.Create(5, 5, BoardSize.Nine, 9);
         cell.SetValue((int?)null);
         cell.AddPossibleValue(3);
         cell.AddPossibleValue(7);
@@ -526,7 +526,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void DeepCopy_CreatesDeepCopy()
     {
         // Arrange
-        var originalCell = Cell.Create(3, 4, 7, true);
+        var originalCell = Cell.Create(3, 4, BoardSize.Nine, 7, true);
         originalCell.PossibleValues.Add(1);
         originalCell.PossibleValues.Add(2);
 
@@ -548,7 +548,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void DeepCopy_EmptyCell_CreatesDeepCopy()
     {
         // Arrange
-        var originalCell = Cell.CreateEmpty(2, 6);
+        var originalCell = Cell.CreateEmpty(2, 6, BoardSize.Nine);
         originalCell.AddPossibleValue(1);
         originalCell.AddPossibleValue(5);
         originalCell.AddPossibleValue(9);
@@ -571,7 +571,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void DeepCopy_ModifyingClonedCell_DoesNotAffectOriginal()
     {
         // Arrange
-        var originalCell = Cell.CreateEmpty(1, 1);
+        var originalCell = Cell.CreateEmpty(1, 1, BoardSize.Nine);
         originalCell.AddPossibleValue(3);
         originalCell.AddPossibleValue(7);
         var clonedCell = originalCell.DeepCopy();
@@ -590,7 +590,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void CreateHint_CreatesLockedCellWithValue()
     {
         // Act
-        var cell = Cell.CreateHint(3, 4, 7);
+        var cell = Cell.CreateHint(3, 4, 7, BoardSize.Nine);
 
         // Assert
         cell.Value.Should().Be(7);
@@ -604,7 +604,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void SetValue_OnHintCell_ThrowsCellIsFixedException()
     {
         // Arrange
-        var cell = Cell.CreateHint(3, 4, 7);
+        var cell = Cell.CreateHint(3, 4, 7, BoardSize.Nine);
 
         // Act
         Action act = () => cell.SetValue(9);
@@ -617,7 +617,7 @@ public class CellTests : MoqBaseTestByType<Cell>
     public void DeepCopy_PreservesIsHint()
     {
         // Arrange
-        var cell = Cell.CreateHint(3, 4, 7);
+        var cell = Cell.CreateHint(3, 4, 7, BoardSize.Nine);
 
         // Act
         var clone = cell.DeepCopy();

--- a/src/backend/Tests/Domain/GameStatisticsTests.cs
+++ b/src/backend/Tests/Domain/GameStatisticsTests.cs
@@ -18,7 +18,7 @@ public class GameStatisticsTests : MoqBaseTestByType<GameStatistics>
         statistics.ValidMoves.Should().Be(0);
         statistics.InvalidMoves.Should().Be(0);
         statistics.HintsUsed.Should().Be(0);
-        statistics.HintsRemaining.Should().Be(GameStatistics.MaxHints);
+        statistics.HintsRemainingFor(BoardSize.Nine).Should().Be(BoardSize.Nine.MaxHints);
         statistics.PlayDuration.Should().Be(TimeSpan.Zero);
         statistics.LastMoveAt.Should().BeNull();
         statistics.AccuracyPercentage.Should().Be(0);
@@ -36,7 +36,7 @@ public class GameStatisticsTests : MoqBaseTestByType<GameStatistics>
 
         // Assert
         statistics.HintsUsed.Should().Be(1);
-        statistics.HintsRemaining.Should().Be(GameStatistics.MaxHints - 1);
+        statistics.HintsRemainingFor(BoardSize.Nine).Should().Be(BoardSize.Nine.MaxHints - 1);
     }
 
     [Fact]
@@ -46,14 +46,14 @@ public class GameStatisticsTests : MoqBaseTestByType<GameStatistics>
         var statistics = GameStatistics.Create();
 
         // Act
-        for (var i = 0; i < GameStatistics.MaxHints; i++)
+        for (var i = 0; i < BoardSize.Nine.MaxHints; i++)
         {
             statistics.RecordHint();
         }
 
         // Assert
-        statistics.HintsUsed.Should().Be(GameStatistics.MaxHints);
-        statistics.HintsRemaining.Should().Be(0);
+        statistics.HintsUsed.Should().Be(BoardSize.Nine.MaxHints);
+        statistics.HintsRemainingFor(BoardSize.Nine).Should().Be(0);
     }
 
     [Fact]

--- a/src/backend/Tests/Domain/SudokuGameHintTests.cs
+++ b/src/backend/Tests/Domain/SudokuGameHintTests.cs
@@ -52,7 +52,7 @@ public class SudokuGameHintTests : MoqBaseTestByType<SudokuGame>
 
         // Assert
         sut.Statistics.HintsUsed.Should().Be(1);
-        sut.Statistics.HintsRemaining.Should().Be(GameStatistics.MaxHints - 1);
+        sut.Statistics.HintsRemainingFor(sut.Size).Should().Be(BoardSize.Nine.MaxHints - 1);
     }
 
     [Fact]
@@ -102,7 +102,7 @@ public class SudokuGameHintTests : MoqBaseTestByType<SudokuGame>
     {
         // Arrange
         var sut = CreateStartedEmptyGame();
-        for (var i = 0; i < GameStatistics.MaxHints; i++)
+        for (var i = 0; i < BoardSize.Nine.MaxHints; i++)
         {
             sut.RevealHint(Solution);
         }
@@ -164,11 +164,11 @@ public class SudokuGameHintTests : MoqBaseTestByType<SudokuGame>
         // Arrange - a board with a single empty cell and a matching solution
         var completed = CellsFactory.CreateCompletedCells().ToList();
         var cells = completed
-            .Select(c => c.Row == 0 && c.Column == 0 ? Cell.CreateEmpty(0, 0) : c)
+            .Select(c => c.Row == 0 && c.Column == 0 ? Cell.CreateEmpty(0, 0, BoardSize.Nine) : c)
             .ToList();
         var sut = GameFactory.CreateGameWithCells(cells);
         sut.StartGame();
-        var solution = SudokuPuzzle.Create("solution", GameDifficulty.Easy, CellsFactory.CreateCompletedCells().ToList());
+        var solution = SudokuPuzzle.Create("solution", GameDifficulty.Easy, BoardSize.Nine, CellsFactory.CreateCompletedCells().ToList());
 
         // Act
         sut.RevealHint(solution);

--- a/src/backend/Tests/Domain/SudokuGameMoveHistoryTests.cs
+++ b/src/backend/Tests/Domain/SudokuGameMoveHistoryTests.cs
@@ -91,6 +91,7 @@ public class SudokuGameMoveHistoryTests : MoqBaseTestByType<SudokuGame>
             ProfileId.New(),
             PlayerAlias.Create("TestPlayer"),
             GameDifficulty.Easy,
+            BoardSize.Nine,
             GameStatusEnum.InProgress,
             GameStatistics.Create(),
             cells,
@@ -114,6 +115,7 @@ public class SudokuGameMoveHistoryTests : MoqBaseTestByType<SudokuGame>
             ProfileId.New(),
             PlayerAlias.Create("TestPlayer"),
             GameDifficulty.Easy,
+            BoardSize.Nine,
             cells
         );
     }

--- a/src/backend/Tests/Domain/SudokuGamePossibleValuesTests.cs
+++ b/src/backend/Tests/Domain/SudokuGamePossibleValuesTests.cs
@@ -24,7 +24,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void AddPossibleValue_ToEmptyCell_AddsPossibleValue()
     {
         // Arrange
-        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, BoardSize.Nine, _initialCells);
         game.StartGame();
         int row = 2, col = 2, value = 3;
 
@@ -48,7 +48,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void AddPossibleValue_ToFixedCell_ThrowsCellIsFixedException()
     {
         // Arrange
-        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, BoardSize.Nine, _initialCells);
         game.StartGame();
         int row = 0, col = 0, value = 3; // Cell at (0,0) is fixed
 
@@ -64,7 +64,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void AddPossibleValue_ToCellWithValue_ThrowsCellAlreadyHasValueException()
     {
         // Arrange
-        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, BoardSize.Nine, _initialCells);
         game.StartGame();
         int row = 1, col = 1, value = 3; // Cell at (1,1) has a value
 
@@ -80,7 +80,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void AddPossibleValue_WhenGameNotInProgress_ThrowsGameNotInProgressException()
     {
         // Arrange
-        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, BoardSize.Nine, _initialCells);
         // Don't start the game
         int row = 2, col = 2, value = 3;
 
@@ -96,7 +96,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void ClearPossibleValues_FromCellWithPossibleValues_ClearsPossibleValues()
     {
         // Arrange
-        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, BoardSize.Nine, _initialCells);
         game.StartGame();
         int row = 2, col = 2;
         game.AddPossibleValue(row, col, 3);
@@ -123,7 +123,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void ClearPossibleValues_FromFixedCell_ThrowsCellIsFixedException()
     {
         // Arrange
-        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, BoardSize.Nine, _initialCells);
         game.StartGame();
         int row = 0, col = 0; // Cell at (0,0) is fixed
 
@@ -139,7 +139,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void ClearPossibleValues_WhenGameNotInProgress_ThrowsGameNotInProgressException()
     {
         // Arrange
-        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, BoardSize.Nine, _initialCells);
         // Don't start the game
         int row = 2, col = 2;
 
@@ -155,7 +155,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void MakeMove_ClearsPossibleValues()
     {
         // Arrange
-        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, BoardSize.Nine, _initialCells);
         game.StartGame();
         int row = 2, col = 2;
         game.AddPossibleValue(row, col, 3);
@@ -174,7 +174,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void RemovePossibleValue_FromCellWithPossibleValue_RemovesPossibleValue()
     {
         // Arrange
-        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, BoardSize.Nine, _initialCells);
         game.StartGame();
         int row = 2, col = 2, value = 3;
         game.AddPossibleValue(row, col, value);
@@ -200,7 +200,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void RemovePossibleValue_FromFixedCell_ThrowsCellIsFixedException()
     {
         // Arrange
-        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, BoardSize.Nine, _initialCells);
         game.StartGame();
         int row = 0, col = 0, value = 3; // Cell at (0,0) is fixed
 
@@ -216,7 +216,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void RemovePossibleValue_WhenGameNotInProgress_ThrowsGameNotInProgressException()
     {
         // Arrange
-        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, BoardSize.Nine, _initialCells);
         // Don't start the game
         int row = 2, col = 2, value = 3;
 
@@ -232,7 +232,7 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
     public void ResetGame_ClearsPossibleValuesForAllNonFixedCells()
     {
         // Arrange
-        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, _initialCells);
+        var game = SudokuGame.Create(_profileId, _playerAlias, _difficulty, BoardSize.Nine, _initialCells);
         game.StartGame();
         game.AddPossibleValue(2, 2, 3);
         game.AddPossibleValue(2, 2, 5);
@@ -257,15 +257,15 @@ public class SudokuGamePossibleValuesTests : MoqBaseTestByType<SudokuGame>
             {
                 if (row == 0 && col == 0)
                 {
-                    cells.Add(Cell.CreateFixed(row, col, 5));
+                    cells.Add(Cell.CreateFixed(row, col, 5, BoardSize.Nine));
                 }
                 else if (row == 1 && col == 1)
                 {
-                    cells.Add(Cell.Create(row, col, 7));
+                    cells.Add(Cell.Create(row, col, BoardSize.Nine, 7));
                 }
                 else
                 {
-                    cells.Add(Cell.CreateEmpty(row, col));
+                    cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
                 }
             }
         }

--- a/src/backend/Tests/Domain/SudokuGameTests.cs
+++ b/src/backend/Tests/Domain/SudokuGameTests.cs
@@ -49,7 +49,7 @@ public class SudokuGameTests : MoqBaseTestByType<SudokuGame>
         var cells = GenerateEmptyCells();
 
         // Act
-        var sut = SudokuGame.Create(profileId, displayName, difficulty, cells);
+        var sut = SudokuGame.Create(profileId, displayName, difficulty, BoardSize.Nine, cells);
 
         // Assert
         sut.Id.Should().NotBeNull();
@@ -71,7 +71,7 @@ public class SudokuGameTests : MoqBaseTestByType<SudokuGame>
         var cells = GenerateEmptyCells();
 
         // Act
-        var sut = SudokuGame.Create(profileId, displayName, GameDifficulty.Easy, cells);
+        var sut = SudokuGame.Create(profileId, displayName, GameDifficulty.Easy, BoardSize.Nine, cells);
 
         // Assert
         sut.ProfileId.Should().Be(profileId);
@@ -86,7 +86,7 @@ public class SudokuGameTests : MoqBaseTestByType<SudokuGame>
         var cells = GenerateEmptyCells();
 
         // Act
-        var sut = SudokuGame.Create(profileId, displayName, GameDifficulty.Easy, cells);
+        var sut = SudokuGame.Create(profileId, displayName, GameDifficulty.Easy, BoardSize.Nine, cells);
 
         // Assert
         sut.DisplayName.Should().Be(displayName);
@@ -101,7 +101,7 @@ public class SudokuGameTests : MoqBaseTestByType<SudokuGame>
         var cells = GenerateEmptyCells();
 
         // Act
-        var sut = SudokuGame.Create(profileId, displayName, GameDifficulty.Easy, cells);
+        var sut = SudokuGame.Create(profileId, displayName, GameDifficulty.Easy, BoardSize.Nine, cells);
 
         // Assert
         var evt = sut.DomainEvents.OfType<GameCreatedEvent>().Single();
@@ -155,7 +155,7 @@ public class SudokuGameTests : MoqBaseTestByType<SudokuGame>
         // Arrange
         var sut = CreateGameWithCells(new[]
         {
-            Cell.CreateFixed(0, 0, 5)
+            Cell.CreateFixed(0, 0, 5, BoardSize.Nine)
         });
         sut.StartGame();
 
@@ -172,7 +172,7 @@ public class SudokuGameTests : MoqBaseTestByType<SudokuGame>
         // Arrange
         var sut = CreateGameWithCells(new[]
         {
-            Cell.CreateFixed(0, 0, 5)
+            Cell.CreateFixed(0, 0, 5, BoardSize.Nine)
         });
         sut.StartGame();
 
@@ -202,8 +202,8 @@ public class SudokuGameTests : MoqBaseTestByType<SudokuGame>
         // Arrange
         var sut = CreateGameWithCells(new[]
         {
-            Cell.Create(0, 0, 5, false),
-            Cell.Create(0, 1, null, false)
+            Cell.Create(0, 0, BoardSize.Nine, 5, false),
+            Cell.Create(0, 1, BoardSize.Nine, null, false)
         });
         sut.StartGame();
 
@@ -222,7 +222,7 @@ public class SudokuGameTests : MoqBaseTestByType<SudokuGame>
         // Arrange
         var sut = CreateGameWithCells(new[]
         {
-            Cell.Create(0, 0, 5, false)
+            Cell.Create(0, 0, BoardSize.Nine, 5, false)
         });
         sut.StartGame();
 
@@ -240,7 +240,7 @@ public class SudokuGameTests : MoqBaseTestByType<SudokuGame>
         // Arrange
         var sut = CreateGameWithCells(new[]
         {
-            Cell.Create(0, 0, 5, false)
+            Cell.Create(0, 0, BoardSize.Nine, 5, false)
         });
         sut.StartGame();
         var initialEventCount = sut.DomainEvents.Count;
@@ -400,7 +400,7 @@ public class SudokuGameTests : MoqBaseTestByType<SudokuGame>
             }
         }
 
-        return SudokuGame.Create(profileId, displayName, difficulty, cells);
+        return SudokuGame.Create(profileId, displayName, difficulty, BoardSize.Nine, cells);
     }
 
     private IEnumerable<Cell> GenerateEmptyCells()
@@ -410,7 +410,7 @@ public class SudokuGameTests : MoqBaseTestByType<SudokuGame>
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         return cells;

--- a/src/backend/Tests/Domain/SudokuPuzzleTests.cs
+++ b/src/backend/Tests/Domain/SudokuPuzzleTests.cs
@@ -12,7 +12,7 @@ public class SudokuPuzzleTests : MoqBaseTestByType<SudokuPuzzle>
     {
         // Arrange
         var cells = CreateTestCells();
-        var originalPuzzle = SudokuPuzzle.Create("test-puzzle-123", GameDifficulty.Medium, cells);
+        var originalPuzzle = SudokuPuzzle.Create("test-puzzle-123", GameDifficulty.Medium, BoardSize.Nine, cells);
 
         // Act
         var clonedPuzzle = originalPuzzle.Clone() as SudokuPuzzle;
@@ -30,7 +30,7 @@ public class SudokuPuzzleTests : MoqBaseTestByType<SudokuPuzzle>
     {
         // Arrange
         var cells = CreateTestCells();
-        var originalPuzzle = SudokuPuzzle.Create("test-puzzle-456", GameDifficulty.Hard, cells);
+        var originalPuzzle = SudokuPuzzle.Create("test-puzzle-456", GameDifficulty.Hard, BoardSize.Nine, cells);
         originalPuzzle.PopulatePossibleValues();
 
         // Act
@@ -57,7 +57,7 @@ public class SudokuPuzzleTests : MoqBaseTestByType<SudokuPuzzle>
     {
         // Arrange
         var cells = CreateTestCells();
-        var originalPuzzle = SudokuPuzzle.Create("test-puzzle-789", GameDifficulty.Easy, cells);
+        var originalPuzzle = SudokuPuzzle.Create("test-puzzle-789", GameDifficulty.Easy, BoardSize.Nine, cells);
         var clonedPuzzle = originalPuzzle.Clone() as SudokuPuzzle;
 
         // Act
@@ -75,7 +75,7 @@ public class SudokuPuzzleTests : MoqBaseTestByType<SudokuPuzzle>
     {
         // Arrange
         var cells = CreateTestCells();
-        var originalPuzzle = SudokuPuzzle.Create("test-puzzle-abc", GameDifficulty.Expert, cells);
+        var originalPuzzle = SudokuPuzzle.Create("test-puzzle-abc", GameDifficulty.Expert, BoardSize.Nine, cells);
         
         // Add some possible values to an empty cell
         var emptyCell = originalPuzzle.GetCell(1, 1);
@@ -102,7 +102,7 @@ public class SudokuPuzzleTests : MoqBaseTestByType<SudokuPuzzle>
     {
         // Arrange
         var cells = CreateTestCells();
-        var originalPuzzle = SudokuPuzzle.Create("test-puzzle-def", GameDifficulty.Medium, cells);
+        var originalPuzzle = SudokuPuzzle.Create("test-puzzle-def", GameDifficulty.Medium, BoardSize.Nine, cells);
 
         // Act
         var clonedPuzzle = originalPuzzle.Clone() as SudokuPuzzle;
@@ -125,17 +125,17 @@ public class SudokuPuzzleTests : MoqBaseTestByType<SudokuPuzzle>
                 if (row == 0 && col == 0)
                 {
                     // Add a fixed cell
-                    cells.Add(Cell.CreateFixed(row, col, 5));
+                    cells.Add(Cell.CreateFixed(row, col, 5, BoardSize.Nine));
                 }
                 else if (row == 2 && col == 3)
                 {
                     // Add another fixed cell
-                    cells.Add(Cell.CreateFixed(row, col, 8));
+                    cells.Add(Cell.CreateFixed(row, col, 8, BoardSize.Nine));
                 }
                 else
                 {
                     // Add empty cells
-                    cells.Add(Cell.CreateEmpty(row, col));
+                    cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
                 }
             }
         }

--- a/src/backend/Tests/Helpers/Builders/BoardSizeGenerator.cs
+++ b/src/backend/Tests/Helpers/Builders/BoardSizeGenerator.cs
@@ -1,0 +1,17 @@
+using AutoFixture.Kernel;
+using Sudoku.Domain.ValueObjects;
+
+namespace UnitTests.Helpers.Builders;
+
+public class BoardSizeGenerator : ISpecimenBuilder
+{
+    public object Create(object request, ISpecimenContext context)
+    {
+        if (request is Type type && type == typeof(BoardSize))
+        {
+            return BoardSize.Nine; // Default to the classic 9x9 board
+        }
+
+        return new NoSpecimen();
+    }
+}

--- a/src/backend/Tests/Helpers/Builders/CellGenerator.cs
+++ b/src/backend/Tests/Helpers/Builders/CellGenerator.cs
@@ -14,6 +14,7 @@ public class CellGenerator : ISpecimenBuilder
             return Cell.Create(
                 _rnd.Next(0, 9),
                 _rnd.Next(0, 9),
+                BoardSize.Nine,
                 _rnd.Next(1, 10)
             );
         }

--- a/src/backend/Tests/Helpers/Builders/SudokuGameGenerator.cs
+++ b/src/backend/Tests/Helpers/Builders/SudokuGameGenerator.cs
@@ -16,6 +16,7 @@ public class SudokuGameGenerator : ISpecimenBuilder
                 ProfileId.New(),
                 context.Create<PlayerAlias>(),
                 context.Create<GameDifficulty>(),
+                BoardSize.Nine,
                 cells
             );
         }

--- a/src/backend/Tests/Helpers/Builders/SudokuPuzzleGenerator.cs
+++ b/src/backend/Tests/Helpers/Builders/SudokuPuzzleGenerator.cs
@@ -15,6 +15,7 @@ public class SudokuPuzzleGenerator : ISpecimenBuilder
             return SudokuPuzzle.Create(
                 context.Create<PlayerAlias>(),
                 context.Create<GameDifficulty>(),
+                BoardSize.Nine,
                 cells
             );
         }

--- a/src/backend/Tests/Helpers/Factories/CellsFactory.cs
+++ b/src/backend/Tests/Helpers/Factories/CellsFactory.cs
@@ -4,7 +4,7 @@ namespace UnitTests.Helpers.Factories;
 
 public static class CellsFactory
 {
-    public static IEnumerable<Cell> CreateCompletedCells()
+    public static IEnumerable<Cell> CreateCompletedCells(BoardSize? size = null)
     {
         int?[,] completedCells = {
             {5, 3, 4, 6, 7, 8, 9, 1, 2},
@@ -18,17 +18,17 @@ public static class CellsFactory
             {3, 4, 5, 2, 8, 6, 1, 7, 9}
         };
 
-        return GetCells(completedCells);
+        return GetCells(completedCells, size ?? BoardSize.Nine);
     }
 
-    public static IEnumerable<Cell> CreateEmptyCells()
+    public static IEnumerable<Cell> CreateEmptyCells(BoardSize? size = null)
     {
         var emptyCells = new int?[9, 9];
 
-        return GetCells(emptyCells);
+        return GetCells(emptyCells, size ?? BoardSize.Nine);
     }
 
-    public static IEnumerable<Cell> CreateIncompleteCells()
+    public static IEnumerable<Cell> CreateIncompleteCells(BoardSize? size = null)
     {
         int?[,] partiallyCompleted = {
             {null, 3, 4, 6, 7, 8, 9, 1, 2},
@@ -42,10 +42,10 @@ public static class CellsFactory
             {3, 4, 5, 2, 8, 6, 1, 7, 9}
         };
 
-        return GetCells(partiallyCompleted);
+        return GetCells(partiallyCompleted, size ?? BoardSize.Nine);
     }
 
-    public static IEnumerable<Cell> CreateInvalidCells()
+    public static IEnumerable<Cell> CreateInvalidCells(BoardSize? size = null)
     {
         int?[,] partiallyCompleted = {
             {null, 3, 4, 6, 7, 8, 9, 1, 2},
@@ -59,10 +59,10 @@ public static class CellsFactory
             {3, 4, 5, 2, 8, 6, 1, 7, 9}
         };
 
-        return GetCells(partiallyCompleted);
+        return GetCells(partiallyCompleted, size ?? BoardSize.Nine);
     }
 
-    private static IEnumerable<Cell> GetCells(int?[,] cellValues)
+    private static IEnumerable<Cell> GetCells(int?[,] cellValues, BoardSize size)
     {
         var cells = new List<Cell>();
 
@@ -71,7 +71,7 @@ public static class CellsFactory
             for (var col = 0; col < 9; col++)
             {
                 var cellValue = cellValues[row, col];
-                cells.Add(Cell.Create(row, col, cellValue, cellValue.HasValue));
+                cells.Add(Cell.Create(row, col, size, cellValue, cellValue.HasValue));
             }
         }
 

--- a/src/backend/Tests/Helpers/Factories/GameFactory.cs
+++ b/src/backend/Tests/Helpers/Factories/GameFactory.cs
@@ -86,15 +86,17 @@ public static class GameFactory
         return game;
     }
 
-    private static SudokuGame CreateGame(IEnumerable<Cell> cells, ProfileId? profileId = null, PlayerAlias? displayName = null, GameDifficulty? difficulty = null)
+    private static SudokuGame CreateGame(IEnumerable<Cell> cells, ProfileId? profileId = null, PlayerAlias? displayName = null, GameDifficulty? difficulty = null, BoardSize? size = null)
     {
         var withDifficulty = difficulty ?? GameDifficulty.Easy;
         var withProfileId = profileId ?? ProfileId.New();
         var withDisplayName = displayName ?? PlayerAlias.Create("DefaultPlayer");
+        var withSize = size ?? BoardSize.Nine;
         var game = SudokuGame.Create(
             withProfileId,
             withDisplayName,
             withDifficulty,
+            withSize,
             cells);
 
         return game;

--- a/src/backend/Tests/Helpers/Factories/PuzzleFactory.cs
+++ b/src/backend/Tests/Helpers/Factories/PuzzleFactory.cs
@@ -73,12 +73,12 @@ public static class PuzzleFactory
         {
             for (var row = 0; row < 9; row++)
             {
-                var cell = Cell.Create(row, col, values[row, col]);
+                var cell = Cell.Create(row, col, BoardSize.Nine, values[row, col]);
                 cells[index++] = cell;
             }
         }
 
-        return SudokuPuzzle.Create(Guid.NewGuid().ToString(), GameDifficulty.Easy, cells);
+        return SudokuPuzzle.Create(Guid.NewGuid().ToString(), GameDifficulty.Easy, BoardSize.Nine, cells);
     }
 
     private static readonly int?[,] EasyPuzzle = {

--- a/src/backend/Tests/Infrastructure/EventHandling/DomainEventDispatcherTests.cs
+++ b/src/backend/Tests/Infrastructure/EventHandling/DomainEventDispatcherTests.cs
@@ -20,6 +20,7 @@ public class DomainEventDispatcherTests : MoqBaseTestByAbstraction<DomainEventDi
     {
         container.AddCustomizations(new PlayerAliasGenerator());
         container.AddCustomizations(new GameDifficultyGenerator());
+        container.AddCustomizations(new BoardSizeGenerator());
     }
 
     [Fact]

--- a/src/backend/Tests/Infrastructure/EventHandling/GameCompletedEventHandlerTests.cs
+++ b/src/backend/Tests/Infrastructure/EventHandling/GameCompletedEventHandlerTests.cs
@@ -93,6 +93,7 @@ public class GameCompletedEventHandlerTests : MoqBaseTestByAbstraction<GameCompl
             ProfileId.New(),
             difficulty,
             statistics,
-            DateTime.UtcNow);
+            DateTime.UtcNow,
+            BoardSize.Nine);
     }
 }

--- a/src/backend/Tests/Infrastructure/EventHandling/GameCreatedEventHandlersTests.cs
+++ b/src/backend/Tests/Infrastructure/EventHandling/GameCreatedEventHandlersTests.cs
@@ -16,7 +16,7 @@ public class GameCreatedEventHandlerTests : MoqBaseTestByAbstraction<GameCreated
         var profileId = ProfileId.New();
         var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Medium;
-        var domainEvent = new GameCreatedEvent(gameId, profileId, displayName, difficulty);
+        var domainEvent = new GameCreatedEvent(gameId, profileId, displayName, difficulty, BoardSize.Nine);
 
         var sut = ResolveSut();
 
@@ -35,7 +35,7 @@ public class GameCreatedEventHandlerTests : MoqBaseTestByAbstraction<GameCreated
         var profileId = ProfileId.New();
         var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Hard;
-        var domainEvent = new GameCreatedEvent(gameId, profileId, displayName, difficulty);
+        var domainEvent = new GameCreatedEvent(gameId, profileId, displayName, difficulty, BoardSize.Nine);
 
         var sut = ResolveSut();
 
@@ -54,7 +54,7 @@ public class GameCreatedEventHandlerTests : MoqBaseTestByAbstraction<GameCreated
         var profileId = ProfileId.New();
         var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Expert;
-        var domainEvent = new GameCreatedEvent(gameId, profileId, displayName, difficulty);
+        var domainEvent = new GameCreatedEvent(gameId, profileId, displayName, difficulty, BoardSize.Nine);
 
         var sut = ResolveSut();
 
@@ -73,7 +73,7 @@ public class GameCreatedEventHandlerTests : MoqBaseTestByAbstraction<GameCreated
         var profileId = ProfileId.New();
         var displayName = PlayerAlias.Create("DifferentPlayer");
         var difficulty = GameDifficulty.Easy;
-        var domainEvent = new GameCreatedEvent(gameId, profileId, displayName, difficulty);
+        var domainEvent = new GameCreatedEvent(gameId, profileId, displayName, difficulty, BoardSize.Nine);
 
         var sut = ResolveSut();
 

--- a/src/backend/Tests/Infrastructure/Mappers/SudokuGameMapperTests.cs
+++ b/src/backend/Tests/Infrastructure/Mappers/SudokuGameMapperTests.cs
@@ -43,6 +43,6 @@ public class SudokuGameMapperTests : MoqBaseTestByType<SudokuGameDocument>
         // Assert
         restored.GetCell(row, column).IsHint.Should().BeTrue();
         restored.Statistics.HintsUsed.Should().Be(1);
-        restored.Statistics.HintsRemaining.Should().Be(game.Statistics.HintsRemaining);
+        restored.Statistics.HintsRemainingFor(restored.Size).Should().Be(game.Statistics.HintsRemainingFor(game.Size));
     }
 }

--- a/src/backend/Tests/Infrastructure/Repositories/AzureBlobGameRepositoryTests.cs
+++ b/src/backend/Tests/Infrastructure/Repositories/AzureBlobGameRepositoryTests.cs
@@ -682,7 +682,7 @@ public class AzureBlobGameRepositoryTests : MoqBaseTestByAbstraction<AzureBlobGa
         var displayName = PlayerAlias.Create("TestPlayer");
         var diff = difficulty ?? GameDifficulty.Medium;
         var cells = CellsFactory.CreateEmptyCells();
-        return SudokuGame.Create(pid, displayName, diff, cells);
+        return SudokuGame.Create(pid, displayName, diff, BoardSize.Nine, cells);
     }
 
     private static string GetBlobPath(string profileId, GameId gameId, string revision)

--- a/src/backend/Tests/Infrastructure/Repositories/CosmosDbGameRepositoryTests.cs
+++ b/src/backend/Tests/Infrastructure/Repositories/CosmosDbGameRepositoryTests.cs
@@ -159,7 +159,7 @@ public class CosmosDbGameRepositoryTests : MoqBaseTestByAbstraction<CosmosDbGame
         var displayName = PlayerAlias.Create("TestPlayer");
         var difficulty = GameDifficulty.Easy;
         var cells = CellsFactory.CreateEmptyCells();
-        var game = SudokuGame.Create(profileId, displayName, difficulty, cells);
+        var game = SudokuGame.Create(profileId, displayName, difficulty, BoardSize.Nine, cells);
         var sut = ResolveSut();
 
         // Act

--- a/src/backend/Tests/Infrastructure/Services/Strategies/TripletsInColumnsStrategyTests.cs
+++ b/src/backend/Tests/Infrastructure/Services/Strategies/TripletsInColumnsStrategyTests.cs
@@ -165,11 +165,11 @@ public class TripletsInColumnsStrategyTests : MoqBaseTestByAbstraction<TripletsI
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
 
         puzzle.PopulatePossibleValues();
 
@@ -223,11 +223,11 @@ public class TripletsInColumnsStrategyTests : MoqBaseTestByAbstraction<TripletsI
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
         
         // Hidden triplets: numbers 7,8,9 appear only in cells (0,0), (1,0), (2,0)
         puzzle.GetCell(0, 0).PossibleValues.UnionWith([1, 4, 7, 8]);
@@ -275,11 +275,11 @@ public class TripletsInColumnsStrategyTests : MoqBaseTestByAbstraction<TripletsI
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
         
         // No triplets - just random possible values
         puzzle.GetCell(0, 0).PossibleValues.UnionWith([1, 2]);
@@ -299,11 +299,11 @@ public class TripletsInColumnsStrategyTests : MoqBaseTestByAbstraction<TripletsI
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        return SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        return SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
     }
 
     private SudokuPuzzle CreatePuzzleWithSomeCellsSet()
@@ -314,11 +314,11 @@ public class TripletsInColumnsStrategyTests : MoqBaseTestByAbstraction<TripletsI
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
         
         // Set some cells
         puzzle.GetCell(0, 0).SetValue(5);
@@ -342,11 +342,11 @@ public class TripletsInColumnsStrategyTests : MoqBaseTestByAbstraction<TripletsI
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
         
         // Naked triplets
         puzzle.GetCell(3, 0).PossibleValues.UnionWith([1, 2, 3]);
@@ -367,11 +367,11 @@ public class TripletsInColumnsStrategyTests : MoqBaseTestByAbstraction<TripletsI
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
 
         puzzle.PopulatePossibleValues();
 

--- a/src/backend/Tests/Infrastructure/Services/Strategies/TripletsInMiniGridsStrategyTests.cs
+++ b/src/backend/Tests/Infrastructure/Services/Strategies/TripletsInMiniGridsStrategyTests.cs
@@ -238,13 +238,13 @@ public class TripletsInMiniGridsStrategyTests : MoqBaseTestByAbstraction<Triplet
         {
             for (var col = 0; col < 9; col++)
             {
-                var cell = Cell.CreateEmpty(row, col);
+                var cell = Cell.CreateEmpty(row, col, BoardSize.Nine);
                 cell.PossibleValues.UnionWith([1, 2, 3, 4, 5, 6, 7, 8, 9]);
                 cells.Add(cell);
             }
         }
 
-        var puzzle = SudokuPuzzle.Create(Guid.NewGuid().ToString(), GameDifficulty.Expert, cells);
+        var puzzle = SudokuPuzzle.Create(Guid.NewGuid().ToString(), GameDifficulty.Expert, BoardSize.Nine, cells);
         return puzzle;
     }
 

--- a/src/backend/Tests/Infrastructure/Services/Strategies/TripletsInRowsStrategyTests.cs
+++ b/src/backend/Tests/Infrastructure/Services/Strategies/TripletsInRowsStrategyTests.cs
@@ -206,11 +206,11 @@ public class TripletsInRowsStrategyTests : MoqBaseTestByAbstraction<TripletsInRo
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
 
         puzzle.PopulatePossibleValues();
 
@@ -242,11 +242,11 @@ public class TripletsInRowsStrategyTests : MoqBaseTestByAbstraction<TripletsInRo
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
 
         puzzle.PopulatePossibleValues();
 
@@ -282,11 +282,11 @@ public class TripletsInRowsStrategyTests : MoqBaseTestByAbstraction<TripletsInRo
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
         
         // Hidden triplets: numbers 7,8,9 appear only in cells (0,0), (0,1), (0,2)
         puzzle.GetCell(0, 0).PossibleValues.UnionWith([1, 4, 7, 8]);
@@ -312,11 +312,11 @@ public class TripletsInRowsStrategyTests : MoqBaseTestByAbstraction<TripletsInRo
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
 
         // Create a scenario where hidden triplets 2, 6, 9 appear only in cells (2,1), (2,3), (2,4)
         // but each cell also has other values that should be removed
@@ -354,11 +354,11 @@ public class TripletsInRowsStrategyTests : MoqBaseTestByAbstraction<TripletsInRo
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
         
         // No triplets - just random possible values
         puzzle.GetCell(0, 0).PossibleValues.UnionWith([1, 2]);
@@ -378,11 +378,11 @@ public class TripletsInRowsStrategyTests : MoqBaseTestByAbstraction<TripletsInRo
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        return SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        return SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
     }
 
     private SudokuPuzzle CreatePuzzleWithSomeCellsSet()
@@ -393,11 +393,11 @@ public class TripletsInRowsStrategyTests : MoqBaseTestByAbstraction<TripletsInRo
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
         
         // Set some cells in row 0
         puzzle.GetCell(0, 0).SetValue(5);
@@ -421,11 +421,11 @@ public class TripletsInRowsStrategyTests : MoqBaseTestByAbstraction<TripletsInRo
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
         
         // Create a scenario where triplet removal will cause an invalid state
         // Set up naked triplets in row 0: cells (0,0), (0,1), (0,3) with values [1,2,3]
@@ -447,11 +447,11 @@ public class TripletsInRowsStrategyTests : MoqBaseTestByAbstraction<TripletsInRo
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
 
         puzzle.PopulatePossibleValues();
 
@@ -488,11 +488,11 @@ public class TripletsInRowsStrategyTests : MoqBaseTestByAbstraction<TripletsInRo
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
 
         puzzle.PopulatePossibleValues();
 
@@ -519,11 +519,11 @@ public class TripletsInRowsStrategyTests : MoqBaseTestByAbstraction<TripletsInRo
         {
             for (var col = 0; col < 9; col++)
             {
-                cells.Add(Cell.CreateEmpty(row, col));
+                cells.Add(Cell.CreateEmpty(row, col, BoardSize.Nine));
             }
         }
         
-        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, cells);
+        var puzzle = SudokuPuzzle.Create("test", GameDifficulty.Easy, BoardSize.Nine, cells);
 
         // Set some cells with values in row 0
         puzzle.GetCell(0, 0).SetValue(9);


### PR DESCRIPTION
## Description

Phase 1 of 6 for the 16x16 Sudoku variant (see `docs/specs/spec-16x16-sudoku.md`). Introduces a `BoardSize` value object as the single source of grid-dimension truth and threads it through the domain layer, paying down the hard-coded `9`/`81`/`3` literal debt called out in the spec's problem statement. Pure refactor — no 16x16 behavior yet; existing 9x9 behavior is unchanged and proven by the full existing test suite staying green.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Added `BoardSize` value object (`Nine`: Size 9/BoxSize 3/MinimumClues 17/MaxHints 3, `Sixteen`: Size 16/BoxSize 4/MinimumClues 55/MaxHints 6), constructed only via `FromValue(int)` (throws `InvalidBoardSizeException` for other values) — same smart-enum pattern as `GameDifficulty`
- Threaded `BoardSize` through `Cell` (ctor + all factories), `SudokuPuzzle` (`Create`, box/count/range math), and `SudokuGame` (`Create`/`Reconstitute`, `ValidateGame`/`IsValidPuzzle`/`IsValidForBox`, hint allowance) — every call site now passes `BoardSize.Nine` explicitly, no default parameter
- Added `Size` to `GameCreatedEvent` and `GameCompletedEvent`
- Replaced the flat `GameStatistics.MaxHints` const with `HintsRemainingFor(BoardSize size)`, sourced from `Size.MaxHints` at the aggregate
- Removed the now-orphaned `Sudoku:Game:MaxHintsPerGame` config key from `scripts/set-app-config.sh` (both labels) — no code read it, and it would become actively misleading once the hint allowance is per-size
- Updated ~35 test files/helpers to pass `BoardSize.Nine` explicitly; added `BoardSizeGenerator` AutoFixture specimen builder alongside the existing `GameDifficultyGenerator` pattern

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable) — `BoardSize.FromValue` behavior covered

713/713 backend tests pass (verified against pre-change baseline via `git stash`), `dotnet build` clean.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)