### PR TITLE
Add rule: move completed specs to docs/specs/completed/

### DIFF
--- a/.claude/rules/spec-lifecycle.md
+++ b/.claude/rules/spec-lifecycle.md
@@ -1,0 +1,6 @@
+# Spec Lifecycle
+
+## Rules
+- Feature specs live in `docs/specs/` while being implemented.
+- Once a spec's implementation is fully merged to `main` (all phases/PRs for it are done), move the spec file into `docs/specs/completed/` in the same commit/PR that finishes the work — don't leave completed specs in the active `docs/specs/` root.
+- Move the file as-is (`git mv`); don't rewrite or summarize it on the way in.


### PR DESCRIPTION
## Description

Codifies an existing but undocumented convention — `docs/specs/completed/` already holds several finished specs — as a `.claude/rules/` entry so it's followed consistently for future spec-driven work (including the in-flight 16x16 Sudoku spec, once all its phases are merged).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- Added `.claude/rules/spec-lifecycle.md`: once a spec's implementation is fully merged, move the spec file into `docs/specs/completed/` in the same commit/PR, moved as-is via `git mv`

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

Documentation-only change, no code affected.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)