### PR TITLE
Fix local Functions puzzle-pool seeding: stale blob connection string in local.settings.json

### DIFF
--- a/src/backend/Sudoku.Functions/local.settings.json
+++ b/src/backend/Sudoku.Functions/local.settings.json
@@ -2,7 +2,6 @@
   "IsEncrypted": false,
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "AzureStorage:ConnectionString": "UseDevelopmentStorage=true"
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
   }
 }


### PR DESCRIPTION
## Description

Root-causes and fixes the local dev issue flagged during Phase 6 validation of the 16x16 Sudoku spec (see the follow-up note in #379): `Sudoku.Functions`' puzzle pool seeder couldn't reach the Azurite blob emulator when running the full stack locally via `Sudoku.AppHost`.

## Root cause

`AddBlobStorageClient` (`InfrastructureServiceCollectionExtensions.cs`) correctly prioritizes the Aspire-injected `"blobs"` connection string over any fallback. But `src/backend/Sudoku.Functions/local.settings.json` — checked into source control — hardcoded `"AzureStorage:ConnectionString": "UseDevelopmentStorage=true"`, which resolves to Azurite's **fixed default ports** (10000/10001/10002). When running under `Sudoku.AppHost`, the Azurite container's blob port is mapped to a **random host port** instead (e.g. `127.0.0.1:54887->10000/tcp`), so nothing listens on the fixed port and the Functions worker's blob client failed with a connection-refused error.

Why this stale value was never a legitimate fallback: this project has no supported standalone (non-Aspire) workflow — `Program.cs` already requires an Aspire-injected Cosmos connection string via `AddAzureCosmosClient("CosmosDb")`, which `local.settings.json` never provided. So this entry only ever shadowed the correct Aspire-injected value; it was never reachable as a genuine fallback.

## Fix

Removed the stale `"AzureStorage:ConnectionString"` entry. `AzureWebJobsStorage` (the Functions host's own bookkeeping storage, separately wired via `.WithHostStorage(storage)` in the AppHost) is untouched.

## Verification

Relaunched the full Aspire stack (API + Functions + Cosmos/Azurite emulators + React) and invoked `PuzzlePoolSeedHttpFunction` directly:

- **Before this fix:** every attempt failed immediately — `Azure.RequestFailedException: No connection could be made... (127.0.0.1:10000)`, retried 6x then failed inside `PuzzlePoolSeeder.SeedPoolAsync()`.
- **After this fix:** the seeder successfully reached the real (dynamically-mapped) Azurite storage and seeded the pool end-to-end: 9x9 reached 10/10 on all four difficulties, 16x16 reached 5/5 on both Easy and Medium, before moving on to the slower 16x16 Hard difficulty (governed by the Phase 3 time-budget logic, as designed).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

This is a local dev config file, not exercised by the automated test suite. Verified manually as described above; `AzureStorage:ConnectionString` itself remains a supported, tested fallback in code (`DependencyInjectionTests.cs`) — only the incorrect checked-in *value* for this project is removed.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)