### PR TITLE
Phase 3/6: gridSize discriminator + size-aware puzzle pool (16x16 Sudoku spec)

### DIFF
--- a/src/backend/Sudoku.Application/Handlers/CreateGameCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/CreateGameCommandHandler.cs
@@ -22,7 +22,7 @@ public class CreateGameCommandHandler(
             var displayName = PlayerAlias.Create(request.DisplayName);
             var difficulty = GameDifficulty.FromName(request.Difficulty);
 
-            var puzzle = await puzzlePoolService.DequeueAsync(difficulty);
+            var puzzle = await puzzlePoolService.DequeueAsync(BoardSize.Nine, difficulty);
 
             if (puzzle is null)
             {

--- a/src/backend/Sudoku.Application/Handlers/DeleteGameCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/DeleteGameCommandHandler.cs
@@ -70,7 +70,8 @@ public class DeleteGameCommandHandler(
             game.ProfileId.ToString(),
             game.Difficulty.Name,
             game.Statistics.PlayDuration,
-            game.CompletedAt ?? DateTime.UtcNow);
+            game.CompletedAt ?? DateTime.UtcNow,
+            game.Size.Size);
 
         await completionRepository.UpsertAsync(completion);
 

--- a/src/backend/Sudoku.Application/Interfaces/IPuzzleBlobStorage.cs
+++ b/src/backend/Sudoku.Application/Interfaces/IPuzzleBlobStorage.cs
@@ -5,7 +5,7 @@ namespace Sudoku.Application.Interfaces;
 
 public interface IPuzzleBlobStorage
 {
-    Task<SudokuPuzzle> CreateAsync(GameDifficulty difficulty);
+    Task<SudokuPuzzle> CreateAsync(GameDifficulty difficulty, BoardSize size);
     Task DeleteAsync(string prefix, string puzzleId);
     IAsyncEnumerable<string> GetPuzzleIdsAsync(string prefix);
     Task<SudokuPuzzle?> LoadAsync(string prefix, string puzzleId);

--- a/src/backend/Sudoku.Application/Interfaces/IPuzzlePoolService.cs
+++ b/src/backend/Sudoku.Application/Interfaces/IPuzzlePoolService.cs
@@ -5,7 +5,7 @@ namespace Sudoku.Application.Interfaces;
 
 public interface IPuzzlePoolService
 {
-    Task<int> GetAvailableCountAsync(GameDifficulty difficulty);
-    Task SeedAsync(GameDifficulty difficulty, int count);
-    Task<SudokuPuzzle?> DequeueAsync(GameDifficulty difficulty);
+    Task<int> GetAvailableCountAsync(BoardSize size, GameDifficulty difficulty);
+    Task SeedAsync(BoardSize size, GameDifficulty difficulty, int count);
+    Task<SudokuPuzzle?> DequeueAsync(BoardSize size, GameDifficulty difficulty);
 }

--- a/src/backend/Sudoku.Application/Models/GameCompletion.cs
+++ b/src/backend/Sudoku.Application/Models/GameCompletion.cs
@@ -10,4 +10,5 @@ public record GameCompletion(
     string ProfileId,
     string Difficulty,
     TimeSpan PlayDuration,
-    DateTime CompletedAt);
+    DateTime CompletedAt,
+    int GridSize);

--- a/src/backend/Sudoku.Functions/Functions/PuzzleReplenishFunction.cs
+++ b/src/backend/Sudoku.Functions/Functions/PuzzleReplenishFunction.cs
@@ -18,7 +18,13 @@ public class PuzzleReplenishFunction(IPuzzlePoolService puzzlePoolService, ILogg
         var sizeSegment = segments?.Length > 0 ? segments[0] : null;
         var difficultyName = segments?.Length > 1 ? segments[1].ToLowerInvariant() : null;
 
-        if (string.IsNullOrEmpty(sizeSegment) || string.IsNullOrEmpty(difficultyName))
+        if (string.IsNullOrEmpty(sizeSegment))
+        {
+            logger.LogWarning("Could not parse board size from event subject: {Subject}", eventGridEvent.Subject);
+            return;
+        }
+
+        if (string.IsNullOrEmpty(difficultyName))
         {
             logger.LogWarning("Could not parse difficulty from event subject: {Subject}", eventGridEvent.Subject);
             return;
@@ -52,12 +58,16 @@ public class PuzzleReplenishFunction(IPuzzlePoolService puzzlePoolService, ILogg
 
     private static BoardSize ParseSize(string sizeSegment)
     {
-        var value = sizeSegment.Split('x', 'X').FirstOrDefault();
-        if (!int.TryParse(value, out var size))
+        var parts = sizeSegment.Split('x', 'X');
+
+        if (parts.Length != 2
+            || !int.TryParse(parts[0], out var width)
+            || !int.TryParse(parts[1], out var height)
+            || width != height)
         {
             throw new InvalidBoardSizeException($"Invalid board size segment: {sizeSegment}");
         }
 
-        return BoardSize.FromValue(size);
+        return BoardSize.FromValue(width);
     }
 }

--- a/src/backend/Sudoku.Functions/Functions/PuzzleReplenishFunction.cs
+++ b/src/backend/Sudoku.Functions/Functions/PuzzleReplenishFunction.cs
@@ -12,13 +12,26 @@ public class PuzzleReplenishFunction(IPuzzlePoolService puzzlePoolService, ILogg
     [Function("PuzzleReplenishFunction")]
     public async Task Run([EventGridTrigger] EventGridEvent eventGridEvent)
     {
-        // Subject format: /blobServices/default/containers/sudoku-puzzles/blobs/{difficulty}/{puzzleId}.json
+        // Subject format: /blobServices/default/containers/sudoku-puzzles/blobs/{size}x{size}/{difficulty}/{puzzleId}.json
         var blobName = eventGridEvent.Subject.Split("/blobs/").LastOrDefault();
-        var difficultyName = blobName?.Split('/').FirstOrDefault()?.ToLowerInvariant();
+        var segments = blobName?.Split('/');
+        var sizeSegment = segments?.Length > 0 ? segments[0] : null;
+        var difficultyName = segments?.Length > 1 ? segments[1].ToLowerInvariant() : null;
 
-        if (string.IsNullOrEmpty(difficultyName))
+        if (string.IsNullOrEmpty(sizeSegment) || string.IsNullOrEmpty(difficultyName))
         {
             logger.LogWarning("Could not parse difficulty from event subject: {Subject}", eventGridEvent.Subject);
+            return;
+        }
+
+        BoardSize size;
+        try
+        {
+            size = ParseSize(sizeSegment);
+        }
+        catch (InvalidBoardSizeException)
+        {
+            logger.LogWarning("Unknown board size '{SizeSegment}' in blob path, ignoring event", sizeSegment);
             return;
         }
 
@@ -33,7 +46,18 @@ public class PuzzleReplenishFunction(IPuzzlePoolService puzzlePoolService, ILogg
             return;
         }
 
-        logger.LogInformation("Replenishing 1 puzzle for {Difficulty}", difficulty.Name);
-        await puzzlePoolService.SeedAsync(difficulty, 1);
+        logger.LogInformation("Replenishing 1 puzzle for {Size} {Difficulty}", size, difficulty.Name);
+        await puzzlePoolService.SeedAsync(size, difficulty, 1);
+    }
+
+    private static BoardSize ParseSize(string sizeSegment)
+    {
+        var value = sizeSegment.Split('x', 'X').FirstOrDefault();
+        if (!int.TryParse(value, out var size))
+        {
+            throw new InvalidBoardSizeException($"Invalid board size segment: {sizeSegment}");
+        }
+
+        return BoardSize.FromValue(size);
     }
 }

--- a/src/backend/Sudoku.Functions/Services/PuzzlePoolSeeder.cs
+++ b/src/backend/Sudoku.Functions/Services/PuzzlePoolSeeder.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Sudoku.Application.Interfaces;
 using Sudoku.Domain.ValueObjects;
@@ -7,36 +8,58 @@ namespace Sudoku.Functions.Services;
 public class PuzzlePoolSeeder(IPuzzlePoolService puzzlePoolService, ILogger<PuzzlePoolSeeder> logger) : IPuzzlePoolSeeder
 {
     public const int TargetPoolSize = 10;
+    public const int TargetPoolSizeSixteen = 5;
 
-    private static readonly GameDifficulty[] Difficulties =
+    /// <summary>
+    /// Headroom under the Azure Functions consumption-plan default timeout (5 minutes), so a
+    /// single invocation always has time to persist/log before the host forcibly terminates it.
+    /// </summary>
+    public static readonly TimeSpan TimeBudget = TimeSpan.FromMinutes(4);
+
+    // Fast/cheap combinations first so a single invocation reliably tops up the 9x9 pools even
+    // if it runs out of budget partway through the slower 16x16 Hard/Expert generation.
+    private static readonly (BoardSize Size, GameDifficulty Difficulty, int Target)[] Combinations =
     [
-        GameDifficulty.Easy,
-        GameDifficulty.Medium,
-        GameDifficulty.Hard,
-        GameDifficulty.Expert
+        (BoardSize.Nine, GameDifficulty.Easy, TargetPoolSize),
+        (BoardSize.Nine, GameDifficulty.Medium, TargetPoolSize),
+        (BoardSize.Nine, GameDifficulty.Hard, TargetPoolSize),
+        (BoardSize.Nine, GameDifficulty.Expert, TargetPoolSize),
+        (BoardSize.Sixteen, GameDifficulty.Easy, TargetPoolSizeSixteen),
+        (BoardSize.Sixteen, GameDifficulty.Medium, TargetPoolSizeSixteen),
+        (BoardSize.Sixteen, GameDifficulty.Hard, TargetPoolSizeSixteen),
+        (BoardSize.Sixteen, GameDifficulty.Expert, TargetPoolSizeSixteen)
     ];
 
     public async Task<int> SeedPoolAsync()
     {
         var totalSeeded = 0;
+        var stopwatch = Stopwatch.StartNew();
 
-        foreach (var difficulty in Difficulties)
+        foreach (var (size, difficulty, target) in Combinations)
         {
-            var currentCount = await puzzlePoolService.GetAvailableCountAsync(difficulty);
-            var needed = TargetPoolSize - currentCount;
+            var currentCount = await puzzlePoolService.GetAvailableCountAsync(size, difficulty);
 
-            if (needed > 0)
+            while (currentCount < target)
             {
-                logger.LogInformation("Seeding {Count} puzzles for {Difficulty} (current: {Current})",
-                    needed, difficulty.Name, currentCount);
-                await puzzlePoolService.SeedAsync(difficulty, needed);
-                totalSeeded += needed;
+                if (stopwatch.Elapsed >= TimeBudget)
+                {
+                    logger.LogInformation(
+                        "Time budget exhausted after seeding {Total} puzzles; stopping for this invocation",
+                        totalSeeded);
+                    return totalSeeded;
+                }
+
+                logger.LogInformation("Seeding 1 puzzle for {Size} {Difficulty} (current: {Current}/{Target})",
+                    size, difficulty.Name, currentCount, target);
+
+                await puzzlePoolService.SeedAsync(size, difficulty, 1);
+
+                totalSeeded++;
+                currentCount++;
             }
-            else
-            {
-                logger.LogInformation("Pool full for {Difficulty} ({Count}/{Target})",
-                    difficulty.Name, currentCount, TargetPoolSize);
-            }
+
+            logger.LogInformation("Pool full for {Size} {Difficulty} ({Count}/{Target})",
+                size, difficulty.Name, currentCount, target);
         }
 
         return totalSeeded;

--- a/src/backend/Sudoku.Infrastructure/EventHandling/GameCompletedEventHandler.cs
+++ b/src/backend/Sudoku.Infrastructure/EventHandling/GameCompletedEventHandler.cs
@@ -17,7 +17,8 @@ public class GameCompletedEventHandler(
             domainEvent.ProfileId.ToString(),
             domainEvent.Difficulty.Name,
             domainEvent.Statistics.PlayDuration,
-            domainEvent.CompletedAt);
+            domainEvent.CompletedAt,
+            domainEvent.Size.Size);
 
         await completionRepository.UpsertAsync(completion);
 

--- a/src/backend/Sudoku.Infrastructure/Mappers/SudokuGameMapper.cs
+++ b/src/backend/Sudoku.Infrastructure/Mappers/SudokuGameMapper.cs
@@ -1,4 +1,5 @@
 using Sudoku.Domain.Entities;
+using Sudoku.Domain.Exceptions;
 using Sudoku.Domain.ValueObjects;
 using Sudoku.Infrastructure.Models;
 
@@ -15,6 +16,7 @@ public static class SudokuGameMapper
             ProfileId = game.ProfileId.ToString(),
             DisplayName = game.DisplayName.Value,
             Difficulty = game.Difficulty.Name,
+            GridSize = game.Size.Size,
             Status = game.Status,
             Cells = game.GetCells().Select(ToDocument).ToList(),
             Statistics = ToDocument(game.Statistics),
@@ -48,15 +50,22 @@ public static class SudokuGameMapper
             ? GameDifficulty.Easy
             : GameDifficulty.FromName(document.Difficulty);
 
+        var size = BoardSize.FromValue(document.GridSize);
+
+        if (document.Cells.Count != size.CellCount)
+        {
+            throw new InvalidPuzzleException();
+        }
+
         var sudokuGame = SudokuGame.Reconstitute(
             GameId.Create(document.GameId),
             profileId,
             displayName,
             difficulty,
-            BoardSize.Nine,
+            size,
             document.Status,
             document.Statistics.ToDomain(),
-            document.Cells.Select(ToDomain).ToList(),
+            document.Cells.Select(c => c.ToDomain(size)).ToList(),
             document.MoveHistory.Select(m => new MoveHistory(m.Row, m.Column, m.PreviousValue, m.NewValue)),
             document.CreatedAt,
             document.StartedAt,
@@ -81,9 +90,9 @@ public static class SudokuGameMapper
         return cellDocument;
     }
 
-    private static Cell ToDomain(this CellDocument document)
+    private static Cell ToDomain(this CellDocument document, BoardSize size)
     {
-        var cell = Cell.Create(document.Row, document.Column, BoardSize.Nine, document.Value, document.IsFixed, document.IsHint);
+        var cell = Cell.Create(document.Row, document.Column, size, document.Value, document.IsFixed, document.IsHint);
 
         // Set possible values using reflection since there's no public setter
         var cellType = typeof(Cell);

--- a/src/backend/Sudoku.Infrastructure/Models/GameCompletionDocument.cs
+++ b/src/backend/Sudoku.Infrastructure/Models/GameCompletionDocument.cs
@@ -8,6 +8,7 @@ public class GameCompletionDocument
     [JsonProperty("gameId")]       public string GameId { get; set; } = string.Empty;
     [JsonProperty("profileId")]    public string ProfileId { get; set; } = string.Empty;
     [JsonProperty("difficulty")]   public string Difficulty { get; set; } = string.Empty;
+    [JsonProperty("gridSize")]     public int GridSize { get; set; } = 9;
     [JsonProperty("playDuration")] public TimeSpan PlayDuration { get; set; }
     [JsonProperty("completedAt")]  public DateTime CompletedAt { get; set; }
 }

--- a/src/backend/Sudoku.Infrastructure/Models/SudokuGameDocument.cs
+++ b/src/backend/Sudoku.Infrastructure/Models/SudokuGameDocument.cs
@@ -23,6 +23,9 @@ public class SudokuGameDocument
     [JsonConverter(typeof(GameDifficultyStringConverter))]
     public string Difficulty { get; set; } = GameDifficulty.Easy.Name;
 
+    [JsonProperty("gridSize")]
+    public int GridSize { get; set; } = 9;
+
     [JsonProperty("status")]
     public GameStatusEnum Status { get; set; }
 

--- a/src/backend/Sudoku.Infrastructure/Models/SudokuPuzzleDocument.cs
+++ b/src/backend/Sudoku.Infrastructure/Models/SudokuPuzzleDocument.cs
@@ -4,5 +4,6 @@ public class SudokuPuzzleDocument
 {
     public string PuzzleId { get; set; } = string.Empty;
     public string Difficulty { get; set; } = string.Empty;
+    public int GridSize { get; set; } = 9;
     public List<CellDocument> Cells { get; set; } = [];
 }

--- a/src/backend/Sudoku.Infrastructure/Repositories/AzureBlobPuzzleRepository.cs
+++ b/src/backend/Sudoku.Infrastructure/Repositories/AzureBlobPuzzleRepository.cs
@@ -14,13 +14,13 @@ public class AzureBlobPuzzleRepository(
 {
     private const string Container = "sudoku-puzzles";
 
-    public async Task<SudokuPuzzle> CreateAsync(GameDifficulty difficulty)
+    public async Task<SudokuPuzzle> CreateAsync(GameDifficulty difficulty, BoardSize size)
     {
-        var puzzle = await puzzleGenerator.GeneratePuzzleAsync(difficulty, BoardSize.Nine);
-        var document = MapToDocument(puzzle);
-        var blobName = $"{difficulty.Name.ToLowerInvariant()}/{puzzle.PuzzleId}.json";
+        var puzzle = await puzzleGenerator.GeneratePuzzleAsync(difficulty, size);
+        var document = MapToDocument(puzzle, size);
+        var blobName = $"{size.Size}x{size.Size}/{difficulty.Name.ToLowerInvariant()}/{puzzle.PuzzleId}.json";
         await storageService.SaveAsync(Container, blobName, document);
-        logger.LogDebug("Stored puzzle {PuzzleId} for {Difficulty}", puzzle.PuzzleId, difficulty.Name);
+        logger.LogDebug("Stored puzzle {PuzzleId} for {Difficulty} ({Size})", puzzle.PuzzleId, difficulty.Name, size);
         return puzzle;
     }
 
@@ -63,11 +63,12 @@ public class AzureBlobPuzzleRepository(
     public Task<SudokuPuzzle> UndoAsync(string alias, string puzzleId) =>
         throw new NotSupportedException();
 
-    private static SudokuPuzzleDocument MapToDocument(SudokuPuzzle puzzle) =>
+    private static SudokuPuzzleDocument MapToDocument(SudokuPuzzle puzzle, BoardSize size) =>
         new()
         {
             PuzzleId = puzzle.PuzzleId,
             Difficulty = puzzle.Difficulty.Name.ToLowerInvariant(),
+            GridSize = size.Size,
             Cells = puzzle.Cells.Select(c => new CellDocument
             {
                 Row = c.Row,
@@ -81,7 +82,8 @@ public class AzureBlobPuzzleRepository(
     private static SudokuPuzzle MapToPuzzle(SudokuPuzzleDocument document)
     {
         var difficulty = GameDifficulty.FromName(document.Difficulty);
-        var cells = document.Cells.Select(c => Cell.Create(c.Row, c.Column, BoardSize.Nine, c.Value, c.IsFixed));
-        return SudokuPuzzle.Create(document.PuzzleId, difficulty, BoardSize.Nine, cells);
+        var size = BoardSize.FromValue(document.GridSize);
+        var cells = document.Cells.Select(c => Cell.Create(c.Row, c.Column, size, c.Value, c.IsFixed));
+        return SudokuPuzzle.Create(document.PuzzleId, difficulty, size, cells);
     }
 }

--- a/src/backend/Sudoku.Infrastructure/Repositories/CosmosDbGameCompletionRepository.cs
+++ b/src/backend/Sudoku.Infrastructure/Repositories/CosmosDbGameCompletionRepository.cs
@@ -94,6 +94,7 @@ public class CosmosDbGameCompletionRepository(
         GameId = completion.GameId,
         ProfileId = completion.ProfileId,
         Difficulty = completion.Difficulty,
+        GridSize = completion.GridSize,
         PlayDuration = completion.PlayDuration,
         CompletedAt = completion.CompletedAt
     };
@@ -103,7 +104,8 @@ public class CosmosDbGameCompletionRepository(
         document.ProfileId,
         document.Difficulty,
         document.PlayDuration,
-        document.CompletedAt);
+        document.CompletedAt,
+        document.GridSize);
 
     private async Task EnsureContainerAsync()
     {

--- a/src/backend/Sudoku.Infrastructure/Services/PuzzlePoolService.cs
+++ b/src/backend/Sudoku.Infrastructure/Services/PuzzlePoolService.cs
@@ -7,31 +7,32 @@ namespace Sudoku.Infrastructure.Services;
 
 public class PuzzlePoolService(IPuzzleBlobStorage puzzleBlobStorage, ILogger<PuzzlePoolService> logger) : IPuzzlePoolService
 {
-    public async Task<int> GetAvailableCountAsync(GameDifficulty difficulty)
+    public async Task<int> GetAvailableCountAsync(BoardSize size, GameDifficulty difficulty)
     {
         var count = 0;
-        await foreach (var _ in puzzleBlobStorage.GetPuzzleIdsAsync(difficulty.Name.ToLowerInvariant()))
+        var prefix = BuildPrefix(size, difficulty);
+        await foreach (var _ in puzzleBlobStorage.GetPuzzleIdsAsync(prefix))
         {
             count++;
         }
 
-        logger.LogDebug("Pool size for {Difficulty}: {Count}", difficulty.Name, count);
+        logger.LogDebug("Pool size for {Size} {Difficulty}: {Count}", size, difficulty.Name, count);
         return count;
     }
 
-    public async Task SeedAsync(GameDifficulty difficulty, int count)
+    public async Task SeedAsync(BoardSize size, GameDifficulty difficulty, int count)
     {
         for (var i = 0; i < count; i++)
         {
-            await puzzleBlobStorage.CreateAsync(difficulty);
+            await puzzleBlobStorage.CreateAsync(difficulty, size);
         }
 
-        logger.LogInformation("Seeded {Count} puzzles for {Difficulty}", count, difficulty.Name);
+        logger.LogInformation("Seeded {Count} puzzles for {Size} {Difficulty}", count, size, difficulty.Name);
     }
 
-    public async Task<SudokuPuzzle?> DequeueAsync(GameDifficulty difficulty)
+    public async Task<SudokuPuzzle?> DequeueAsync(BoardSize size, GameDifficulty difficulty)
     {
-        var prefix = difficulty.Name.ToLowerInvariant();
+        var prefix = BuildPrefix(size, difficulty);
         var puzzleIds = new List<string>();
 
         await foreach (var id in puzzleBlobStorage.GetPuzzleIdsAsync(prefix))
@@ -58,4 +59,7 @@ public class PuzzlePoolService(IPuzzleBlobStorage puzzleBlobStorage, ILogger<Puz
         await puzzleBlobStorage.DeleteAsync(prefix, puzzleId);
         return puzzle;
     }
+
+    private static string BuildPrefix(BoardSize size, GameDifficulty difficulty) =>
+        $"{size.Size}x{size.Size}/{difficulty.Name.ToLowerInvariant()}";
 }

--- a/src/backend/Tests/Application/Handlers/DeleteGameCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/DeleteGameCommandHandlerTests.cs
@@ -68,7 +68,8 @@ public class DeleteGameCommandHandlerTests : MoqBaseTestByAbstraction<Handler, I
                 game.ProfileId.ToString(),
                 game.Difficulty.Name,
                 game.Statistics.PlayDuration,
-                game.CompletedAt!.Value),
+                game.CompletedAt!.Value,
+                game.Size.Size),
             Times.Once);
     }
 
@@ -83,7 +84,8 @@ public class DeleteGameCommandHandlerTests : MoqBaseTestByAbstraction<Handler, I
             game.ProfileId.ToString(),
             game.Difficulty.Name,
             game.Statistics.PlayDuration,
-            game.CompletedAt!.Value));
+            game.CompletedAt!.Value,
+            game.Size.Size));
         var sut = ResolveSut();
 
         // Act

--- a/src/backend/Tests/Application/Handlers/GetPlayerStatsQueryHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/GetPlayerStatsQueryHandlerTests.cs
@@ -241,5 +241,5 @@ public class GetPlayerStatsQueryHandlerTests
     }
 
     private GameCompletion Completion(string difficulty, TimeSpan playDuration) =>
-        new(Guid.NewGuid().ToString(), _profileId, difficulty, playDuration, DateTime.UtcNow);
+        new(Guid.NewGuid().ToString(), _profileId, difficulty, playDuration, DateTime.UtcNow, 9);
 }

--- a/src/backend/Tests/Functions/PuzzlePoolSeederTests.cs
+++ b/src/backend/Tests/Functions/PuzzlePoolSeederTests.cs
@@ -10,7 +10,8 @@ namespace UnitTests.Functions;
 public class PuzzlePoolSeederTests : MoqBaseTestByAbstraction<PuzzlePoolSeeder, IPuzzlePoolSeeder>
 {
     private readonly Mock<IPuzzlePoolService> _mockPuzzlePoolService;
-    private const int TargetPoolSize = PuzzlePoolSeeder.TargetPoolSize;
+    private const int TargetPoolSizeNine = PuzzlePoolSeeder.TargetPoolSize;
+    private const int TargetPoolSizeSixteen = PuzzlePoolSeeder.TargetPoolSizeSixteen;
 
     public PuzzlePoolSeederTests()
     {
@@ -18,30 +19,30 @@ public class PuzzlePoolSeederTests : MoqBaseTestByAbstraction<PuzzlePoolSeeder, 
     }
 
     [Fact]
-    public async Task SeedPoolAsync_WhenPoolBelowTarget_SeedsMissingPuzzlesForEachDifficulty()
+    public async Task SeedPoolAsync_WhenNineBySizePoolsBelowTarget_SeedsOnePuzzleAtATimeUntilTargetReached()
     {
-        // Arrange
-        var currentCount = 7;
-        var expectedSeedCount = TargetPoolSize - currentCount;
-        _mockPuzzlePoolService.SetupGetAvailableCountReturns(currentCount);
+        // Arrange — 16x16 pools already at target so only the four 9x9 combinations need seeding
+        var currentCount = 8;
+        var expectedPerCombination = TargetPoolSizeNine - currentCount;
+        SetupAllCounts(nineCount: currentCount, sixteenCount: TargetPoolSizeSixteen);
 
         var sut = ResolveSut();
 
         // Act
         await sut.SeedPoolAsync();
 
-        // Assert
-        _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Easy, expectedSeedCount);
-        _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Medium, expectedSeedCount);
-        _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Hard, expectedSeedCount);
-        _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Expert, expectedSeedCount);
+        // Assert — one-at-a-time: SeedAsync(size, difficulty, 1) called once per missing puzzle
+        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Nine, GameDifficulty.Easy, 1, expectedPerCombination);
+        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Nine, GameDifficulty.Medium, 1, expectedPerCombination);
+        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Nine, GameDifficulty.Hard, 1, expectedPerCombination);
+        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Nine, GameDifficulty.Expert, 1, expectedPerCombination);
     }
 
     [Fact]
-    public async Task SeedPoolAsync_WhenPoolAtTarget_DoesNotSeedAnyPuzzles()
+    public async Task SeedPoolAsync_WhenAllPoolsAtTarget_DoesNotSeedAnyPuzzles()
     {
         // Arrange
-        _mockPuzzlePoolService.SetupGetAvailableCountReturns(TargetPoolSize);
+        SetupAllCounts(nineCount: TargetPoolSizeNine, sixteenCount: TargetPoolSizeSixteen);
 
         var sut = ResolveSut();
 
@@ -53,10 +54,10 @@ public class PuzzlePoolSeederTests : MoqBaseTestByAbstraction<PuzzlePoolSeeder, 
     }
 
     [Fact]
-    public async Task SeedPoolAsync_ChecksEachDifficultyExactlyOnce()
+    public async Task SeedPoolAsync_ChecksEachOfTheEightCombinationsExactlyOnce()
     {
         // Arrange
-        _mockPuzzlePoolService.SetupGetAvailableCountReturns(TargetPoolSize);
+        SetupAllCounts(nineCount: TargetPoolSizeNine, sixteenCount: TargetPoolSizeSixteen);
 
         var sut = ResolveSut();
 
@@ -64,10 +65,14 @@ public class PuzzlePoolSeederTests : MoqBaseTestByAbstraction<PuzzlePoolSeeder, 
         await sut.SeedPoolAsync();
 
         // Assert
-        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(GameDifficulty.Easy);
-        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(GameDifficulty.Medium);
-        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(GameDifficulty.Hard);
-        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(GameDifficulty.Expert);
+        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(BoardSize.Nine, GameDifficulty.Easy);
+        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(BoardSize.Nine, GameDifficulty.Medium);
+        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(BoardSize.Nine, GameDifficulty.Hard);
+        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(BoardSize.Nine, GameDifficulty.Expert);
+        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(BoardSize.Sixteen, GameDifficulty.Easy);
+        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(BoardSize.Sixteen, GameDifficulty.Medium);
+        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(BoardSize.Sixteen, GameDifficulty.Hard);
+        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(BoardSize.Sixteen, GameDifficulty.Expert);
     }
 
     [Theory]
@@ -75,10 +80,10 @@ public class PuzzlePoolSeederTests : MoqBaseTestByAbstraction<PuzzlePoolSeeder, 
     [InlineData(5, 5)]
     [InlineData(9, 1)]
     [InlineData(10, 0)]
-    public async Task SeedPoolAsync_SeedsExactlyTheNumberNeededToReachTarget(int currentCount, int expectedSeedCount)
+    public async Task SeedPoolAsync_ForNineBySize_SeedsExactlyTheNumberNeededToReachTarget(int currentCount, int expectedSeedCount)
     {
-        // Arrange
-        _mockPuzzlePoolService.SetupGetAvailableCountReturns(currentCount);
+        // Arrange — 16x16 pools already at target so only the 9x9 combination under test is exercised
+        SetupAllCounts(nineCount: currentCount, sixteenCount: TargetPoolSizeSixteen);
 
         var sut = ResolveSut();
 
@@ -88,10 +93,7 @@ public class PuzzlePoolSeederTests : MoqBaseTestByAbstraction<PuzzlePoolSeeder, 
         // Assert
         if (expectedSeedCount > 0)
         {
-            _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Easy, expectedSeedCount);
-            _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Medium, expectedSeedCount);
-            _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Hard, expectedSeedCount);
-            _mockPuzzlePoolService.VerifySeedCalledOnce(GameDifficulty.Expert, expectedSeedCount);
+            _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Nine, GameDifficulty.Easy, 1, expectedSeedCount);
         }
         else
         {
@@ -100,12 +102,32 @@ public class PuzzlePoolSeederTests : MoqBaseTestByAbstraction<PuzzlePoolSeeder, 
     }
 
     [Fact]
-    public async Task SeedPoolAsync_ReturnsTotalSeededAcrossAllDifficulties()
+    public async Task SeedPoolAsync_ForSixteenBySixteen_TargetsFivePerDifficultyAndLeavesFullPoolsAlone()
+    {
+        // Arrange — 9x9 pools already full; only Sixteen/Easy is short by 2 puzzles
+        SetupAllCounts(nineCount: TargetPoolSizeNine, sixteenCount: TargetPoolSizeSixteen);
+        _mockPuzzlePoolService.SetupGetAvailableCountReturns(BoardSize.Sixteen, GameDifficulty.Easy, TargetPoolSizeSixteen - 2);
+
+        var sut = ResolveSut();
+
+        // Act
+        await sut.SeedPoolAsync();
+
+        // Assert
+        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Sixteen, GameDifficulty.Easy, 1, 2);
+        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Sixteen, GameDifficulty.Medium, 1, 0);
+        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Sixteen, GameDifficulty.Hard, 1, 0);
+        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Sixteen, GameDifficulty.Expert, 1, 0);
+        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Nine, GameDifficulty.Easy, 1, 0);
+    }
+
+    [Fact]
+    public async Task SeedPoolAsync_ReturnsTotalSeededAcrossAllCombinations()
     {
         // Arrange
-        var currentCount = 7;
-        var expectedTotal = (TargetPoolSize - currentCount) * 4; // four difficulties
-        _mockPuzzlePoolService.SetupGetAvailableCountReturns(currentCount);
+        var nineCurrentCount = 8;
+        var expectedTotal = (TargetPoolSizeNine - nineCurrentCount) * 4;
+        SetupAllCounts(nineCount: nineCurrentCount, sixteenCount: TargetPoolSizeSixteen);
 
         var sut = ResolveSut();
 
@@ -114,5 +136,17 @@ public class PuzzlePoolSeederTests : MoqBaseTestByAbstraction<PuzzlePoolSeeder, 
 
         // Assert
         totalSeeded.Should().Be(expectedTotal);
+    }
+
+    private void SetupAllCounts(int nineCount, int sixteenCount)
+    {
+        _mockPuzzlePoolService.SetupGetAvailableCountReturns(BoardSize.Nine, GameDifficulty.Easy, nineCount);
+        _mockPuzzlePoolService.SetupGetAvailableCountReturns(BoardSize.Nine, GameDifficulty.Medium, nineCount);
+        _mockPuzzlePoolService.SetupGetAvailableCountReturns(BoardSize.Nine, GameDifficulty.Hard, nineCount);
+        _mockPuzzlePoolService.SetupGetAvailableCountReturns(BoardSize.Nine, GameDifficulty.Expert, nineCount);
+        _mockPuzzlePoolService.SetupGetAvailableCountReturns(BoardSize.Sixteen, GameDifficulty.Easy, sixteenCount);
+        _mockPuzzlePoolService.SetupGetAvailableCountReturns(BoardSize.Sixteen, GameDifficulty.Medium, sixteenCount);
+        _mockPuzzlePoolService.SetupGetAvailableCountReturns(BoardSize.Sixteen, GameDifficulty.Hard, sixteenCount);
+        _mockPuzzlePoolService.SetupGetAvailableCountReturns(BoardSize.Sixteen, GameDifficulty.Expert, sixteenCount);
     }
 }

--- a/src/backend/Tests/Functions/PuzzleReplenishFunctionTests.cs
+++ b/src/backend/Tests/Functions/PuzzleReplenishFunctionTests.cs
@@ -22,29 +22,33 @@ public class PuzzleReplenishFunctionTests : MoqBaseTestByType<PuzzleReplenishFun
     }
 
     [Theory]
-    [InlineData("easy", "Easy")]
-    [InlineData("medium", "Medium")]
-    [InlineData("hard", "Hard")]
-    [InlineData("expert", "Expert")]
-    public async Task Run_WithValidBlobPath_ParsesDifficultyAndSeedsOneReplacement(string difficultyPrefix, string expectedDifficultyName)
+    [InlineData("9x9", "easy", "Easy")]
+    [InlineData("9x9", "medium", "Medium")]
+    [InlineData("9x9", "hard", "Hard")]
+    [InlineData("9x9", "expert", "Expert")]
+    [InlineData("16x16", "easy", "Easy")]
+    [InlineData("16x16", "expert", "Expert")]
+    public async Task Run_WithValidBlobPath_ParsesSizeAndDifficultyAndSeedsOneReplacement(
+        string sizeSegment, string difficultyPrefix, string expectedDifficultyName)
     {
         // Arrange
+        var expectedSize = BoardSize.FromValue(int.Parse(sizeSegment.Split('x')[0]));
         var expectedDifficulty = GameDifficulty.FromName(expectedDifficultyName);
-        var subject = $"/blobServices/default/containers/sudoku-puzzles/blobs/{difficultyPrefix}/{Guid.NewGuid()}.json";
+        var subject = $"/blobServices/default/containers/sudoku-puzzles/blobs/{sizeSegment}/{difficultyPrefix}/{Guid.NewGuid()}.json";
         var eventGridEvent = CreateEventGridEvent(subject);
 
         // Act
         await _sut.Run(eventGridEvent);
 
         // Assert
-        _mockPuzzlePoolService.VerifySeedCalledOnce(expectedDifficulty, 1);
+        _mockPuzzlePoolService.VerifySeedCalledOnce(expectedSize, expectedDifficulty, 1);
     }
 
     [Fact]
     public async Task Run_WithUnknownDifficultyName_DoesNotSeed()
     {
         // Arrange
-        var subject = "/blobServices/default/containers/sudoku-puzzles/blobs/unknown/puzzle.json";
+        var subject = "/blobServices/default/containers/sudoku-puzzles/blobs/9x9/unknown/puzzle.json";
         var eventGridEvent = CreateEventGridEvent(subject);
 
         // Act
@@ -58,7 +62,7 @@ public class PuzzleReplenishFunctionTests : MoqBaseTestByType<PuzzleReplenishFun
     public async Task Run_WithUnknownDifficultyName_LogsWarning()
     {
         // Arrange
-        var subject = "/blobServices/default/containers/sudoku-puzzles/blobs/unknown/puzzle.json";
+        var subject = "/blobServices/default/containers/sudoku-puzzles/blobs/9x9/unknown/puzzle.json";
         var eventGridEvent = CreateEventGridEvent(subject);
 
         // Act
@@ -66,6 +70,34 @@ public class PuzzleReplenishFunctionTests : MoqBaseTestByType<PuzzleReplenishFun
 
         // Assert
         Logger.WarningLogs().AssertContains("Unknown difficulty");
+    }
+
+    [Fact]
+    public async Task Run_WithUnknownSizeSegment_DoesNotSeed()
+    {
+        // Arrange
+        var subject = "/blobServices/default/containers/sudoku-puzzles/blobs/25x25/easy/puzzle.json";
+        var eventGridEvent = CreateEventGridEvent(subject);
+
+        // Act
+        await _sut.Run(eventGridEvent);
+
+        // Assert
+        _mockPuzzlePoolService.VerifySeedNeverCalled();
+    }
+
+    [Fact]
+    public async Task Run_WithUnknownSizeSegment_LogsWarning()
+    {
+        // Arrange
+        var subject = "/blobServices/default/containers/sudoku-puzzles/blobs/25x25/easy/puzzle.json";
+        var eventGridEvent = CreateEventGridEvent(subject);
+
+        // Act
+        await _sut.Run(eventGridEvent);
+
+        // Assert
+        Logger.WarningLogs().AssertContains("Unknown board size");
     }
 
     [Fact]

--- a/src/backend/Tests/Functions/PuzzleReplenishFunctionTests.cs
+++ b/src/backend/Tests/Functions/PuzzleReplenishFunctionTests.cs
@@ -122,8 +122,57 @@ public class PuzzleReplenishFunctionTests : MoqBaseTestByType<PuzzleReplenishFun
         // Act
         await _sut.Run(eventGridEvent);
 
+        // Assert: the leading "/" makes the first path segment empty, so the board-size
+        // segment is what's actually missing here, not the difficulty. Prior to this fix the
+        // warning always blamed "difficulty" regardless of which segment was actually absent.
+        Logger.WarningLogs().AssertContains("Could not parse board size from event subject: /no-blobs-segment/here");
+    }
+
+    [Fact]
+    public async Task Run_WithMissingDifficultySegment_LogsDifficultySpecificWarning()
+    {
+        // Arrange
+        var eventGridEvent = CreateEventGridEvent("/blobServices/default/containers/sudoku-puzzles/blobs/9x9");
+
+        // Act
+        await _sut.Run(eventGridEvent);
+
         // Assert
-        Logger.WarningLogs().AssertContains("Could not parse difficulty from event subject: /no-blobs-segment/here");
+        Logger.WarningLogs().AssertContains("Could not parse difficulty from event subject");
+    }
+
+    [Theory]
+    [InlineData("16")]
+    [InlineData("16x9")]
+    [InlineData("16x16x16")]
+    public async Task Run_WithMalformedSizeSegment_DoesNotSeed(string sizeSegment)
+    {
+        // Arrange
+        var subject = $"/blobServices/default/containers/sudoku-puzzles/blobs/{sizeSegment}/easy/puzzle.json";
+        var eventGridEvent = CreateEventGridEvent(subject);
+
+        // Act
+        await _sut.Run(eventGridEvent);
+
+        // Assert
+        _mockPuzzlePoolService.VerifySeedNeverCalled();
+    }
+
+    [Theory]
+    [InlineData("16")]
+    [InlineData("16x9")]
+    [InlineData("16x16x16")]
+    public async Task Run_WithMalformedSizeSegment_LogsWarning(string sizeSegment)
+    {
+        // Arrange
+        var subject = $"/blobServices/default/containers/sudoku-puzzles/blobs/{sizeSegment}/easy/puzzle.json";
+        var eventGridEvent = CreateEventGridEvent(subject);
+
+        // Act
+        await _sut.Run(eventGridEvent);
+
+        // Assert
+        Logger.WarningLogs().AssertContains("Unknown board size");
     }
 
     private static EventGridEvent CreateEventGridEvent(string subject) =>

--- a/src/backend/Tests/Infrastructure/EventHandling/GameCompletedEventHandlerTests.cs
+++ b/src/backend/Tests/Infrastructure/EventHandling/GameCompletedEventHandlerTests.cs
@@ -28,7 +28,8 @@ public class GameCompletedEventHandlerTests : MoqBaseTestByAbstraction<GameCompl
             domainEvent.ProfileId.ToString(),
             "Hard",
             TimeSpan.FromMinutes(12),
-            domainEvent.CompletedAt);
+            domainEvent.CompletedAt,
+            domainEvent.Size.Size);
         var sut = ResolveSut();
 
         // Act

--- a/src/backend/Tests/Infrastructure/Mappers/SudokuGameMapperTests.cs
+++ b/src/backend/Tests/Infrastructure/Mappers/SudokuGameMapperTests.cs
@@ -1,4 +1,5 @@
 using DepenMock.Attributes;
+using Sudoku.Domain.Exceptions;
 using Sudoku.Domain.ValueObjects;
 using Sudoku.Infrastructure.Mappers;
 using Sudoku.Infrastructure.Models;
@@ -44,5 +45,71 @@ public class SudokuGameMapperTests : MoqBaseTestByType<SudokuGameDocument>
         restored.GetCell(row, column).IsHint.Should().BeTrue();
         restored.Statistics.HintsUsed.Should().Be(1);
         restored.Statistics.HintsRemainingFor(restored.Size).Should().Be(game.Statistics.HintsRemainingFor(game.Size));
+    }
+
+    [Fact]
+    public void ToDomain_WhenDocumentGridSizePropertyNeverSet_DefaultsToNine()
+    {
+        // Arrange — GridSize is left at its property initializer, matching a document written
+        // before FR-10 introduced the property (Newtonsoft keeps the initializer when absent).
+        var document = CreateDocumentForSize(BoardSize.Nine);
+
+        // Act
+        var restored = SudokuGameMapper.ToDomain(document);
+
+        // Assert
+        restored.Size.Should().Be(BoardSize.Nine);
+    }
+
+    [Fact]
+    public void ToDomain_WhenDocumentGridSizeIsSixteen_ReconstitutesAsSixteenBySixteen()
+    {
+        // Arrange
+        var document = CreateDocumentForSize(BoardSize.Sixteen);
+
+        // Act
+        var restored = SudokuGameMapper.ToDomain(document);
+
+        // Assert
+        restored.Size.Should().Be(BoardSize.Sixteen);
+        restored.GetCells().Should().HaveCount(BoardSize.Sixteen.CellCount);
+    }
+
+    [Fact]
+    public void ToDomain_WhenGridSizeDisagreesWithCellCount_Throws()
+    {
+        // Arrange — GridSize claims 16x16 but the cell collection is still 9x9-sized (81 cells)
+        var game = GameFactory.CreateGameWithDifficulty(GameDifficulty.Easy);
+        var document = SudokuGameMapper.ToDocument(game);
+        document.GridSize = 16;
+
+        // Act
+        var act = () => SudokuGameMapper.ToDomain(document);
+
+        // Assert
+        act.Should().Throw<InvalidPuzzleException>();
+    }
+
+    private static SudokuGameDocument CreateDocumentForSize(BoardSize size)
+    {
+        var cells = new List<CellDocument>();
+        for (var row = 0; row < size.Size; row++)
+        {
+            for (var column = 0; column < size.Size; column++)
+            {
+                cells.Add(new CellDocument { Row = row, Column = column, Value = null, IsFixed = false });
+            }
+        }
+
+        return new SudokuGameDocument
+        {
+            Id = Guid.NewGuid().ToString(),
+            GameId = Guid.NewGuid().ToString(),
+            ProfileId = Guid.NewGuid().ToString(),
+            DisplayName = "Player",
+            Difficulty = GameDifficulty.Easy.Name,
+            GridSize = size.Size,
+            Cells = cells
+        };
     }
 }

--- a/src/backend/Tests/Infrastructure/Models/GridSizeBackCompatTests.cs
+++ b/src/backend/Tests/Infrastructure/Models/GridSizeBackCompatTests.cs
@@ -1,0 +1,177 @@
+using Newtonsoft.Json;
+using Sudoku.Infrastructure.Models;
+
+namespace UnitTests.Infrastructure.Models;
+
+/// <summary>
+/// Guards the zero-migration back-compat guarantee (FR-10): every pre-existing Cosmos/blob
+/// document was written before the <c>gridSize</c> property existed, so it must still
+/// deserialize as a 9x9 document. These fixtures are literal JSON strings shaped like the
+/// documents actually written pre-change — not round-tripped through the current serializer —
+/// so they fail if the <c>GridSize</c> initializer default (9) is ever removed or renamed.
+/// </summary>
+public class GridSizeBackCompatTests
+{
+    [Fact]
+    public void SudokuGameDocument_WhenGridSizeAbsentFromJson_DeserializesAsNine()
+    {
+        // Arrange
+        const string json = """
+            {
+              "id": "11111111-1111-1111-1111-111111111111",
+              "gameId": "11111111-1111-1111-1111-111111111111",
+              "profileId": "22222222-2222-2222-2222-222222222222",
+              "displayName": "Player One",
+              "difficulty": "Easy",
+              "status": 1,
+              "cells": [],
+              "statistics": {
+                "totalMoves": 0,
+                "validMoves": 0,
+                "invalidMoves": 0,
+                "hintsUsed": 0,
+                "playDuration": "00:00:00",
+                "lastMoveAt": null
+              },
+              "moveHistory": [],
+              "createdAt": "2025-01-01T00:00:00Z",
+              "startedAt": null,
+              "completedAt": null,
+              "pausedAt": null
+            }
+            """;
+
+        // Act
+        var document = JsonConvert.DeserializeObject<SudokuGameDocument>(json);
+
+        // Assert
+        document.Should().NotBeNull();
+        document!.GridSize.Should().Be(9);
+    }
+
+    [Fact]
+    public void SudokuGameDocument_WhenGridSizeSixteenPresentInJson_DeserializesAsSixteen()
+    {
+        // Arrange
+        const string json = """
+            {
+              "id": "11111111-1111-1111-1111-111111111111",
+              "gameId": "11111111-1111-1111-1111-111111111111",
+              "profileId": "22222222-2222-2222-2222-222222222222",
+              "displayName": "Player One",
+              "difficulty": "Easy",
+              "gridSize": 16,
+              "status": 1,
+              "cells": [],
+              "statistics": {
+                "totalMoves": 0,
+                "validMoves": 0,
+                "invalidMoves": 0,
+                "hintsUsed": 0,
+                "playDuration": "00:00:00",
+                "lastMoveAt": null
+              },
+              "moveHistory": [],
+              "createdAt": "2025-01-01T00:00:00Z",
+              "startedAt": null,
+              "completedAt": null,
+              "pausedAt": null
+            }
+            """;
+
+        // Act
+        var document = JsonConvert.DeserializeObject<SudokuGameDocument>(json);
+
+        // Assert
+        document.Should().NotBeNull();
+        document!.GridSize.Should().Be(16);
+    }
+
+    [Fact]
+    public void SudokuPuzzleDocument_WhenGridSizeAbsentFromJson_DeserializesAsNine()
+    {
+        // Arrange
+        const string json = """
+            {
+              "PuzzleId": "puzzle-1",
+              "Difficulty": "easy",
+              "Cells": []
+            }
+            """;
+
+        // Act
+        var document = JsonConvert.DeserializeObject<SudokuPuzzleDocument>(json);
+
+        // Assert
+        document.Should().NotBeNull();
+        document!.GridSize.Should().Be(9);
+    }
+
+    [Fact]
+    public void SudokuPuzzleDocument_WhenGridSizeSixteenPresentInJson_DeserializesAsSixteen()
+    {
+        // Arrange
+        const string json = """
+            {
+              "PuzzleId": "puzzle-1",
+              "Difficulty": "easy",
+              "GridSize": 16,
+              "Cells": []
+            }
+            """;
+
+        // Act
+        var document = JsonConvert.DeserializeObject<SudokuPuzzleDocument>(json);
+
+        // Assert
+        document.Should().NotBeNull();
+        document!.GridSize.Should().Be(16);
+    }
+
+    [Fact]
+    public void GameCompletionDocument_WhenGridSizeAbsentFromJson_DeserializesAsNine()
+    {
+        // Arrange
+        const string json = """
+            {
+              "id": "11111111-1111-1111-1111-111111111111",
+              "gameId": "11111111-1111-1111-1111-111111111111",
+              "profileId": "22222222-2222-2222-2222-222222222222",
+              "difficulty": "Easy",
+              "playDuration": "00:12:00",
+              "completedAt": "2025-01-01T00:00:00Z"
+            }
+            """;
+
+        // Act
+        var document = JsonConvert.DeserializeObject<GameCompletionDocument>(json);
+
+        // Assert
+        document.Should().NotBeNull();
+        document!.GridSize.Should().Be(9);
+    }
+
+    [Fact]
+    public void GameCompletionDocument_WhenGridSizeSixteenPresentInJson_DeserializesAsSixteen()
+    {
+        // Arrange
+        const string json = """
+            {
+              "id": "11111111-1111-1111-1111-111111111111",
+              "gameId": "11111111-1111-1111-1111-111111111111",
+              "profileId": "22222222-2222-2222-2222-222222222222",
+              "difficulty": "Easy",
+              "gridSize": 16,
+              "playDuration": "00:12:00",
+              "completedAt": "2025-01-01T00:00:00Z"
+            }
+            """;
+
+        // Act
+        var document = JsonConvert.DeserializeObject<GameCompletionDocument>(json);
+
+        // Assert
+        document.Should().NotBeNull();
+        document!.GridSize.Should().Be(16);
+    }
+}

--- a/src/backend/Tests/Infrastructure/Models/GridSizeBackCompatTests.cs
+++ b/src/backend/Tests/Infrastructure/Models/GridSizeBackCompatTests.cs
@@ -1,5 +1,6 @@
-using Newtonsoft.Json;
+using System.Text.Json;
 using Sudoku.Infrastructure.Models;
+using JsonConvert = Newtonsoft.Json.JsonConvert;
 
 namespace UnitTests.Infrastructure.Models;
 
@@ -87,20 +88,30 @@ public class GridSizeBackCompatTests
         document!.GridSize.Should().Be(16);
     }
 
+    // SudokuPuzzleDocument is blob-stored via AzureStorageService, which serializes with
+    // System.Text.Json using JsonNamingPolicy.CamelCase (not Newtonsoft, and not PascalCase) --
+    // see AzureStorageService's _jsonOptions. These two fixtures deserialize with the same
+    // serializer/options and camelCase keys so they are representative of a real stored blob,
+    // rather than merely proving Newtonsoft's case-insensitive matching happens to also work.
+    private static readonly JsonSerializerOptions BlobJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
     [Fact]
     public void SudokuPuzzleDocument_WhenGridSizeAbsentFromJson_DeserializesAsNine()
     {
         // Arrange
         const string json = """
             {
-              "PuzzleId": "puzzle-1",
-              "Difficulty": "easy",
-              "Cells": []
+              "puzzleId": "puzzle-1",
+              "difficulty": "easy",
+              "cells": []
             }
             """;
 
         // Act
-        var document = JsonConvert.DeserializeObject<SudokuPuzzleDocument>(json);
+        var document = JsonSerializer.Deserialize<SudokuPuzzleDocument>(json, BlobJsonOptions);
 
         // Assert
         document.Should().NotBeNull();
@@ -113,15 +124,15 @@ public class GridSizeBackCompatTests
         // Arrange
         const string json = """
             {
-              "PuzzleId": "puzzle-1",
-              "Difficulty": "easy",
-              "GridSize": 16,
-              "Cells": []
+              "puzzleId": "puzzle-1",
+              "difficulty": "easy",
+              "gridSize": 16,
+              "cells": []
             }
             """;
 
         // Act
-        var document = JsonConvert.DeserializeObject<SudokuPuzzleDocument>(json);
+        var document = JsonSerializer.Deserialize<SudokuPuzzleDocument>(json, BlobJsonOptions);
 
         // Assert
         document.Should().NotBeNull();

--- a/src/backend/Tests/Infrastructure/Repositories/AzureBlobPuzzleRepositoryTests.cs
+++ b/src/backend/Tests/Infrastructure/Repositories/AzureBlobPuzzleRepositoryTests.cs
@@ -32,14 +32,14 @@ public class AzureBlobPuzzleRepositoryTests : MoqBaseTestByAbstraction<AzureBlob
         // Arrange
         var difficulty = GameDifficulty.Easy;
         var puzzle = PuzzleFactory.GetPuzzle(difficulty);
-        var expectedBlobName = $"{difficulty.Name.ToLowerInvariant()}/{puzzle.PuzzleId}.json";
+        var expectedBlobName = $"9x9/{difficulty.Name.ToLowerInvariant()}/{puzzle.PuzzleId}.json";
 
         _mockPuzzleGenerator
             .Setup(x => x.GeneratePuzzleAsync(difficulty, BoardSize.Nine))
             .ReturnsAsync(puzzle);
 
         // Act
-        var result = await _sut.CreateAsync(difficulty);
+        var result = await _sut.CreateAsync(difficulty, BoardSize.Nine);
 
         // Assert
         result.Should().NotBeNull();
@@ -57,10 +57,27 @@ public class AzureBlobPuzzleRepositoryTests : MoqBaseTestByAbstraction<AzureBlob
         _mockPuzzleGenerator.SetupGeneratePuzzleAsyncReturns(puzzle);
 
         // Act
-        await _sut.CreateAsync(difficulty);
+        await _sut.CreateAsync(difficulty, BoardSize.Nine);
 
         // Assert
-        _mockStorageService.VerifySavesBlobCheckUsingPartialName<SudokuPuzzleDocument>(PuzzleContainer, "expert/");
+        _mockStorageService.VerifySavesBlobCheckUsingPartialName<SudokuPuzzleDocument>(PuzzleContainer, "9x9/expert/");
+    }
+
+    [Fact]
+    public async Task CreateAsync_ForSixteenBySixteen_SavesBlobWithSizePrefix()
+    {
+        // Arrange
+        var difficulty = GameDifficulty.Easy;
+        var puzzle = PuzzleFactory.GetPuzzle(GameDifficulty.Easy);
+        _mockPuzzleGenerator
+            .Setup(x => x.GeneratePuzzleAsync(difficulty, BoardSize.Sixteen))
+            .ReturnsAsync(puzzle);
+
+        // Act
+        await _sut.CreateAsync(difficulty, BoardSize.Sixteen);
+
+        // Assert
+        _mockStorageService.VerifySavesBlobCheckUsingPartialName<SudokuPuzzleDocument>(PuzzleContainer, "16x16/easy/");
     }
 
     [Fact]

--- a/src/backend/Tests/Infrastructure/Repositories/CosmosDbGameRepositoryTests.cs
+++ b/src/backend/Tests/Infrastructure/Repositories/CosmosDbGameRepositoryTests.cs
@@ -92,7 +92,7 @@ public class CosmosDbGameRepositoryTests : MoqBaseTestByAbstraction<CosmosDbGame
             DisplayName = displayName.Value,
             Difficulty = difficulty,
             Status = GameStatusEnum.NotStarted,
-            Cells = [],
+            Cells = CreateNineByNineCells(),
             CreatedAt = DateTime.UtcNow
         };
         _mockCosmosDbService.GetItemReturnsDocument(gameId, gameDocument);
@@ -125,7 +125,7 @@ public class CosmosDbGameRepositoryTests : MoqBaseTestByAbstraction<CosmosDbGame
                 DisplayName = displayName.Value,
                 Difficulty = GameDifficulty.Easy,
                 Status = GameStatusEnum.NotStarted,
-                Cells = [],
+                Cells = CreateNineByNineCells(),
                 CreatedAt = DateTime.UtcNow.AddMinutes(-10)
             },
             new()
@@ -136,7 +136,7 @@ public class CosmosDbGameRepositoryTests : MoqBaseTestByAbstraction<CosmosDbGame
                 DisplayName = displayName.Value,
                 Difficulty = GameDifficulty.Medium,
                 Status = GameStatusEnum.InProgress,
-                Cells = [],
+                Cells = CreateNineByNineCells(),
                 CreatedAt = DateTime.UtcNow
             }
         };
@@ -256,5 +256,19 @@ public class CosmosDbGameRepositoryTests : MoqBaseTestByAbstraction<CosmosDbGame
         // Assert
         await saveAsync.Should().ThrowAsync<InvalidOperationException>();
         _mockEventDispatcher.VerifyDispatched<GameCreatedEvent>(Times.Never);
+    }
+
+    private static List<CellDocument> CreateNineByNineCells()
+    {
+        var cells = new List<CellDocument>();
+        for (var row = 0; row < 9; row++)
+        {
+            for (var column = 0; column < 9; column++)
+            {
+                cells.Add(new CellDocument { Row = row, Column = column, Value = null, IsFixed = false });
+            }
+        }
+
+        return cells;
     }
 }

--- a/src/backend/Tests/Infrastructure/Services/PuzzlePoolServiceTests.cs
+++ b/src/backend/Tests/Infrastructure/Services/PuzzlePoolServiceTests.cs
@@ -28,7 +28,7 @@ public class PuzzlePoolServiceTests : MoqBaseTestByAbstraction<PuzzlePoolService
         var sut = ResolveSut();
 
         // Act
-        var result = await sut.GetAvailableCountAsync(difficulty);
+        var result = await sut.GetAvailableCountAsync(BoardSize.Nine, difficulty);
 
         // Assert
         result.Should().Be(2);
@@ -45,10 +45,28 @@ public class PuzzlePoolServiceTests : MoqBaseTestByAbstraction<PuzzlePoolService
         var sut = ResolveSut();
 
         // Act
-        var result = await sut.GetAvailableCountAsync(difficulty);
+        var result = await sut.GetAvailableCountAsync(BoardSize.Nine, difficulty);
 
         // Assert
         result.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetAvailableCountAsync_UsesSizeAndDifficultyPrefix()
+    {
+        // Arrange
+        var difficulty = GameDifficulty.Hard;
+        var expectedPrefix = "16x16/hard";
+
+        _mockBlobStorage.SetupGetPuzzleIdsAsyncReturns(["id1"]);
+
+        var sut = ResolveSut();
+
+        // Act
+        await sut.GetAvailableCountAsync(BoardSize.Sixteen, difficulty);
+
+        // Assert
+        _mockBlobStorage.VerifyGetPuzzleIdsAsyncCalledWith(expectedPrefix);
     }
 
     [Fact]
@@ -64,10 +82,10 @@ public class PuzzlePoolServiceTests : MoqBaseTestByAbstraction<PuzzlePoolService
         var sut = ResolveSut();
 
         // Act
-        await sut.SeedAsync(difficulty, count);
+        await sut.SeedAsync(BoardSize.Nine, difficulty, count);
 
         // Assert
-        _mockBlobStorage.VerifyCreateAsyncCalledExactly(difficulty, count);
+        _mockBlobStorage.VerifyCreateAsyncCalledExactly(difficulty, BoardSize.Nine, count);
     }
 
     [Fact]
@@ -78,10 +96,28 @@ public class PuzzlePoolServiceTests : MoqBaseTestByAbstraction<PuzzlePoolService
         var sut = ResolveSut();
 
         // Act
-        await sut.SeedAsync(difficulty, 0);
+        await sut.SeedAsync(BoardSize.Nine, difficulty, 0);
 
         // Assert
         _mockBlobStorage.VerifyCreateAsyncNeverCalled();
+    }
+
+    [Fact]
+    public async Task SeedAsync_ForSixteenBySixteen_PassesSizeToBlobStorage()
+    {
+        // Arrange
+        var difficulty = GameDifficulty.Hard;
+        var puzzle = PuzzleFactory.GetPuzzle(difficulty);
+
+        _mockBlobStorage.SetupCreateAsyncReturns(puzzle);
+
+        var sut = ResolveSut();
+
+        // Act
+        await sut.SeedAsync(BoardSize.Sixteen, difficulty, 1);
+
+        // Assert
+        _mockBlobStorage.VerifyCreateAsyncCalledExactly(difficulty, BoardSize.Sixteen, 1);
     }
 
     [Fact]
@@ -90,7 +126,7 @@ public class PuzzlePoolServiceTests : MoqBaseTestByAbstraction<PuzzlePoolService
         // Arrange
         var difficulty = GameDifficulty.Easy;
         var puzzleId = Guid.NewGuid().ToString();
-        var prefix = difficulty.Name.ToLowerInvariant();
+        var prefix = $"9x9/{difficulty.Name.ToLowerInvariant()}";
         var puzzle = PuzzleFactory.GetPuzzle(difficulty);
 
         _mockBlobStorage.SetupGetPuzzleIdsAsyncReturns([puzzleId]);
@@ -99,7 +135,7 @@ public class PuzzlePoolServiceTests : MoqBaseTestByAbstraction<PuzzlePoolService
         var sut = ResolveSut();
 
         // Act
-        var result = await sut.DequeueAsync(difficulty);
+        var result = await sut.DequeueAsync(BoardSize.Nine, difficulty);
 
         // Assert
         result.Should().NotBeNull();
@@ -119,7 +155,7 @@ public class PuzzlePoolServiceTests : MoqBaseTestByAbstraction<PuzzlePoolService
         var sut = ResolveSut();
 
         // Act
-        var result = await sut.DequeueAsync(difficulty);
+        var result = await sut.DequeueAsync(BoardSize.Nine, difficulty);
 
         // Assert
         result.Should().BeNull();
@@ -133,7 +169,6 @@ public class PuzzlePoolServiceTests : MoqBaseTestByAbstraction<PuzzlePoolService
         // Arrange
         var difficulty = GameDifficulty.Hard;
         var puzzleId = Guid.NewGuid().ToString();
-        var prefix = difficulty.Name.ToLowerInvariant();
 
         _mockBlobStorage.SetupGetPuzzleIdsAsyncReturns([puzzleId]);
         _mockBlobStorage.SetupLoadAsyncReturnsNull();
@@ -141,10 +176,33 @@ public class PuzzlePoolServiceTests : MoqBaseTestByAbstraction<PuzzlePoolService
         var sut = ResolveSut();
 
         // Act
-        var result = await sut.DequeueAsync(difficulty);
+        var result = await sut.DequeueAsync(BoardSize.Nine, difficulty);
 
         // Assert
         result.Should().BeNull();
         _mockBlobStorage.VerifyDeleteAsyncNeverCalled();
+    }
+
+    [Fact]
+    public async Task DequeueAsync_ForSixteenBySixteen_UsesSizePrefix()
+    {
+        // Arrange
+        var difficulty = GameDifficulty.Expert;
+        var puzzleId = Guid.NewGuid().ToString();
+        var prefix = "16x16/expert";
+        var puzzle = PuzzleFactory.GetPuzzle(difficulty);
+
+        _mockBlobStorage.SetupGetPuzzleIdsAsyncReturns([puzzleId]);
+        _mockBlobStorage.SetupLoadAsyncReturns(puzzle);
+
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.DequeueAsync(BoardSize.Sixteen, difficulty);
+
+        // Assert
+        result.Should().NotBeNull();
+        _mockBlobStorage.VerifyLoadAsyncCalledOnce(prefix, puzzleId);
+        _mockBlobStorage.VerifyDeleteAsyncCalledOnce(prefix, puzzleId);
     }
 }

--- a/src/backend/Tests/Mocks/MockPuzzleBlobStorageExtensions.cs
+++ b/src/backend/Tests/Mocks/MockPuzzleBlobStorageExtensions.cs
@@ -10,7 +10,7 @@ public static class MockPuzzleBlobStorageExtensions
     {
         public void SetupCreateAsyncReturns(SudokuPuzzle puzzle)
         {
-            mock.Setup(x => x.CreateAsync(It.IsAny<GameDifficulty>()))
+            mock.Setup(x => x.CreateAsync(It.IsAny<GameDifficulty>(), It.IsAny<BoardSize>()))
                 .ReturnsAsync(puzzle);
         }
 
@@ -44,14 +44,14 @@ public static class MockPuzzleBlobStorageExtensions
                 .ReturnsAsync((SudokuPuzzle)null!);
         }
 
-        public void VerifyCreateAsyncCalledExactly(GameDifficulty difficulty, int times)
+        public void VerifyCreateAsyncCalledExactly(GameDifficulty difficulty, BoardSize size, int times)
         {
-            mock.Verify(x => x.CreateAsync(difficulty), Times.Exactly(times));
+            mock.Verify(x => x.CreateAsync(difficulty, size), Times.Exactly(times));
         }
 
         public void VerifyCreateAsyncNeverCalled()
         {
-            mock.Verify(x => x.CreateAsync(It.IsAny<GameDifficulty>()), Times.Never);
+            mock.Verify(x => x.CreateAsync(It.IsAny<GameDifficulty>(), It.IsAny<BoardSize>()), Times.Never);
         }
 
         public void VerifyDeleteAsyncCalledOnce(string prefix, string puzzleId)
@@ -72,6 +72,11 @@ public static class MockPuzzleBlobStorageExtensions
         public void VerifyLoadAsyncNeverCalled()
         {
             mock.Verify(x => x.LoadAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        }
+
+        public void VerifyGetPuzzleIdsAsyncCalledWith(string prefix)
+        {
+            mock.Verify(x => x.GetPuzzleIdsAsync(prefix), Times.Once);
         }
     }
 }

--- a/src/backend/Tests/Mocks/MockPuzzlePoolServiceExtensions.cs
+++ b/src/backend/Tests/Mocks/MockPuzzlePoolServiceExtensions.cs
@@ -11,52 +11,63 @@ public static class MockPuzzlePoolServiceExtensions
         public void SetupDequeueReturns(SudokuPuzzle? puzzle)
         {
             mock
-                .Setup(x => x.DequeueAsync(It.IsAny<GameDifficulty>()))
+                .Setup(x => x.DequeueAsync(It.IsAny<BoardSize>(), It.IsAny<GameDifficulty>()))
                 .ReturnsAsync(puzzle);
         }
 
         public void SetupDequeueReturnsEmpty()
         {
             mock
-                .Setup(x => x.DequeueAsync(It.IsAny<GameDifficulty>()))
+                .Setup(x => x.DequeueAsync(It.IsAny<BoardSize>(), It.IsAny<GameDifficulty>()))
                 .ReturnsAsync((SudokuPuzzle?)null);
         }
 
         public void SetupDequeueThrows(Exception ex)
         {
-            mock.Setup(x => x.DequeueAsync(It.IsAny<GameDifficulty>()))
+            mock.Setup(x => x.DequeueAsync(It.IsAny<BoardSize>(), It.IsAny<GameDifficulty>()))
                 .ThrowsAsync(ex);
         }
 
         public void SetupGetAvailableCountReturns(int count)
         {
-            mock.Setup(x => x.GetAvailableCountAsync(It.IsAny<GameDifficulty>()))
+            mock.Setup(x => x.GetAvailableCountAsync(It.IsAny<BoardSize>(), It.IsAny<GameDifficulty>()))
+                .ReturnsAsync(count);
+        }
+
+        public void SetupGetAvailableCountReturns(BoardSize size, GameDifficulty difficulty, int count)
+        {
+            mock.Setup(x => x.GetAvailableCountAsync(size, difficulty))
                 .ReturnsAsync(count);
         }
 
         public void VerifyDequeueCalledOnce()
         {
-            mock.Verify(x => x.DequeueAsync(It.IsAny<GameDifficulty>()), Times.Once);
+            mock.Verify(x => x.DequeueAsync(It.IsAny<BoardSize>(), It.IsAny<GameDifficulty>()), Times.Once);
         }
 
         public void VerifyDequeueNotCalled()
         {
-            mock.Verify(x => x.DequeueAsync(It.IsAny<GameDifficulty>()), Times.Never);
+            mock.Verify(x => x.DequeueAsync(It.IsAny<BoardSize>(), It.IsAny<GameDifficulty>()), Times.Never);
         }
 
-        public void VerifyGetAvailableCountCalledOnce(GameDifficulty difficulty)
+        public void VerifyGetAvailableCountCalledOnce(BoardSize size, GameDifficulty difficulty)
         {
-            mock.Verify(x => x.GetAvailableCountAsync(difficulty), Times.Once);
+            mock.Verify(x => x.GetAvailableCountAsync(size, difficulty), Times.Once);
         }
 
-        public void VerifySeedCalledOnce(GameDifficulty difficulty, int expectedCount)
+        public void VerifySeedCalledOnce(BoardSize size, GameDifficulty difficulty, int expectedCount)
         {
-            mock.Verify(x => x.SeedAsync(difficulty, expectedCount), Times.Once);
+            mock.Verify(x => x.SeedAsync(size, difficulty, expectedCount), Times.Once);
+        }
+
+        public void VerifySeedCalledTimes(BoardSize size, GameDifficulty difficulty, int expectedCount, int times)
+        {
+            mock.Verify(x => x.SeedAsync(size, difficulty, expectedCount), Times.Exactly(times));
         }
 
         public void VerifySeedNeverCalled()
         {
-            mock.Verify(x => x.SeedAsync(It.IsAny<GameDifficulty>(), It.IsAny<int>()), Times.Never);
+            mock.Verify(x => x.SeedAsync(It.IsAny<BoardSize>(), It.IsAny<GameDifficulty>(), It.IsAny<int>()), Times.Never);
         }
     }
 }


### PR DESCRIPTION
## Description

Phase 3 of 6 for the 16x16 Sudoku variant (see `docs/specs/spec-16x16-sudoku.md`). Adds a `gridSize` discriminator to the three persistence documents with a zero-migration back-compat guarantee, threads `BoardSize` through the game mapper, and gives the puzzle pool a size axis with a uniform blob path scheme.

This phase also reworks the pool seeder in direct response to the Phase 2 finding (#374) that 16x16 Hard/Expert generation is slow and seed-dependent (occasionally 5+ minutes per puzzle): it now generates one puzzle at a time with a time-budget check before each, instead of a per-difficulty batch call, so a single invocation can't blow through an Azure Functions consumption-plan timeout.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- `SudokuGameDocument`, `SudokuPuzzleDocument`, `GameCompletionDocument` gain `GridSize` defaulting to 9 (FR-10) — every pre-existing document deserializes as 9x9 with **no migration**
- `SudokuGameMapper.ToDomain` resolves `BoardSize.FromValue(document.GridSize)`, threads it through `Reconstitute` and cell reconstruction, and throws `InvalidPuzzleException` if the cell count disagrees with the declared size
- `GameCompletion` gains `GridSize`, threaded from `GameCreatedEvent`/`GameCompletedEvent`'s `Size` (added in Phase 1) through `GameCompletedEventHandler` and `DeleteGameCommandHandler`
- `IPuzzlePoolService`/`IPuzzleBlobStorage` gain a `BoardSize` parameter; blob pool paths become the uniform `{size}x{size}/{difficulty}/{puzzleId}.json` scheme for both sizes (FR-7) — legacy 9x9 pool blobs become orphaned as noted in the spec's own risk section, refilled by the seeder at the new path post-deploy
- `PuzzleReplenishFunction`'s Event Grid subject parsing updated to match the new path shape (extracts size from the first segment, difficulty from the second)
- `PuzzlePoolSeeder` restructured: iterates 8 `(size, difficulty)` combinations (9x9 targets 10/difficulty, 16x16 targets 5/difficulty per FR-9), seeding one puzzle at a time with a `Stopwatch`-checked 4-minute time budget before each — fast/cheap 9x9 combinations run first so a single invocation reliably tops those up even if it runs out of budget on slow 16x16 Hard/Expert

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

748/748 tests pass (up from 730 baseline on `main`), `dotnet build` clean. Added `GridSizeBackCompatTests.cs` — literal pre-change JSON fixtures (not round-tripped through the current serializer) proving `gridSize`-absent documents deserialize as 9x9 for all three document types, plus a `gridSize: 16` case for each.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)