### PR TITLE
Phase 5/6: 16x16 React frontend support (16x16 Sudoku spec)

### DIFF
--- a/src/frontend/Sudoku.React/src/api/apiClient.ts
+++ b/src/frontend/Sudoku.React/src/api/apiClient.ts
@@ -73,8 +73,11 @@ export const apiClient = {
       headers: { 'Content-Type': 'application/json' },
     });
     if (!res.ok) {
+      // Retry-After can be delta-seconds ("30") or an HTTP-date; only the numeric
+      // form is meaningful here, so normalize anything else (including NaN) to undefined.
       const retryAfterHeader = res.headers.get('Retry-After');
-      const retryAfterSeconds = retryAfterHeader ? parseInt(retryAfterHeader, 10) : undefined;
+      const parsedRetryAfter = retryAfterHeader ? parseInt(retryAfterHeader, 10) : NaN;
+      const retryAfterSeconds = Number.isNaN(parsedRetryAfter) ? undefined : parsedRetryAfter;
       throw new ApiError(`HTTP ${res.status}: ${res.statusText}`, res.status, retryAfterSeconds);
     }
     const location = res.headers.get('Location');

--- a/src/frontend/Sudoku.React/src/api/apiClient.ts
+++ b/src/frontend/Sudoku.React/src/api/apiClient.ts
@@ -2,6 +2,23 @@ import type { GameModel, PlayerStatsModel, ProfileModel } from '../types';
 
 const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
 
+/**
+ * Preserves the HTTP status and `Retry-After` header of a failed request —
+ * needed by NewGamePage to distinguish a 503 pool-empty response (16x16) from
+ * other create-game failures.
+ */
+export class ApiError extends Error {
+  status: number;
+  retryAfterSeconds?: number;
+
+  constructor(message: string, status: number, retryAfterSeconds?: number) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   console.log(`BASE_URL: ${BASE_URL}, Requesting: ${path}`);
   const res = await fetch(`${BASE_URL}${path}`, {
@@ -50,12 +67,16 @@ export const apiClient = {
   deleteProfile: (alias: string): Promise<{ status: number; data: null }> =>
     requestWithStatus<null>(`/api/profiles/${encodeURIComponent(alias)}`, { method: 'DELETE' }),
 
-  createGame: async (profileId: string, difficulty: string): Promise<GameModel> => {
-    const res = await fetch(`${BASE_URL}/api/players/${profileId}/games/${difficulty}`, {
+  createGame: async (profileId: string, difficulty: string, size = 9): Promise<GameModel> => {
+    const res = await fetch(`${BASE_URL}/api/players/${profileId}/games/${difficulty}?size=${size}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
     });
-    if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+    if (!res.ok) {
+      const retryAfterHeader = res.headers.get('Retry-After');
+      const retryAfterSeconds = retryAfterHeader ? parseInt(retryAfterHeader, 10) : undefined;
+      throw new ApiError(`HTTP ${res.status}: ${res.statusText}`, res.status, retryAfterSeconds);
+    }
     const location = res.headers.get('Location');
     const gameId = location?.split('/').pop();
     if (!gameId) throw new Error('No Location header in createGame response');

--- a/src/frontend/Sudoku.React/src/components/CellInput.module.css
+++ b/src/frontend/Sudoku.React/src/components/CellInput.module.css
@@ -94,3 +94,22 @@
   align-items: center;
   justify-content: center;
 }
+
+/* 16x16 non-positional wrapped pencil marks — a positional 4x4 grid at ~30px
+   cell size is illegible, so only the noted candidates render as a compact
+   wrapped row of symbols. */
+.pencilValuesWrapped {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-content: center;
+  justify-content: center;
+  align-items: center;
+  gap: 1px;
+  pointer-events: none;
+  color: var(--ink-soft);
+  font-size: clamp(6px, 1.6vw, 7px);
+  font-weight: 500;
+  overflow: hidden;
+}

--- a/src/frontend/Sudoku.React/src/components/CellInput.test.tsx
+++ b/src/frontend/Sudoku.React/src/components/CellInput.test.tsx
@@ -67,3 +67,75 @@ describe('CellInput - editable cell', () => {
     expect(screen.queryByText('1')).not.toBeInTheDocument();
   });
 });
+
+describe('CellInput at size 16 (boxSize 4)', () => {
+  it('renders values 10-16 as letters A-G', () => {
+    const cell = makeCell({ isFixed: true, value: 16, hasValue: true });
+    render(<CellInput cell={cell} {...baseProps} size={16} boxSize={4} />);
+    expect(screen.getByRole('button')).toHaveTextContent('G');
+  });
+
+  it('renders noted candidates as a non-positional wrapped row, not a fixed 16-slot grid', () => {
+    const cell = makeCell({ isFixed: false, hasValue: false, possibleValues: [10, 3, 16] });
+    render(<CellInput cell={cell} {...baseProps} size={16} boxSize={4} />);
+    // Only the present candidates render — sorted ascending, as symbols.
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('G')).toBeInTheDocument();
+    // Absent values should not render an empty placeholder slot (unlike the 9x9 positional grid).
+    expect(screen.queryByText('1')).not.toBeInTheDocument();
+  });
+
+  it('places a box-right border at the end of each 4-column box, not the last column', () => {
+    const cell = makeCell({ row: 0, column: 3 });
+    render(<CellInput cell={cell} {...baseProps} size={16} boxSize={4} />);
+    expect(screen.getByRole('button').className).toMatch(/boxRight/);
+  });
+
+  it('places lastCol instead of boxRight on the final column', () => {
+    const cell = makeCell({ row: 0, column: 15 });
+    render(<CellInput cell={cell} {...baseProps} size={16} boxSize={4} />);
+    const className = screen.getByRole('button').className;
+    expect(className).toMatch(/lastCol/);
+    expect(className).not.toMatch(/boxRight/);
+  });
+
+  it('does not place a box-right border mid-box', () => {
+    const cell = makeCell({ row: 0, column: 1 });
+    render(<CellInput cell={cell} {...baseProps} size={16} boxSize={4} />);
+    expect(screen.getByRole('button').className).not.toMatch(/boxRight/);
+  });
+
+  it('places a box-bottom border at the end of each 4-row box, not the last row', () => {
+    const cell = makeCell({ row: 3, column: 0 });
+    render(<CellInput cell={cell} {...baseProps} size={16} boxSize={4} />);
+    expect(screen.getByRole('button').className).toMatch(/boxBottom/);
+  });
+
+  it('places lastRow instead of boxBottom on the final row', () => {
+    const cell = makeCell({ row: 15, column: 0 });
+    render(<CellInput cell={cell} {...baseProps} size={16} boxSize={4} />);
+    const className = screen.getByRole('button').className;
+    expect(className).toMatch(/lastRow/);
+    expect(className).not.toMatch(/boxBottom/);
+  });
+});
+
+describe('CellInput at size 9 (boxSize 3) box borders — unchanged positional behavior', () => {
+  it('places a box-right border at columns 2 and 5', () => {
+    [2, 5].forEach(column => {
+      const cell = makeCell({ row: 0, column });
+      const { unmount } = render(<CellInput cell={cell} {...baseProps} />);
+      expect(screen.getByRole('button').className).toMatch(/boxRight/);
+      unmount();
+    });
+  });
+
+  it('places lastCol, not boxRight, at column 8', () => {
+    const cell = makeCell({ row: 0, column: 8 });
+    render(<CellInput cell={cell} {...baseProps} />);
+    const className = screen.getByRole('button').className;
+    expect(className).toMatch(/lastCol/);
+    expect(className).not.toMatch(/boxRight/);
+  });
+});

--- a/src/frontend/Sudoku.React/src/components/CellInput.tsx
+++ b/src/frontend/Sudoku.React/src/components/CellInput.tsx
@@ -1,4 +1,5 @@
 import type { CellModel } from '../types';
+import { valueToSymbol } from '../utils/symbols';
 import styles from './CellInput.module.css';
 
 interface CellInputProps {
@@ -7,6 +8,8 @@ interface CellInputProps {
   isHighlighted: boolean;
   isSameNumber: boolean;
   isInvalid: boolean;
+  size?: number;
+  boxSize?: number;
   onSelect: () => void;
 }
 
@@ -16,16 +19,20 @@ export default function CellInput({
   isHighlighted,
   isSameNumber,
   isInvalid,
+  size = 9,
+  boxSize = 3,
   onSelect,
 }: CellInputProps) {
   const getCellClass = (): string => {
     const classes = [styles.cell];
 
-    // 3x3 box separators / outer edges
-    if (cell.column === 2 || cell.column === 5) classes.push(styles.boxRight);
-    if (cell.column === 8) classes.push(styles.lastCol);
-    if (cell.row === 2 || cell.row === 5) classes.push(styles.boxBottom);
-    if (cell.row === 8) classes.push(styles.lastRow);
+    // Box separators / outer edges, derived from boxSize
+    const isBoxRightCol = (cell.column + 1) % boxSize === 0 && cell.column !== size - 1;
+    const isBoxBottomRow = (cell.row + 1) % boxSize === 0 && cell.row !== size - 1;
+    if (isBoxRightCol) classes.push(styles.boxRight);
+    if (cell.column === size - 1) classes.push(styles.lastCol);
+    if (isBoxBottomRow) classes.push(styles.boxBottom);
+    if (cell.row === size - 1) classes.push(styles.lastRow);
 
     // Background fill precedence: selected > invalid > same-number > peer highlight
     if (isSelected) classes.push(styles.selected);
@@ -55,16 +62,28 @@ export default function CellInput({
     >
       {cell.hasValue && cell.value !== null ? (
         <span key={cell.value} className={`${styles.digit} ${digitClass} tnum`}>
-          {cell.value}
+          {valueToSymbol(cell.value)}
         </span>
       ) : showPencil ? (
-        <span className={styles.pencilValues}>
-          {[1, 2, 3, 4, 5, 6, 7, 8, 9].map(n => (
-            <span key={n} className={styles.pencilEntry}>
-              {cell.possibleValues.includes(n) ? n : ''}
-            </span>
-          ))}
-        </span>
+        size === 16 ? (
+          <span className={styles.pencilValuesWrapped}>
+            {[...cell.possibleValues]
+              .sort((a, b) => a - b)
+              .map(n => (
+                <span key={n} className={styles.pencilEntry}>
+                  {valueToSymbol(n)}
+                </span>
+              ))}
+          </span>
+        ) : (
+          <span className={styles.pencilValues}>
+            {[1, 2, 3, 4, 5, 6, 7, 8, 9].map(n => (
+              <span key={n} className={styles.pencilEntry}>
+                {cell.possibleValues.includes(n) ? valueToSymbol(n) : ''}
+              </span>
+            ))}
+          </span>
+        )
       ) : null}
     </button>
   );

--- a/src/frontend/Sudoku.React/src/components/GameBoard.module.css
+++ b/src/frontend/Sudoku.React/src/components/GameBoard.module.css
@@ -5,8 +5,8 @@
 
 .board {
   display: grid;
-  grid-template-columns: repeat(9, 1fr);
-  grid-template-rows: repeat(9, 1fr);
+  grid-template-columns: repeat(var(--grid-size, 9), 1fr);
+  grid-template-rows: repeat(var(--grid-size, 9), 1fr);
   width: 100%;
   max-width: 440px;
   aspect-ratio: 1 / 1;
@@ -15,6 +15,10 @@
   overflow: hidden;
   background-color: var(--surface);
   box-shadow: 0 10px 34px var(--shadow);
+}
+
+.boardLarge {
+  max-width: 640px;
 }
 
 .board:focus {

--- a/src/frontend/Sudoku.React/src/components/GameBoard.test.tsx
+++ b/src/frontend/Sudoku.React/src/components/GameBoard.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import GameBoard from './GameBoard';
-import { make81Cells, makeCell } from '../test/helpers';
+import { make81Cells, makeCell, makeCells } from '../test/helpers';
 
 function renderBoard(overrides: Partial<React.ComponentProps<typeof GameBoard>> = {}) {
   const defaults = {
@@ -46,5 +46,19 @@ describe('GameBoard', () => {
     renderBoard({ onKeyDown });
     fireEvent.keyDown(screen.getByRole('grid'), { key: '5' });
     expect(onKeyDown).toHaveBeenCalled();
+  });
+});
+
+describe('GameBoard at size 16', () => {
+  it('renders 256 cell buttons', () => {
+    renderBoard({ cells: makeCells(16), size: 16 });
+    expect(screen.getAllByRole('button')).toHaveLength(256);
+  });
+
+  it('renders letter-symbol cell values', () => {
+    const cells = makeCells(16);
+    cells[0] = makeCell({ row: 0, column: 0, value: 16, hasValue: true, isFixed: true });
+    renderBoard({ cells, size: 16 });
+    expect(screen.getByText('G')).toBeInTheDocument();
   });
 });

--- a/src/frontend/Sudoku.React/src/components/GameBoard.tsx
+++ b/src/frontend/Sudoku.React/src/components/GameBoard.tsx
@@ -1,5 +1,6 @@
-import { type KeyboardEvent } from 'react';
+import { type CSSProperties, type KeyboardEvent } from 'react';
 import type { CellModel } from '../types';
+import { getBoxSize } from '../utils/gameUtils';
 import CellInput from './CellInput';
 import styles from './GameBoard.module.css';
 
@@ -8,6 +9,7 @@ interface GameBoardProps {
   invalidCells: CellModel[];
   selectedCell: { row: number; column: number } | null;
   pencilMode: boolean;
+  size?: number;
   onCellSelect: (row: number, column: number) => void;
   onKeyDown: (e: KeyboardEvent<HTMLDivElement>) => void;
 }
@@ -16,11 +18,13 @@ export default function GameBoard({
   cells,
   invalidCells,
   selectedCell,
+  size = 9,
   onCellSelect,
   onKeyDown,
 }: GameBoardProps) {
-  const rows = Array.from({ length: 9 }, (_, i) => i);
-  const cols = Array.from({ length: 9 }, (_, i) => i);
+  const boxSize = getBoxSize(size);
+  const rows = Array.from({ length: size }, (_, i) => i);
+  const cols = Array.from({ length: size }, (_, i) => i);
 
   const selectedCellData = selectedCell
     ? cells.find(c => c.row === selectedCell.row && c.column === selectedCell.column)
@@ -32,8 +36,8 @@ export default function GameBoard({
     return (
       selectedCell.row === row ||
       selectedCell.column === col ||
-      (Math.floor(selectedCell.row / 3) === Math.floor(row / 3) &&
-        Math.floor(selectedCell.column / 3) === Math.floor(col / 3))
+      (Math.floor(selectedCell.row / boxSize) === Math.floor(row / boxSize) &&
+        Math.floor(selectedCell.column / boxSize) === Math.floor(col / boxSize))
     );
   };
 
@@ -46,9 +50,18 @@ export default function GameBoard({
     cell.value === selectedValue &&
     !(selectedCell?.row === cell.row && selectedCell?.column === cell.column);
 
+  const boardStyle = { '--grid-size': size, '--box-size': boxSize } as CSSProperties;
+  const boardClass = size === 16 ? `${styles.board} ${styles.boardLarge}` : styles.board;
+
   return (
     <div className={styles.boardOuter}>
-      <div className={styles.board} tabIndex={0} onKeyDown={onKeyDown} role="grid">
+      <div
+        className={boardClass}
+        style={boardStyle}
+        tabIndex={0}
+        onKeyDown={onKeyDown}
+        role="grid"
+      >
         {rows.map(r =>
           cols.map(c => {
             const cell = cells.find(cell => cell.row === r && cell.column === c);
@@ -57,6 +70,8 @@ export default function GameBoard({
               <CellInput
                 key={`${r}-${c}`}
                 cell={cell}
+                size={size}
+                boxSize={boxSize}
                 isSelected={selectedCell?.row === r && selectedCell?.column === c}
                 isHighlighted={isHighlighted(r, c)}
                 isSameNumber={isSameNumber(cell)}

--- a/src/frontend/Sudoku.React/src/components/GameControls.module.css
+++ b/src/frontend/Sudoku.React/src/components/GameControls.module.css
@@ -11,6 +11,19 @@
   gap: 6px;
 }
 
+/* Number pad: 16 keys, 8x2 on desktop, dropping to 4x4 on narrow viewports */
+.numberPad16 {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 6px;
+}
+
+@media (max-width: 480px) {
+  .numberPad16 {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
 .numBtn {
   flex: 1;
   display: flex;

--- a/src/frontend/Sudoku.React/src/components/GameControls.test.tsx
+++ b/src/frontend/Sudoku.React/src/components/GameControls.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import GameControls from './GameControls';
-import { make81Cells } from '../test/helpers';
+import { make81Cells, makeCells } from '../test/helpers';
 
 function renderControls(overrides: Partial<React.ComponentProps<typeof GameControls>> = {}) {
   const defaults = {
@@ -110,5 +110,42 @@ describe('GameControls', () => {
     renderControls({ onTogglePencil });
     await user.click(screen.getByRole('button', { name: /pencil/i }));
     expect(onTogglePencil).toHaveBeenCalledOnce();
+  });
+});
+
+describe('GameControls at size 16', () => {
+  it('renders 16 buttons with letter labels A-G for values 10-16', () => {
+    renderControls({ cells: makeCells(16), size: 16 });
+    for (let n = 1; n <= 9; n++) {
+      expect(screen.getByRole('button', { name: n.toString() })).toBeInTheDocument();
+    }
+    ['A', 'B', 'C', 'D', 'E', 'F', 'G'].forEach(letter => {
+      expect(screen.getByRole('button', { name: letter })).toBeInTheDocument();
+    });
+  });
+
+  it('does not render letter buttons at size 9', () => {
+    renderControls();
+    ['A', 'B', 'C', 'D', 'E', 'F', 'G'].forEach(letter => {
+      expect(screen.queryByRole('button', { name: letter })).not.toBeInTheDocument();
+    });
+  });
+
+  it('calls onNumberClick with the numeric value when a letter button is clicked', async () => {
+    const user = userEvent.setup();
+    const onNumberClick = vi.fn();
+    renderControls({ cells: makeCells(16), size: 16, onNumberClick });
+    await user.click(screen.getByRole('button', { name: 'G' }));
+    expect(onNumberClick).toHaveBeenCalledWith(16);
+  });
+
+  it('shows the remaining count out of 16 for a value', () => {
+    const cells = makeCells(16);
+    [0, 1, 2].forEach(i => {
+      cells[i] = { ...cells[i], value: 16, hasValue: true };
+    });
+    renderControls({ cells, size: 16 });
+    const gButton = screen.getByRole('button', { name: 'G' });
+    expect(gButton).toHaveTextContent('13');
   });
 });

--- a/src/frontend/Sudoku.React/src/components/GameControls.tsx
+++ b/src/frontend/Sudoku.React/src/components/GameControls.tsx
@@ -1,4 +1,5 @@
 import type { CellModel } from '../types';
+import { valueToSymbol, valuesForSize } from '../utils/symbols';
 import styles from './GameControls.module.css';
 
 interface GameControlsProps {
@@ -6,6 +7,7 @@ interface GameControlsProps {
   pencilMode: boolean;
   canUndo: boolean;
   hintsRemaining: number;
+  size?: number;
   onNumberClick: (value: number) => void;
   onErase: () => void;
   onUndo: () => void;
@@ -19,6 +21,7 @@ export default function GameControls({
   pencilMode,
   canUndo,
   hintsRemaining,
+  size = 9,
   onNumberClick,
   onErase,
   onUndo,
@@ -28,14 +31,17 @@ export default function GameControls({
 }: GameControlsProps) {
   const remainingFor = (n: number): number => {
     const placed = cells.filter(c => c.hasValue && c.value === n).length;
-    return 9 - placed;
+    return size - placed;
   };
+
+  const numberPadClass = size === 16 ? styles.numberPad16 : styles.numberPad;
 
   return (
     <div className={styles.controls}>
-      <div className={styles.numberPad}>
-        {[1, 2, 3, 4, 5, 6, 7, 8, 9].map(n => {
+      <div className={numberPadClass}>
+        {valuesForSize(size).map(n => {
           const remaining = remainingFor(n);
+          const symbol = valueToSymbol(n);
           return (
             <button
               key={n}
@@ -43,9 +49,9 @@ export default function GameControls({
               className={styles.numBtn}
               onClick={() => onNumberClick(n)}
               disabled={remaining <= 0}
-              aria-label={String(n)}
+              aria-label={symbol}
             >
-              <span className={styles.numDigit}>{n}</span>
+              <span className={styles.numDigit}>{symbol}</span>
               <span className={`${styles.numRemaining} tnum`}>{remaining}</span>
             </button>
           );

--- a/src/frontend/Sudoku.React/src/components/GameThumbnail.module.css
+++ b/src/frontend/Sudoku.React/src/components/GameThumbnail.module.css
@@ -11,8 +11,8 @@
 
 .sudokuThumbnail {
   display: grid;
-  grid-template-columns: repeat(9, 1fr);
-  grid-template-rows: repeat(9, 1fr);
+  grid-template-columns: repeat(var(--grid-size, 9), 1fr);
+  grid-template-rows: repeat(var(--grid-size, 9), 1fr);
   width: 88px;
   height: 88px;
   min-width: 88px;
@@ -23,6 +23,17 @@
   background-color: var(--surface);
   cursor: pointer;
   font-size: 7px;
+}
+
+/* 16x16 renders size x size with thinner lines and a smaller font — 256
+   cells at thumbnail scale need finer grid lines to stay legible. */
+.sudokuThumbnailLarge {
+  font-size: 4px;
+}
+
+.sudokuThumbnailLarge .cell {
+  border-right-width: 0.25px;
+  border-bottom-width: 0.25px;
 }
 
 .cell {

--- a/src/frontend/Sudoku.React/src/components/GameThumbnail.test.tsx
+++ b/src/frontend/Sudoku.React/src/components/GameThumbnail.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import GameThumbnail from './GameThumbnail';
-import { makeGame } from '../test/helpers';
+import { makeGame, makeCells } from '../test/helpers';
 
 describe('GameThumbnail', () => {
   it('renders an 81-cell grid', () => {
@@ -38,5 +38,28 @@ describe('GameThumbnail', () => {
     // At least one cell with value 8 should be visible
     const eights = screen.getAllByText('8');
     expect(eights.length).toBeGreaterThan(0);
+  });
+
+  it('renders a 256-cell grid for a 16x16 game', () => {
+    const game = makeGame({ cells: makeCells(16), size: 16 });
+    render(<GameThumbnail game={game} onSelect={() => {}} onDelete={() => {}} />);
+    const cells = document.querySelectorAll('[class*="cell"]');
+    expect(cells.length).toBeGreaterThanOrEqual(256);
+  });
+
+  it('renders letter symbols for values 10-16 on a 16x16 thumbnail', () => {
+    const game = makeGame({ cells: makeCells(16), size: 16 });
+    game.cells[0] = { ...game.cells[0], value: 16, hasValue: true };
+    render(<GameThumbnail game={game} onSelect={() => {}} onDelete={() => {}} />);
+    expect(screen.getAllByText('G').length).toBeGreaterThan(0);
+  });
+
+  it('falls back to deriving size from cell count for a legacy game object with no size field', () => {
+    const game = makeGame({ cells: makeCells(16), size: 16 });
+    // Simulate a cached game object that predates the `size` field.
+    const legacyGame = { ...game, size: undefined as unknown as number };
+    render(<GameThumbnail game={legacyGame} onSelect={() => {}} onDelete={() => {}} />);
+    const cells = document.querySelectorAll('[class*="cell"]');
+    expect(cells.length).toBeGreaterThanOrEqual(256);
   });
 });

--- a/src/frontend/Sudoku.React/src/components/GameThumbnail.tsx
+++ b/src/frontend/Sudoku.React/src/components/GameThumbnail.tsx
@@ -1,5 +1,8 @@
+import type { CSSProperties } from 'react';
 import type { GameModel } from '../types';
 import { formatDuration } from '../utils/timeUtils';
+import { deriveSize } from '../utils/gameUtils';
+import { valueToSymbol } from '../utils/symbols';
 import styles from './GameThumbnail.module.css';
 
 interface GameThumbnailProps {
@@ -9,15 +12,21 @@ interface GameThumbnailProps {
 }
 
 export default function GameThumbnail({ game, onSelect, onDelete }: GameThumbnailProps) {
-  const rows = Array.from({ length: 9 }, (_, r) => r);
-  const cols = Array.from({ length: 9 }, (_, c) => c);
+  const size = game.size ?? deriveSize(game.cells);
+  const rows = Array.from({ length: size }, (_, r) => r);
+  const cols = Array.from({ length: size }, (_, c) => c);
   const meta = `${formatDuration(game.statistics?.playDuration, '00:00')} · ${game.statistics?.totalMoves ?? 0} moves`;
+  const thumbnailStyle = { '--grid-size': size } as CSSProperties;
+  const thumbnailClass = size === 16
+    ? `${styles.sudokuThumbnail} ${styles.sudokuThumbnailLarge}`
+    : styles.sudokuThumbnail;
 
   return (
     <div className={styles.savedGameCard}>
       <button
         type="button"
-        className={styles.sudokuThumbnail}
+        className={thumbnailClass}
+        style={thumbnailStyle}
         onClick={() => onSelect(game)}
         title={`${game.difficulty} - ${game.status}`}
       >
@@ -27,7 +36,7 @@ export default function GameThumbnail({ game, onSelect, onDelete }: GameThumbnai
             const cellClass = cell?.isFixed ? `${styles.cell} ${styles.given}` : `${styles.cell} ${styles.entry}`;
             return (
               <span key={`${r}-${c}`} className={cellClass}>
-                {cell?.value ?? ''}
+                {cell?.value != null ? valueToSymbol(cell.value) : ''}
               </span>
             );
           })

--- a/src/frontend/Sudoku.React/src/hooks/useGameService.test.ts
+++ b/src/frontend/Sudoku.React/src/hooks/useGameService.test.ts
@@ -41,6 +41,7 @@ const mockGames: GameModel[] = [
     pausedAt: null,
     cells: [],
     moveHistory: [],
+    size: 9,
     statistics: {
       totalMoves: 5,
       invalidMoves: 0,
@@ -61,6 +62,7 @@ const mockGames: GameModel[] = [
     pausedAt: null,
     cells: [],
     moveHistory: [],
+    size: 9,
     statistics: {
       totalMoves: 15,
       invalidMoves: 2,
@@ -81,6 +83,7 @@ const mockGames: GameModel[] = [
     pausedAt: null,
     cells: [],
     moveHistory: [],
+    size: 9,
     statistics: {
       totalMoves: 25,
       invalidMoves: 5,

--- a/src/frontend/Sudoku.React/src/hooks/useGameService.ts
+++ b/src/frontend/Sudoku.React/src/hooks/useGameService.ts
@@ -10,7 +10,7 @@ export interface UseGameServiceReturn {
   isLoaded: boolean;
   loadGames: (profileId: string, forceRefresh?: boolean) => Promise<void>;
   deleteGame: (profileId: string, gameId: string) => Promise<void>;
-  createGame: (profileId: string, difficulty: string) => Promise<GameModel>;
+  createGame: (profileId: string, difficulty: string, size?: number) => Promise<GameModel>;
   clearCache: () => void;
   refreshGames: (profileId: string) => Promise<void>;
 
@@ -141,7 +141,7 @@ export function useGameService(): UseGameServiceReturn {
     await loadGames(profileId, true);
   }, [loadGames]);
 
-  const createGame = useCallback(async (profileId: string, difficulty: string): Promise<GameModel> => {
+  const createGame = useCallback(async (profileId: string, difficulty: string, size = 9): Promise<GameModel> => {
     if (!profileId) {
       throw new Error('Profile ID is required');
     }
@@ -150,7 +150,7 @@ export function useGameService(): UseGameServiceReturn {
 
     try {
       // Create the game via API
-      const newGame = await apiClient.createGame(profileId, difficulty);
+      const newGame = await apiClient.createGame(profileId, difficulty, size);
 
       // Update localStorage cache with the new game
       const cachedGames = localStorage.getItem('savedGames');

--- a/src/frontend/Sudoku.React/src/pages/GamePage.test.tsx
+++ b/src/frontend/Sudoku.React/src/pages/GamePage.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, fireEvent, within } from '@testing-library/rea
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import GamePage from './GamePage';
-import { makeGame, make81Cells, makeCell } from '../test/helpers';
+import { makeGame, make81Cells, makeCell, makeCells } from '../test/helpers';
 
 vi.mock('../api/apiClient', () => ({
   apiClient: {
@@ -329,6 +329,31 @@ describe('GamePage - keyboard navigation', () => {
     // No error should occur
     expect(grid).toBeInTheDocument();
   });
+
+  it('clamps arrow-key navigation to size - 1 on a 16x16 board', async () => {
+    const cells = makeCells(16);
+    // Select the bottom-right cell (row 15, column 15) and confirm ArrowDown/ArrowRight don't crash past bounds.
+    const game = makeGame({ cells, size: 16 });
+    vi.mocked(useGameService).mockReturnValue({
+      savedGames: [], isLoading: false, error: null, isLoaded: false,
+      loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
+      currentGame: game, isGameLoading: false, gameError: null,
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: vi.fn(), undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
+      addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
+    });
+    renderGamePage();
+    await waitFor(() => {
+      expect(screen.getByRole('grid')).toBeInTheDocument();
+    });
+    const grid = screen.getByRole('grid');
+    const inputs = within(grid).getAllByRole('button');
+    // The last button in row-major order is (row 15, column 15).
+    await userEvent.click(inputs[255]);
+    fireEvent.keyDown(grid, { key: 'ArrowDown' });
+    fireEvent.keyDown(grid, { key: 'ArrowRight' });
+    // No error should occur; selection stays clamped within the 16x16 board.
+    expect(grid).toBeInTheDocument();
+  });
 });
 
 describe('GamePage - number input', () => {
@@ -358,6 +383,55 @@ describe('GamePage - number input', () => {
       expect(mockMakeMove).toHaveBeenCalledWith(
         'test-player', game.id, 0, 0, 5, expect.any(String)
       );
+    });
+  });
+
+  it('rejects letter input on a 9x9 board (does not call makeMove)', async () => {
+    const cells = make81Cells();
+    cells[0] = makeCell({ row: 0, column: 0, isFixed: false, hasValue: false });
+    const game = makeGame({ cells });
+    const mockMakeMove = vi.fn();
+    vi.mocked(useGameService).mockReturnValue({
+      savedGames: [], isLoading: false, error: null, isLoaded: false,
+      loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
+      currentGame: game, isGameLoading: false, gameError: null,
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: mockMakeMove, undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
+      addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
+    });
+    renderGamePage();
+    await waitFor(() => {
+      expect(screen.getByRole('grid')).toBeInTheDocument();
+    });
+    const grid = screen.getByRole('grid');
+    const inputs = within(grid).getAllByRole('button');
+    await userEvent.click(inputs[0]);
+    fireEvent.keyDown(grid, { key: 'a' });
+    expect(mockMakeMove).not.toHaveBeenCalled();
+  });
+
+  it('maps a letter keypress to its numeric value on a 16x16 board', async () => {
+    const cells = makeCells(16);
+    cells[0] = makeCell({ row: 0, column: 0, isFixed: false, hasValue: false });
+    const game = makeGame({ cells, size: 16 });
+    const updatedGame = makeGame({ cells, size: 16 });
+    const mockMakeMove = vi.fn().mockResolvedValue(updatedGame);
+    vi.mocked(useGameService).mockReturnValue({
+      savedGames: [], isLoading: false, error: null, isLoaded: false,
+      loadGames: vi.fn(), deleteGame: vi.fn(), createGame: vi.fn(), clearCache: vi.fn(), refreshGames: vi.fn(),
+      currentGame: game, isGameLoading: false, gameError: null,
+      getGame: vi.fn(), pauseGame: vi.fn(), resumeGame: vi.fn(), makeMove: mockMakeMove, undoMove: vi.fn(), requestHint: vi.fn(), resetGame: vi.fn(),
+      addPossibleValue: vi.fn(), removePossibleValue: vi.fn(), clearPossibleValues: vi.fn(), clearCurrentGame: vi.fn(),
+    });
+    renderGamePage();
+    await waitFor(() => {
+      expect(screen.getByRole('grid')).toBeInTheDocument();
+    });
+    const grid = screen.getByRole('grid');
+    const inputs = within(grid).getAllByRole('button');
+    await userEvent.click(inputs[0]);
+    fireEvent.keyDown(grid, { key: 'g' });
+    await waitFor(() => {
+      expect(mockMakeMove).toHaveBeenCalledWith('test-player', game.id, 0, 0, 16, expect.any(String));
     });
   });
 

--- a/src/frontend/Sudoku.React/src/pages/GamePage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/GamePage.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback, useRef, type KeyboardEvent } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import type { GameModel } from '../types';
-import { validateCells, isSolved } from '../utils/gameUtils';
+import { validateCells, isSolved, deriveSize } from '../utils/gameUtils';
+import { symbolToValue } from '../utils/symbols';
 import { usePlayerService } from '../hooks/usePlayerService';
 import { useGameService } from '../hooks/useGameService';
 import Layout from '../components/Layout';
@@ -204,13 +205,23 @@ export default function GamePage() {
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
-    if (!selectedCell) return;
+    if (!selectedCell || !game) return;
     const { row, column } = selectedCell;
+    const size = game.size ?? deriveSize(game.cells);
 
     if (e.key >= '1' && e.key <= '9') {
       e.preventDefault();
       handleNumberInput(parseInt(e.key));
       return;
+    }
+
+    if (size === 16 && /^[a-gA-G]$/.test(e.key)) {
+      const value = symbolToValue(e.key);
+      if (value !== null) {
+        e.preventDefault();
+        handleNumberInput(value);
+        return;
+      }
     }
 
     if (e.key === '0' || e.key === 'Delete' || e.key === 'Backspace') {
@@ -222,9 +233,9 @@ export default function GamePage() {
     let newRow = row;
     let newCol = column;
     if (e.key === 'ArrowUp') { e.preventDefault(); newRow = Math.max(0, row - 1); }
-    else if (e.key === 'ArrowDown') { e.preventDefault(); newRow = Math.min(8, row + 1); }
+    else if (e.key === 'ArrowDown') { e.preventDefault(); newRow = Math.min(size - 1, row + 1); }
     else if (e.key === 'ArrowLeft') { e.preventDefault(); newCol = Math.max(0, column - 1); }
-    else if (e.key === 'ArrowRight') { e.preventDefault(); newCol = Math.min(8, column + 1); }
+    else if (e.key === 'ArrowRight') { e.preventDefault(); newCol = Math.min(size - 1, column + 1); }
 
     if (newRow !== row || newCol !== column) {
       setSelectedCell({ row: newRow, column: newCol });
@@ -294,6 +305,7 @@ export default function GamePage() {
   const difficultyLabel = game.difficulty
     ? game.difficulty.charAt(0).toUpperCase() + game.difficulty.slice(1)
     : '';
+  const size = game.size ?? deriveSize(game.cells);
 
   return (
     <Layout title={difficultyLabel} onBack={handleHome}>
@@ -307,6 +319,7 @@ export default function GamePage() {
           invalidCells={invalidCells}
           selectedCell={selectedCell}
           pencilMode={pencilMode}
+          size={size}
           onCellSelect={(r, c) => setSelectedCell({ row: r, column: c })}
           onKeyDown={handleKeyDown}
         />
@@ -315,6 +328,7 @@ export default function GamePage() {
           pencilMode={pencilMode}
           canUndo={(game.moveHistory?.length ?? 0) > 0}
           hintsRemaining={game.statistics.hintsRemaining}
+          size={size}
           onNumberClick={handleNumberInput}
           onErase={handleErase}
           onUndo={handleUndo}

--- a/src/frontend/Sudoku.React/src/pages/NewGamePage.module.css
+++ b/src/frontend/Sudoku.React/src/pages/NewGamePage.module.css
@@ -48,3 +48,21 @@
 .dot:nth-child(1) { animation-delay: 0s; }
 .dot:nth-child(2) { animation-delay: 0.16s; }
 .dot:nth-child(3) { animation-delay: 0.32s; }
+
+.retryButton {
+  padding: 14px 22px;
+  border: none;
+  border-radius: 12px;
+  background-color: var(--accent);
+  color: var(--accent-ink);
+  font-family: inherit;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 6px 18px var(--shadow);
+  transition: transform 0.15s ease;
+}
+
+.retryButton:hover {
+  transform: translateY(-1px);
+}

--- a/src/frontend/Sudoku.React/src/pages/NewGamePage.module.css
+++ b/src/frontend/Sudoku.React/src/pages/NewGamePage.module.css
@@ -49,6 +49,13 @@
 .dot:nth-child(2) { animation-delay: 0.16s; }
 .dot:nth-child(3) { animation-delay: 0.32s; }
 
+.actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
 .retryButton {
   padding: 14px 22px;
   border: none;
@@ -65,4 +72,19 @@
 
 .retryButton:hover {
   transform: translateY(-1px);
+}
+
+.homeButton {
+  padding: 8px 12px;
+  border: none;
+  background: none;
+  color: var(--ink-soft);
+  font-family: inherit;
+  font-size: 14px;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.homeButton:hover {
+  color: var(--ink);
 }

--- a/src/frontend/Sudoku.React/src/pages/NewGamePage.test.tsx
+++ b/src/frontend/Sudoku.React/src/pages/NewGamePage.test.tsx
@@ -152,7 +152,23 @@ describe('NewGamePage', () => {
       expect(screen.getByText(/Preparing puzzles/i)).toBeInTheDocument();
     });
     expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /back to home/i })).toBeInTheDocument();
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates home when "Back to home" is clicked on a 503 pool-empty response', async () => {
+    const mockCreateGame = vi.fn().mockRejectedValue(new ApiError('HTTP 503', 503, 30));
+    mockUseGameService.mockReturnValue({
+      savedGames: [], isLoading: false, error: null, isLoaded: false,
+      loadGames: vi.fn(), deleteGame: vi.fn(), createGame: mockCreateGame, clearCache: vi.fn(), refreshGames: vi.fn(),
+    });
+    const user = userEvent.setup();
+    renderNewGamePage('Expert', 16);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /back to home/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: /back to home/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/');
   });
 
   it('retries game creation when the retry button is clicked', async () => {

--- a/src/frontend/Sudoku.React/src/pages/NewGamePage.test.tsx
+++ b/src/frontend/Sudoku.React/src/pages/NewGamePage.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import NewGamePage from './NewGamePage';
 import { makeGame } from '../test/helpers';
+import { ApiError } from '../api/apiClient';
 
 const mockNavigate = vi.fn();
 
@@ -25,9 +27,10 @@ vi.mock('../hooks/useGameService', () => ({
   useGameService: () => mockUseGameService(),
 }));
 
-function renderNewGamePage(difficulty: string) {
+function renderNewGamePage(difficulty: string, size?: number) {
+  const path = size !== undefined ? `/new/${difficulty}?size=${size}` : `/new/${difficulty}`;
   return render(
-    <MemoryRouter initialEntries={[`/new/${difficulty}`]}>
+    <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path="/new/:difficulty" element={<NewGamePage />} />
       </Routes>
@@ -112,5 +115,74 @@ describe('NewGamePage', () => {
   it('shows the three breathing dots loader', () => {
     renderNewGamePage('Hard');
     expect(screen.getAllByTestId('loader-dot')).toHaveLength(3);
+  });
+
+  it('defaults to size 9 when no size query param is present', async () => {
+    const mockCreateGame = vi.fn().mockResolvedValue(makeGame());
+    mockUseGameService.mockReturnValue({
+      savedGames: [], isLoading: false, error: null, isLoaded: false,
+      loadGames: vi.fn(), deleteGame: vi.fn(), createGame: mockCreateGame, clearCache: vi.fn(), refreshGames: vi.fn(),
+    });
+    renderNewGamePage('Easy');
+    await waitFor(() => {
+      expect(mockCreateGame).toHaveBeenCalledWith('profile-123', 'Easy', 9);
+    });
+  });
+
+  it('passes the size query param through to createGame', async () => {
+    const mockCreateGame = vi.fn().mockResolvedValue(makeGame({ size: 16 }));
+    mockUseGameService.mockReturnValue({
+      savedGames: [], isLoading: false, error: null, isLoaded: false,
+      loadGames: vi.fn(), deleteGame: vi.fn(), createGame: mockCreateGame, clearCache: vi.fn(), refreshGames: vi.fn(),
+    });
+    renderNewGamePage('Expert', 16);
+    await waitFor(() => {
+      expect(mockCreateGame).toHaveBeenCalledWith('profile-123', 'Expert', 16);
+    });
+  });
+
+  it('shows a "Preparing puzzles" message and retry button on a 503 pool-empty response', async () => {
+    const mockCreateGame = vi.fn().mockRejectedValue(new ApiError('HTTP 503', 503, 30));
+    mockUseGameService.mockReturnValue({
+      savedGames: [], isLoading: false, error: null, isLoaded: false,
+      loadGames: vi.fn(), deleteGame: vi.fn(), createGame: mockCreateGame, clearCache: vi.fn(), refreshGames: vi.fn(),
+    });
+    renderNewGamePage('Expert', 16);
+    await waitFor(() => {
+      expect(screen.getByText(/Preparing puzzles/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('retries game creation when the retry button is clicked', async () => {
+    const mockCreateGame = vi.fn()
+      .mockRejectedValueOnce(new ApiError('HTTP 503', 503, 30))
+      .mockResolvedValueOnce(makeGame({ id: 'retried-game', size: 16 }));
+    mockUseGameService.mockReturnValue({
+      savedGames: [], isLoading: false, error: null, isLoaded: false,
+      loadGames: vi.fn(), deleteGame: vi.fn(), createGame: mockCreateGame, clearCache: vi.fn(), refreshGames: vi.fn(),
+    });
+    const user = userEvent.setup();
+    renderNewGamePage('Expert', 16);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/game/retried-game', { replace: true });
+    });
+  });
+
+  it('navigates home on a non-503 error, unaffected by the pool-empty handling', async () => {
+    const mockCreateGame = vi.fn().mockRejectedValue(new ApiError('HTTP 500', 500));
+    mockUseGameService.mockReturnValue({
+      savedGames: [], isLoading: false, error: null, isLoaded: false,
+      loadGames: vi.fn(), deleteGame: vi.fn(), createGame: mockCreateGame, clearCache: vi.fn(), refreshGames: vi.fn(),
+    });
+    renderNewGamePage('Easy');
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
   });
 });

--- a/src/frontend/Sudoku.React/src/pages/NewGamePage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/NewGamePage.tsx
@@ -91,9 +91,14 @@ export default function NewGamePage() {
       <Layout hideHeader>
         <div className={styles.loadingContainer}>
           <p className={styles.message}>Preparing puzzles — try again in a moment</p>
-          <button type="button" className={styles.retryButton} onClick={handleRetry}>
-            Retry
-          </button>
+          <div className={styles.actions}>
+            <button type="button" className={styles.retryButton} onClick={handleRetry}>
+              Retry
+            </button>
+            <button type="button" className={styles.homeButton} onClick={() => navigate('/')}>
+              Back to home
+            </button>
+          </div>
         </div>
       </Layout>
     );

--- a/src/frontend/Sudoku.React/src/pages/NewGamePage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/NewGamePage.tsx
@@ -7,6 +7,8 @@ import { ApiError } from '../api/apiClient';
 import Layout from '../components/Layout';
 import styles from './NewGamePage.module.css';
 
+const SUPPORTED_SIZES = [9, 16];
+
 interface AttemptCreateGameParams {
   profileId: string;
   difficulty: string;
@@ -51,7 +53,8 @@ export default function NewGamePage() {
   const [poolEmpty, setPoolEmpty] = useState(false);
 
   const sizeParam = searchParams.get('size');
-  const size = sizeParam ? parseInt(sizeParam, 10) : 9;
+  const parsedSize = sizeParam ? parseInt(sizeParam, 10) : 9;
+  const size = SUPPORTED_SIZES.includes(parsedSize) ? parsedSize : 9;
 
   useEffect(() => {
     if (!isInitialized || !profileId || !difficulty) {

--- a/src/frontend/Sudoku.React/src/pages/NewGamePage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/NewGamePage.tsx
@@ -1,35 +1,100 @@
-import { useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate, useSearchParams, type NavigateFunction } from 'react-router-dom';
+import type { GameModel } from '../types';
 import { usePlayerService } from '../hooks/usePlayerService';
 import { useGameService } from '../hooks/useGameService';
+import { ApiError } from '../api/apiClient';
 import Layout from '../components/Layout';
 import styles from './NewGamePage.module.css';
 
+interface AttemptCreateGameParams {
+  profileId: string;
+  difficulty: string;
+  size: number;
+  createGame: (profileId: string, difficulty: string, size: number) => Promise<GameModel>;
+  navigate: NavigateFunction;
+  onPoolEmpty: () => void;
+}
+
+/**
+ * Plain (non-hook) helper shared by the initial create-on-mount effect and the
+ * manual retry button, kept outside the component so effect callbacks never
+ * directly reference a memoized setState-calling closure.
+ */
+async function attemptCreateGame({
+  profileId,
+  difficulty,
+  size,
+  createGame,
+  navigate,
+  onPoolEmpty,
+}: AttemptCreateGameParams): Promise<void> {
+  try {
+    const game = await createGame(profileId, difficulty, size);
+    navigate(`/game/${game.id}`, { replace: true });
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 503) {
+      onPoolEmpty();
+      return;
+    }
+    console.error('Failed to create game', e);
+    navigate('/');
+  }
+}
+
 export default function NewGamePage() {
   const { difficulty } = useParams<{ difficulty: string }>();
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { profileId, isInitialized, isNewPlayer } = usePlayerService();
   const { createGame } = useGameService();
+  const [poolEmpty, setPoolEmpty] = useState(false);
+
+  const sizeParam = searchParams.get('size');
+  const size = sizeParam ? parseInt(sizeParam, 10) : 9;
 
   useEffect(() => {
-    const create = async () => {
-      if (!isInitialized || !profileId || !difficulty) {
-        return;
-      }
-      try {
-        const game = await createGame(profileId, difficulty);
-        navigate(`/game/${game.id}`, { replace: true });
-      } catch (e) {
-        console.error('Failed to create game', e);
-        navigate('/');
-      }
-    };
-    create();
-  }, [difficulty, navigate, profileId, isInitialized, createGame]);
+    if (!isInitialized || !profileId || !difficulty) {
+      return;
+    }
+    attemptCreateGame({
+      profileId,
+      difficulty,
+      size,
+      createGame,
+      navigate,
+      onPoolEmpty: () => setPoolEmpty(true),
+    });
+  }, [difficulty, navigate, profileId, isInitialized, createGame, size]);
 
   useEffect(() => {
     if (isNewPlayer) navigate('/');
   }, [isNewPlayer, navigate]);
+
+  const handleRetry = () => {
+    if (!profileId || !difficulty) return;
+    attemptCreateGame({
+      profileId,
+      difficulty,
+      size,
+      createGame,
+      navigate,
+      onPoolEmpty: () => setPoolEmpty(true),
+    });
+  };
+
+  if (poolEmpty) {
+    return (
+      <Layout hideHeader>
+        <div className={styles.loadingContainer}>
+          <p className={styles.message}>Preparing puzzles — try again in a moment</p>
+          <button type="button" className={styles.retryButton} onClick={handleRetry}>
+            Retry
+          </button>
+        </div>
+      </Layout>
+    );
+  }
 
   return (
     <Layout hideHeader>

--- a/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.module.css
+++ b/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.module.css
@@ -19,6 +19,35 @@
   margin: 0 0 24px 0;
 }
 
+.sizeToggle {
+  display: flex;
+  gap: 6px;
+  padding: 5px;
+  margin-bottom: 20px;
+  border: 1px solid var(--line);
+  border-radius: 13px;
+  background-color: var(--surface);
+}
+
+.sizeOption {
+  flex: 1;
+  padding: 11px 10px;
+  border: none;
+  border-radius: 9px;
+  background-color: transparent;
+  color: var(--ink-soft);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.sizeOptionActive {
+  background-color: var(--accent);
+  color: var(--accent-ink);
+}
+
 .options {
   display: flex;
   flex-direction: column;

--- a/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.test.tsx
+++ b/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.test.tsx
@@ -37,32 +37,46 @@ describe('SelectDifficultyPage', () => {
     expect(screen.getByRole('button', { name: /Expert/i })).toBeInTheDocument();
   });
 
-  it('navigates to /new/Easy when Easy is clicked', async () => {
+  it('navigates to /new/Easy?size=9 when Easy is clicked', async () => {
     const user = userEvent.setup();
     renderPage();
     await user.click(screen.getByRole('button', { name: /Easy/i }));
-    expect(mockNavigate).toHaveBeenCalledWith('/new/Easy');
+    expect(mockNavigate).toHaveBeenCalledWith('/new/Easy?size=9');
   });
 
-  it('navigates to /new/Medium when Medium is clicked', async () => {
+  it('navigates to /new/Medium?size=9 when Medium is clicked', async () => {
     const user = userEvent.setup();
     renderPage();
     await user.click(screen.getByRole('button', { name: /Medium/i }));
-    expect(mockNavigate).toHaveBeenCalledWith('/new/Medium');
+    expect(mockNavigate).toHaveBeenCalledWith('/new/Medium?size=9');
   });
 
-  it('navigates to /new/Hard when Hard is clicked', async () => {
+  it('navigates to /new/Hard?size=9 when Hard is clicked', async () => {
     const user = userEvent.setup();
     renderPage();
     await user.click(screen.getByRole('button', { name: /Hard/i }));
-    expect(mockNavigate).toHaveBeenCalledWith('/new/Hard');
+    expect(mockNavigate).toHaveBeenCalledWith('/new/Hard?size=9');
   });
 
-  it('navigates to /new/Expert when Expert is clicked', async () => {
+  it('navigates to /new/Expert?size=9 when Expert is clicked', async () => {
     const user = userEvent.setup();
     renderPage();
     await user.click(screen.getByRole('button', { name: /Expert/i }));
-    expect(mockNavigate).toHaveBeenCalledWith('/new/Expert');
+    expect(mockNavigate).toHaveBeenCalledWith('/new/Expert?size=9');
+  });
+
+  it('defaults to the Classic 9x9 size toggle option', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: /Classic 9×9/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /Giant 16×16/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('navigates with ?size=16 when Giant 16x16 is selected before picking a difficulty', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole('button', { name: /Giant 16×16/i }));
+    await user.click(screen.getByRole('button', { name: /Expert/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/new/Expert?size=16');
   });
 
   it('navigates to / when the header back affordance is clicked', async () => {

--- a/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { usePlayerService } from '../hooks/usePlayerService';
 import Layout from '../components/Layout';
@@ -14,6 +14,7 @@ const DIFFICULTIES = [
 export default function SelectDifficultyPage() {
   const navigate = useNavigate();
   const { isNewPlayer } = usePlayerService();
+  const [selectedSize, setSelectedSize] = useState<9 | 16>(9);
 
   useEffect(() => {
     if (isNewPlayer) navigate('/');
@@ -24,13 +25,33 @@ export default function SelectDifficultyPage() {
       <div className={styles.container}>
         <h1 className={styles.title}>Select difficulty</h1>
         <p className={styles.subtitle}>how much quiet do you want?</p>
+
+        <div className={styles.sizeToggle} role="group" aria-label="Board size">
+          <button
+            type="button"
+            className={`${styles.sizeOption} ${selectedSize === 9 ? styles.sizeOptionActive : ''}`}
+            aria-pressed={selectedSize === 9}
+            onClick={() => setSelectedSize(9)}
+          >
+            Classic 9×9
+          </button>
+          <button
+            type="button"
+            className={`${styles.sizeOption} ${selectedSize === 16 ? styles.sizeOptionActive : ''}`}
+            aria-pressed={selectedSize === 16}
+            onClick={() => setSelectedSize(16)}
+          >
+            Giant 16×16
+          </button>
+        </div>
+
         <div className={styles.options}>
           {DIFFICULTIES.map(({ name, subtitle, dots }) => (
             <button
               key={name}
               type="button"
               className={styles.card}
-              onClick={() => navigate(`/new/${name}`)}
+              onClick={() => navigate(`/new/${name}?size=${selectedSize}`)}
             >
               <span className={styles.cardText}>
                 <span className={styles.cardTitle}>{name}</span>

--- a/src/frontend/Sudoku.React/src/pages/StatsPage.test.tsx
+++ b/src/frontend/Sudoku.React/src/pages/StatsPage.test.tsx
@@ -141,4 +141,42 @@ describe('StatsPage', () => {
       expect(difficultyRow(difficulty)).toBeInTheDocument();
     });
   });
+
+  it('does not show the 16x16 section when the player has no 16x16 completions', () => {
+    mockUseStatsService.mockReturnValue(statsService({
+      stats: makePlayerStats({ gamesPlayed: 1, gamesWon: 1, winRate: 1 }),
+    }));
+
+    renderPage();
+
+    expect(screen.queryByText(/Giant 16×16/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the 16x16 section when the player has 16x16 completions', () => {
+    mockUseStatsService.mockReturnValue(statsService({
+      stats: makePlayerStats({
+        gamesPlayed: 6,
+        gamesWon: 5,
+        winRate: 5 / 6,
+        byDifficulty: [
+          makeDifficultyStats({ difficulty: 'Easy', size: 9, gamesPlayed: 5, gamesWon: 4 }),
+          makeDifficultyStats({
+            difficulty: 'Expert',
+            size: 16,
+            gamesPlayed: 1,
+            gamesWon: 1,
+            averageSolveTime: '00:45:00',
+            bestSolveTime: '00:45:00',
+          }),
+        ],
+      }),
+    }));
+
+    renderPage();
+
+    expect(screen.getByText(/Giant 16×16/i)).toBeInTheDocument();
+    expect(screen.getByText(/Classic 9×9/i)).toBeInTheDocument();
+    const row = difficultyRow('Expert');
+    expect(within(row).getAllByText('45:00')).toHaveLength(2);
+  });
 });

--- a/src/frontend/Sudoku.React/src/pages/StatsPage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/StatsPage.tsx
@@ -19,6 +19,10 @@ export default function StatsPage() {
   const winRate = stats ? `${Math.round(stats.winRate * 100)}%` : '0%';
   const isEmpty = isLoaded && !error && stats?.gamesPlayed === 0;
 
+  const nineByDifficulty = stats?.byDifficulty.filter(d => d.size === 9) ?? [];
+  const sixteenByDifficulty = stats?.byDifficulty.filter(d => d.size === 16) ?? [];
+  const hasSixteenCompletions = sixteenByDifficulty.some(d => d.gamesPlayed > 0);
+
   return (
     <Layout>
       <div className={styles.container}>
@@ -53,8 +57,8 @@ export default function StatsPage() {
               </div>
             </div>
 
-            <section className={styles.breakdown} aria-labelledby="by-difficulty">
-              <h2 id="by-difficulty" className={styles.eyebrow}>By difficulty</h2>
+            <section className={styles.breakdown} aria-labelledby="by-difficulty-9">
+              <h2 id="by-difficulty-9" className={styles.eyebrow}>Classic 9×9 — by difficulty</h2>
 
               <table className={styles.table}>
                 <thead>
@@ -67,7 +71,7 @@ export default function StatsPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {stats.byDifficulty.map(row => (
+                  {nineByDifficulty.map(row => (
                     <tr key={row.difficulty}>
                       <th scope="row" className={styles.difficulty}>{row.difficulty}</th>
                       <td className="tnum">{row.gamesPlayed}</td>
@@ -79,6 +83,35 @@ export default function StatsPage() {
                 </tbody>
               </table>
             </section>
+
+            {hasSixteenCompletions && (
+              <section className={styles.breakdown} aria-labelledby="by-difficulty-16">
+                <h2 id="by-difficulty-16" className={styles.eyebrow}>Giant 16×16 — by difficulty</h2>
+
+                <table className={styles.table}>
+                  <thead>
+                    <tr>
+                      <th scope="col">Difficulty</th>
+                      <th scope="col">Played</th>
+                      <th scope="col">Won</th>
+                      <th scope="col">Avg</th>
+                      <th scope="col">Best</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sixteenByDifficulty.map(row => (
+                      <tr key={row.difficulty}>
+                        <th scope="row" className={styles.difficulty}>{row.difficulty}</th>
+                        <td className="tnum">{row.gamesPlayed}</td>
+                        <td className="tnum">{row.gamesWon}</td>
+                        <td className="tnum">{formatDuration(row.averageSolveTime)}</td>
+                        <td className="tnum">{formatDuration(row.bestSolveTime)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </section>
+            )}
           </>
         )}
       </div>

--- a/src/frontend/Sudoku.React/src/test/helpers.ts
+++ b/src/frontend/Sudoku.React/src/test/helpers.ts
@@ -24,20 +24,23 @@ export function makeStats(overrides: Partial<GameStatisticsModel> = {}): GameSta
   };
 }
 
-export function make81Cells(overrides: Partial<CellModel>[] = []): CellModel[] {
+export function makeCells(size = 9, overrides: Partial<CellModel>[] = []): CellModel[] {
   const cells: CellModel[] = [];
-  for (let r = 0; r < 9; r++) {
-    for (let c = 0; c < 9; c++) {
-      const idx = r * 9 + c;
+  for (let r = 0; r < size; r++) {
+    for (let c = 0; c < size; c++) {
+      const idx = r * size + c;
       cells.push(makeCell({ row: r, column: c, ...overrides[idx] }));
     }
   }
   return cells;
 }
 
+export const make81Cells = (overrides: Partial<CellModel>[] = []): CellModel[] => makeCells(9, overrides);
+
 export function makeDifficultyStats(overrides: Partial<DifficultyStatsModel> = {}): DifficultyStatsModel {
   return {
     difficulty: 'Easy',
+    size: 9,
     gamesPlayed: 0,
     gamesWon: 0,
     averageSolveTime: null,
@@ -62,6 +65,7 @@ export function makePlayerStats(overrides: Partial<PlayerStatsModel> = {}): Play
 }
 
 export function makeGame(overrides: Partial<GameModel> = {}): GameModel {
+  const size = overrides.size ?? 9;
   return {
     id: 'game-1',
     profileId: 'profile-1',
@@ -73,8 +77,9 @@ export function makeGame(overrides: Partial<GameModel> = {}): GameModel {
     startedAt: '2024-01-01T00:00:00Z',
     completedAt: null,
     pausedAt: null,
-    cells: make81Cells(),
+    cells: makeCells(size),
     moveHistory: [],
+    size,
     ...overrides,
   };
 }

--- a/src/frontend/Sudoku.React/src/types/index.ts
+++ b/src/frontend/Sudoku.React/src/types/index.ts
@@ -48,7 +48,8 @@ export interface GameModel {
   pausedAt: string | null;
   cells: CellModel[];
   moveHistory: MoveHistoryModel[];
-  size: number;
+  /** Absent on game state cached before this field existed — derive via deriveSize(cells) when missing. */
+  size?: number;
 }
 
 export interface DifficultyStatsModel {

--- a/src/frontend/Sudoku.React/src/types/index.ts
+++ b/src/frontend/Sudoku.React/src/types/index.ts
@@ -48,10 +48,12 @@ export interface GameModel {
   pausedAt: string | null;
   cells: CellModel[];
   moveHistory: MoveHistoryModel[];
+  size: number;
 }
 
 export interface DifficultyStatsModel {
   difficulty: string;
+  size: number;
   gamesPlayed: number;
   gamesWon: number;
   /** "HH:MM:SS", or null when the player has no wins at this difficulty. */

--- a/src/frontend/Sudoku.React/src/utils/gameUtils.test.ts
+++ b/src/frontend/Sudoku.React/src/utils/gameUtils.test.ts
@@ -6,8 +6,10 @@ import {
   getMiniGridCells,
   isSolved,
   validateCells,
+  deriveSize,
+  getBoxSize,
 } from './gameUtils';
-import { makeCell, make81Cells } from '../test/helpers';
+import { makeCell, make81Cells, makeCells } from '../test/helpers';
 
 describe('getCell', () => {
   it('returns the matching cell', () => {
@@ -153,4 +155,75 @@ describe('isSolved', () => {
     }
     expect(isSolved(cells)).toBe(true);
   });
+});
+
+describe('deriveSize', () => {
+  it('derives 9 from 81 cells', () => {
+    expect(deriveSize(make81Cells())).toBe(9);
+  });
+
+  it('derives 16 from 256 cells', () => {
+    expect(deriveSize(makeCells(16))).toBe(16);
+  });
+});
+
+describe('getBoxSize', () => {
+  it('derives 3 for a 9x9 board', () => {
+    expect(getBoxSize(9)).toBe(3);
+  });
+
+  it('derives 4 for a 16x16 board', () => {
+    expect(getBoxSize(16)).toBe(4);
+  });
+});
+
+describe('16x16 (boxSize 4) behavior', () => {
+  it('getMiniGridCells returns 16 cells for a 4x4 block', () => {
+    const cells = makeCells(16);
+    const block = getMiniGridCells(cells, 0, 0);
+    expect(block).toHaveLength(16);
+    block.forEach(c => {
+      expect(c.row).toBeGreaterThanOrEqual(0);
+      expect(c.row).toBeLessThan(4);
+      expect(c.column).toBeGreaterThanOrEqual(0);
+      expect(c.column).toBeLessThan(4);
+    });
+  });
+
+  it('getMiniGridCells returns cells for an inner 4x4 block', () => {
+    const cells = makeCells(16);
+    const block = getMiniGridCells(cells, 9, 9);
+    expect(block).toHaveLength(16);
+    block.forEach(c => {
+      expect(c.row).toBeGreaterThanOrEqual(8);
+      expect(c.row).toBeLessThan(12);
+      expect(c.column).toBeGreaterThanOrEqual(8);
+      expect(c.column).toBeLessThan(12);
+    });
+  });
+
+  it('validateCells flags duplicates within a 4x4 box on a 16x16 board', () => {
+    const cells = makeCells(16);
+    cells[0] = makeCell({ row: 0, column: 0, value: 11, hasValue: true });
+    cells[find16Index(3, 3)] = makeCell({ row: 3, column: 3, value: 11, hasValue: true });
+    const invalid = validateCells(cells);
+    expect(invalid.some(c => c.row === 0 && c.column === 0)).toBe(true);
+    expect(invalid.some(c => c.row === 3 && c.column === 3)).toBe(true);
+  });
+
+  it('validateCells does not flag the same value in different rows/columns/boxes on a 16x16 board', () => {
+    const cells = makeCells(16);
+    cells[find16Index(0, 0)] = makeCell({ row: 0, column: 0, value: 16, hasValue: true });
+    cells[find16Index(4, 4)] = makeCell({ row: 4, column: 4, value: 16, hasValue: true });
+    const invalid = validateCells(cells);
+    expect(invalid).toHaveLength(0);
+  });
+
+  it('isSolved requires 256 cells for a 16x16 board', () => {
+    expect(isSolved(makeCells(16))).toBe(false);
+  });
+
+  function find16Index(row: number, col: number): number {
+    return row * 16 + col;
+  }
 });

--- a/src/frontend/Sudoku.React/src/utils/gameUtils.test.ts
+++ b/src/frontend/Sudoku.React/src/utils/gameUtils.test.ts
@@ -219,8 +219,10 @@ describe('16x16 (boxSize 4) behavior', () => {
     expect(invalid).toHaveLength(0);
   });
 
-  it('isSolved requires 256 cells for a 16x16 board', () => {
-    expect(isSolved(makeCells(16))).toBe(false);
+  it('isSolved rejects a 16x16-shaped cell collection with the wrong cell count', () => {
+    // One cell short of 256 — must be rejected by the cell-count guard itself,
+    // not merely because the board happens to be unsolved.
+    expect(isSolved(makeCells(16).slice(0, 255))).toBe(false);
   });
 
   function find16Index(row: number, col: number): number {

--- a/src/frontend/Sudoku.React/src/utils/gameUtils.ts
+++ b/src/frontend/Sudoku.React/src/utils/gameUtils.ts
@@ -3,6 +3,9 @@ import type { CellModel } from '../types';
 /** Supported board cell counts (9x9 = 81, 16x16 = 256). */
 const SUPPORTED_CELL_COUNTS = [81, 256];
 
+/** Supported board sizes. */
+const SUPPORTED_SIZES = [9, 16];
+
 export function getCell(cells: CellModel[], row: number, col: number): CellModel | undefined {
   return cells.find(c => c.row === row && c.column === col);
 }
@@ -18,13 +21,27 @@ export function getColumnCells(cells: CellModel[], col: number): CellModel[] {
 /**
  * Derives the board size (9 or 16) from a cell collection. This is the documented
  * fallback for cached game state predating the `size` field on `GameModel`.
+ * Falls back to 9 (with a console warning) for an unexpected cell count, rather
+ * than returning a non-integer size that would corrupt downstream box/row math.
  */
 export function deriveSize(cells: CellModel[]): number {
+  if (!SUPPORTED_CELL_COUNTS.includes(cells.length)) {
+    console.warn(`deriveSize: unexpected cell count ${cells.length}, defaulting to size 9`);
+    return 9;
+  }
   return Math.sqrt(cells.length);
 }
 
-/** Derives the box size (3 for 9x9, 4 for 16x16) from the board size. */
+/**
+ * Derives the box size (3 for 9x9, 4 for 16x16) from the board size. Falls back
+ * to 3 (with a console warning) for an unsupported size, for the same reason as
+ * `deriveSize` above.
+ */
 export function getBoxSize(size: number): number {
+  if (!SUPPORTED_SIZES.includes(size)) {
+    console.warn(`getBoxSize: unexpected size ${size}, defaulting to boxSize 3`);
+    return 3;
+  }
   return Math.sqrt(size);
 }
 

--- a/src/frontend/Sudoku.React/src/utils/gameUtils.ts
+++ b/src/frontend/Sudoku.React/src/utils/gameUtils.ts
@@ -1,5 +1,8 @@
 import type { CellModel } from '../types';
 
+/** Supported board cell counts (9x9 = 81, 16x16 = 256). */
+const SUPPORTED_CELL_COUNTS = [81, 256];
+
 export function getCell(cells: CellModel[], row: number, col: number): CellModel | undefined {
   return cells.find(c => c.row === row && c.column === col);
 }
@@ -12,21 +15,38 @@ export function getColumnCells(cells: CellModel[], col: number): CellModel[] {
   return cells.filter(c => c.column === col);
 }
 
+/**
+ * Derives the board size (9 or 16) from a cell collection. This is the documented
+ * fallback for cached game state predating the `size` field on `GameModel`.
+ */
+export function deriveSize(cells: CellModel[]): number {
+  return Math.sqrt(cells.length);
+}
+
+/** Derives the box size (3 for 9x9, 4 for 16x16) from the board size. */
+export function getBoxSize(size: number): number {
+  return Math.sqrt(size);
+}
+
 export function getMiniGridCells(cells: CellModel[], row: number, col: number): CellModel[] {
-  const startRow = Math.floor(row / 3) * 3;
-  const startCol = Math.floor(col / 3) * 3;
+  const size = deriveSize(cells);
+  const boxSize = getBoxSize(size);
+  const startRow = Math.floor(row / boxSize) * boxSize;
+  const startCol = Math.floor(col / boxSize) * boxSize;
   return cells.filter(
-    c => c.row >= startRow && c.row < startRow + 3 && c.column >= startCol && c.column < startCol + 3
+    c => c.row >= startRow && c.row < startRow + boxSize && c.column >= startCol && c.column < startCol + boxSize
   );
 }
 
 export function isSolved(cells: CellModel[]): boolean {
-  if (cells.length !== 81) return false;
+  if (!SUPPORTED_CELL_COUNTS.includes(cells.length)) return false;
   return cells.every(c => c.hasValue) && validateCells(cells).length === 0;
 }
 
 export function validateCells(cells: CellModel[]): CellModel[] {
   const invalid = new Set<string>();
+  const size = deriveSize(cells);
+  const boxSize = getBoxSize(size);
 
   const checkGroup = (group: CellModel[]) => {
     const withValues = group.filter(c => c.hasValue && c.value !== null);
@@ -39,13 +59,13 @@ export function validateCells(cells: CellModel[]): CellModel[] {
     });
   };
 
-  for (let i = 0; i < 9; i++) {
+  for (let i = 0; i < size; i++) {
     checkGroup(getRowCells(cells, i));
     checkGroup(getColumnCells(cells, i));
   }
 
-  for (let r = 0; r < 9; r += 3) {
-    for (let c = 0; c < 9; c += 3) {
+  for (let r = 0; r < size; r += boxSize) {
+    for (let c = 0; c < size; c += boxSize) {
       checkGroup(getMiniGridCells(cells, r, c));
     }
   }

--- a/src/frontend/Sudoku.React/src/utils/symbols.test.ts
+++ b/src/frontend/Sudoku.React/src/utils/symbols.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { valueToSymbol, symbolToValue, valuesForSize } from './symbols';
+
+describe('valueToSymbol', () => {
+  it('renders single digits as-is', () => {
+    expect(valueToSymbol(1)).toBe('1');
+    expect(valueToSymbol(5)).toBe('5');
+    expect(valueToSymbol(9)).toBe('9');
+  });
+
+  it('renders 10-16 as letters A-G', () => {
+    expect(valueToSymbol(10)).toBe('A');
+    expect(valueToSymbol(11)).toBe('B');
+    expect(valueToSymbol(12)).toBe('C');
+    expect(valueToSymbol(13)).toBe('D');
+    expect(valueToSymbol(14)).toBe('E');
+    expect(valueToSymbol(15)).toBe('F');
+    expect(valueToSymbol(16)).toBe('G');
+  });
+});
+
+describe('symbolToValue', () => {
+  it('parses digits 1-9', () => {
+    expect(symbolToValue('1')).toBe(1);
+    expect(symbolToValue('5')).toBe(5);
+    expect(symbolToValue('9')).toBe(9);
+  });
+
+  it('parses letters A-G, case-insensitively', () => {
+    expect(symbolToValue('A')).toBe(10);
+    expect(symbolToValue('a')).toBe(10);
+    expect(symbolToValue('G')).toBe(16);
+    expect(symbolToValue('g')).toBe(16);
+    expect(symbolToValue('D')).toBe(13);
+    expect(symbolToValue('d')).toBe(13);
+  });
+
+  it('returns null for out-of-range digits', () => {
+    expect(symbolToValue('0')).toBeNull();
+  });
+
+  it('returns null for letters outside A-G', () => {
+    expect(symbolToValue('h')).toBeNull();
+    expect(symbolToValue('H')).toBeNull();
+    expect(symbolToValue('z')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(symbolToValue('')).toBeNull();
+  });
+
+  it('returns null for multi-character input', () => {
+    expect(symbolToValue('10')).toBeNull();
+    expect(symbolToValue('AB')).toBeNull();
+  });
+});
+
+describe('valuesForSize', () => {
+  it('returns 1-9 for size 9', () => {
+    expect(valuesForSize(9)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  it('returns 1-16 for size 16', () => {
+    expect(valuesForSize(16)).toEqual(Array.from({ length: 16 }, (_, i) => i + 1));
+  });
+});

--- a/src/frontend/Sudoku.React/src/utils/symbols.ts
+++ b/src/frontend/Sudoku.React/src/utils/symbols.ts
@@ -1,0 +1,19 @@
+/**
+ * The single place the 1-9 / A-G symbol mapping exists for the 16x16 board.
+ * Wire format stays numeric everywhere; these helpers are presentation-only.
+ */
+export function valueToSymbol(value: number): string {
+  return value >= 10 ? String.fromCharCode(55 + value) : String(value);
+}
+
+export function symbolToValue(ch: string): number | null {
+  if (ch.length !== 1) return null;
+  const upper = ch.toUpperCase();
+  if (upper >= '1' && upper <= '9') return upper.charCodeAt(0) - '0'.charCodeAt(0);
+  if (upper >= 'A' && upper <= 'G') return upper.charCodeAt(0) - 'A'.charCodeAt(0) + 10;
+  return null;
+}
+
+export function valuesForSize(size: number): number[] {
+  return Array.from({ length: size }, (_, i) => i + 1);
+}


### PR DESCRIPTION
## Description

Phase 5 of 6 for the 16x16 Sudoku variant (see `docs/specs/spec-16x16-sudoku.md`) — the biggest phase, threading board size through the entire React app to consume the size-aware backend from Phases 1-4.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- New `src/utils/symbols.ts` — the single place the 1-9/A-G presentation mapping exists (`valueToSymbol`/`symbolToValue`/`valuesForSize`); wire format stays numeric everywhere
- `GameModel`/`DifficultyStatsModel` gain `size`, matching the backend's additive DTO changes
- `gameUtils` gains `deriveSize`/`getBoxSize` helpers; `getMiniGridCells`/`isSolved`/`validateCells` generalized off derived size/boxSize instead of hard-coded 9/3
- `GameBoard`/`CellInput`/`GameControls`/`GameThumbnail` all thread an optional `size` prop (default 9, zero diff to existing 9x9 call sites): box borders and peer-highlight math derive from `boxSize`; the number pad renders `valuesForSize(size)` with symbol labels in an 8×2/4×4 grid at size 16; pencil marks keep the existing positional 3×3 grid at 9x9 but render as a wrapped, non-positional row of symbols at 16x16 (a positional 4×4 grid at board scale would be illegible); thumbnails derive size from `game.size` with a `deriveSize(cells)` fallback for stale cached state
- `GamePage` accepts keyboard input `a-g`/`A-G` (via `symbolToValue`) only when `size === 16`, alongside the existing always-on `1-9`; arrow-key navigation clamps to `size - 1`
- `SelectDifficultyPage` gains a "Classic 9×9"/"Giant 16×16" toggle appending `?size=` to the existing `/new/:difficulty` route (no router changes)
- `NewGamePage` reads the size param; a new `ApiError` class (carrying HTTP status + `Retry-After`) lets it distinguish a 16x16 pool-empty 503 from other failures, showing "Preparing puzzles — try again in a moment" with a retry button instead of silently bouncing home
- `StatsPage` sections its table by size; the 16x16 section only renders when the player has at least one 16x16 completion or active game, matching the backend's now-8-row stats payload
- `test/helpers.ts` gains `makeCells(size)`, with `make81Cells` kept as a thin wrapper so no existing 9x9 test call site needed to change

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

`npm run build` clean (this repo's CI type-checks test files via `tsc -b`, verified locally). `npm test` — 229/229 passing (up from 180 baseline). `npm run lint` clean of new issues (4 pre-existing errors confirmed via `git show main:...` to predate this branch, left untouched as out of scope).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)