### PR TITLE
Auto-eliminate placed values from peer pencil marks (row/column/box)

### DIFF
--- a/src/backend/Sudoku.Application/DTOs/GameDto.cs
+++ b/src/backend/Sudoku.Application/DTOs/GameDto.cs
@@ -90,7 +90,7 @@ public record MoveHistoryDto(
     int? PreviousValue,
     int? NewValue)
 {
-    public static MoveHistoryDto FromMoveHistory(MoveHistory moveHistory)
+    public static MoveHistoryDto FromMoveHistory(MoveHistoryEntry moveHistory)
     {
         return new MoveHistoryDto(
             moveHistory.Row,

--- a/src/backend/Sudoku.Domain/Entities/SudokuGame.cs
+++ b/src/backend/Sudoku.Domain/Entities/SudokuGame.cs
@@ -3,7 +3,7 @@ namespace Sudoku.Domain.Entities;
 public class SudokuGame : AggregateRoot
 {
     private readonly List<Cell> _cells;
-    private readonly List<MoveHistory> _moveHistory;
+    private readonly List<GameHistoryEntry> _history;
 
     public GameId Id { get; private set; }
     public ProfileId ProfileId { get; private set; }
@@ -16,12 +16,12 @@ public class SudokuGame : AggregateRoot
     public DateTime? StartedAt { get; private set; }
     public DateTime? CompletedAt { get; private set; }
     public DateTime? PausedAt { get; private set; }
-    public List<MoveHistory> MoveHistory => _moveHistory;
+    public IReadOnlyList<MoveHistoryEntry> MoveHistory => _history.OfType<MoveHistoryEntry>().ToList();
 
     private SudokuGame()
     {
         _cells = [];
-        _moveHistory = [];
+        _history = [];
     }
 
     public static SudokuGame Create(ProfileId profileId, PlayerAlias displayName, GameDifficulty difficulty, BoardSize size, IEnumerable<Cell> initialCells)
@@ -53,7 +53,7 @@ public class SudokuGame : AggregateRoot
         GameStatusEnum statusEnum,
         GameStatistics statistics,
         IEnumerable<Cell> cells,
-        IEnumerable<MoveHistory> moveHistory,
+        IEnumerable<GameHistoryEntry> history,
         DateTime createdAt,
         DateTime? startedAt,
         DateTime? completedAt,
@@ -75,7 +75,7 @@ public class SudokuGame : AggregateRoot
         };
 
         game._cells.AddRange(cells);
-        game._moveHistory.AddRange(moveHistory);
+        game._history.AddRange(history);
 
         return game;
     }
@@ -109,19 +109,50 @@ public class SudokuGame : AggregateRoot
         // Check if this is a valid move (only when setting a value, not clearing)
         var isValid = !value.HasValue || IsValidMove(row, column, value.Value);
 
-        // Record move history before making the change
         var previousValue = cell.Value;
-        _moveHistory.Add(new MoveHistory(row, column, previousValue, value));
-
         cell.SetValue(value);
         Statistics.RecordMove(isValid);
 
+        var peerEliminations = value.HasValue
+            ? EliminatePeerCandidates(row, column, value.Value)
+            : [];
+
+        _history.Add(new MoveHistoryEntry(row, column, previousValue, value, peerEliminations));
+
         AddDomainEvent(new MoveMadeEvent(Id, row, column, value, Statistics));
+
+        foreach (var elimination in peerEliminations)
+        {
+            AddDomainEvent(new PossibleValueRemovedEvent(Id, elimination.Row, elimination.Column, elimination.Value));
+        }
 
         if (IsGameComplete())
         {
             CompleteGame();
         }
+    }
+
+    private List<PeerElimination> EliminatePeerCandidates(int row, int column, int value)
+    {
+        var boxRow = row / Size.BoxSize * Size.BoxSize;
+        var boxColumn = column / Size.BoxSize * Size.BoxSize;
+
+        var peers = _cells.Where(c =>
+            (c.Row == row || c.Column == column ||
+             (c.Row >= boxRow && c.Row < boxRow + Size.BoxSize && c.Column >= boxColumn && c.Column < boxColumn + Size.BoxSize)) &&
+            !(c.Row == row && c.Column == column));
+
+        var eliminations = new List<PeerElimination>();
+        foreach (var peer in peers)
+        {
+            if (peer.PossibleValues.Contains(value))
+            {
+                peer.RemovePossibleValue(value);
+                eliminations.Add(new PeerElimination(peer.Row, peer.Column, value));
+            }
+        }
+
+        return eliminations;
     }
 
     /// <summary>
@@ -155,9 +186,16 @@ public class SudokuGame : AggregateRoot
         var index = _cells.FindIndex(c => c.Row == target.Row && c.Column == target.Column);
         _cells[index] = Cell.CreateHint(target.Row, target.Column, correctValue, Size);
 
+        var peerEliminations = EliminatePeerCandidates(target.Row, target.Column, correctValue);
+
         Statistics.RecordHint();
 
         AddDomainEvent(new HintRevealedEvent(Id, target.Row, target.Column, correctValue, Statistics));
+
+        foreach (var elimination in peerEliminations)
+        {
+            AddDomainEvent(new PossibleValueRemovedEvent(Id, elimination.Row, elimination.Column, elimination.Value));
+        }
 
         if (IsGameComplete())
         {
@@ -186,6 +224,7 @@ public class SudokuGame : AggregateRoot
         }
 
         cell.AddPossibleValue(value);
+        _history.Add(new PossibleValueAddedEntry(row, column, value));
         AddDomainEvent(new PossibleValueAddedEvent(Id, row, column, value));
     }
 
@@ -203,6 +242,7 @@ public class SudokuGame : AggregateRoot
         }
 
         cell.RemovePossibleValue(value);
+        _history.Add(new PossibleValueRemovedEntry(row, column, value));
         AddDomainEvent(new PossibleValueRemovedEvent(Id, row, column, value));
     }
 
@@ -219,7 +259,9 @@ public class SudokuGame : AggregateRoot
             throw new CellIsFixedException($"Cannot modify fixed cell at position ({row}, {column})");
         }
 
+        var previousValues = cell.PossibleValues.ToList();
         cell.ClearPossibleValues();
+        _history.Add(new PossibleValuesClearedEntry(row, column, previousValues));
         AddDomainEvent(new PossibleValuesClearedEvent(Id, row, column));
     }
 
@@ -230,21 +272,47 @@ public class SudokuGame : AggregateRoot
             throw new GameNotInProgressException($"Cannot undo move in {Status} state");
         }
 
-        if (_moveHistory.Count == 0)
+        if (_history.Count == 0)
         {
             throw new NoMoveHistoryException();
         }
 
-        var lastMove = _moveHistory[^1];
-        _moveHistory.RemoveAt(_moveHistory.Count - 1);
+        var lastEntry = _history[^1];
+        _history.RemoveAt(_history.Count - 1);
 
-        var cell = GetCell(lastMove.Row, lastMove.Column);
-        cell.SetValue(lastMove.PreviousValue);
+        switch (lastEntry)
+        {
+            case MoveHistoryEntry move:
+                var cell = GetCell(move.Row, move.Column);
+                cell.SetValue(move.PreviousValue);
 
-        // Decrement the move count in statistics
-        Statistics.UndoMove();
+                foreach (var elimination in move.PeerEliminations)
+                {
+                    GetCell(elimination.Row, elimination.Column).AddPossibleValue(elimination.Value);
+                }
 
-        AddDomainEvent(new MoveUndoneEvent(Id, lastMove.Row, lastMove.Column, lastMove.PreviousValue));
+                Statistics.UndoMove();
+                AddDomainEvent(new MoveUndoneEvent(Id, move.Row, move.Column, move.PreviousValue));
+                break;
+
+            case PossibleValueAddedEntry added:
+                GetCell(added.Row, added.Column).RemovePossibleValue(added.Value);
+                AddDomainEvent(new PossibleValueRemovedEvent(Id, added.Row, added.Column, added.Value));
+                break;
+
+            case PossibleValueRemovedEntry removed:
+                GetCell(removed.Row, removed.Column).AddPossibleValue(removed.Value);
+                AddDomainEvent(new PossibleValueAddedEvent(Id, removed.Row, removed.Column, removed.Value));
+                break;
+
+            case PossibleValuesClearedEntry cleared:
+                var clearedCell = GetCell(cleared.Row, cleared.Column);
+                foreach (var previousValue in cleared.PreviousValues)
+                {
+                    clearedCell.AddPossibleValue(previousValue);
+                }
+                break;
+        }
     }
 
     public void ResetGame()
@@ -275,7 +343,7 @@ public class SudokuGame : AggregateRoot
         }
 
         // Clear move history
-        _moveHistory.Clear();
+        _history.Clear();
 
         // Reset statistics but keep the original timestamp
         Statistics = GameStatistics.Create();
@@ -396,6 +464,8 @@ public class SudokuGame : AggregateRoot
 
     public IReadOnlyList<Cell> GetCells() => _cells.AsReadOnly();
 
+    public IReadOnlyList<GameHistoryEntry> GetHistory() => _history.AsReadOnly();
+
     public Cell GetCell(int row, int column)
     {
         return _cells.FirstOrDefault(c => c.Row == row && c.Column == column) ?? throw new CellNotFoundException($"Cell not found at position ({row}, {column})");
@@ -485,6 +555,21 @@ public class SudokuGame : AggregateRoot
     }
 }
 
-public record MoveHistory(int Row, int Column, int? PreviousValue, int? NewValue);
+public abstract record GameHistoryEntry(int Row, int Column);
+
+public sealed record PeerElimination(int Row, int Column, int Value);
+
+public sealed record MoveHistoryEntry(
+    int Row,
+    int Column,
+    int? PreviousValue,
+    int? NewValue,
+    IReadOnlyList<PeerElimination> PeerEliminations) : GameHistoryEntry(Row, Column);
+
+public sealed record PossibleValueAddedEntry(int Row, int Column, int Value) : GameHistoryEntry(Row, Column);
+
+public sealed record PossibleValueRemovedEntry(int Row, int Column, int Value) : GameHistoryEntry(Row, Column);
+
+public sealed record PossibleValuesClearedEntry(int Row, int Column, IReadOnlyList<int> PreviousValues) : GameHistoryEntry(Row, Column);
 
 public record ValidationResult(bool IsValid, List<string> Errors);

--- a/src/backend/Sudoku.Infrastructure/Mappers/SudokuGameMapper.cs
+++ b/src/backend/Sudoku.Infrastructure/Mappers/SudokuGameMapper.cs
@@ -20,15 +20,7 @@ public static class SudokuGameMapper
             Status = game.Status,
             Cells = game.GetCells().Select(ToDocument).ToList(),
             Statistics = ToDocument(game.Statistics),
-            MoveHistory = game.MoveHistory
-                .Select(m => new MoveHistoryDocument
-                {
-                    Row = m.Row,
-                    Column = m.Column,
-                    PreviousValue = m.PreviousValue,
-                    NewValue = m.NewValue
-                })
-                .ToList(),
+            History = game.GetHistory().Select(ToDocument).ToList(),
             CreatedAt = game.CreatedAt,
             StartedAt = game.StartedAt,
             CompletedAt = game.CompletedAt,
@@ -57,6 +49,11 @@ public static class SudokuGameMapper
             throw new InvalidPuzzleException();
         }
 
+        var history = document.History.Count > 0
+            ? document.History.Select(ToDomain)
+            : document.MoveHistory.Select(m =>
+                (GameHistoryEntry)new MoveHistoryEntry(m.Row, m.Column, m.PreviousValue, m.NewValue, []));
+
         var sudokuGame = SudokuGame.Reconstitute(
             GameId.Create(document.GameId),
             profileId,
@@ -66,7 +63,7 @@ public static class SudokuGameMapper
             document.Status,
             document.Statistics.ToDomain(),
             document.Cells.Select(c => c.ToDomain(size)).ToList(),
-            document.MoveHistory.Select(m => new MoveHistory(m.Row, m.Column, m.PreviousValue, m.NewValue)),
+            history,
             document.CreatedAt,
             document.StartedAt,
             document.CompletedAt,
@@ -75,6 +72,57 @@ public static class SudokuGameMapper
 
         return sudokuGame;
     }
+
+    private static GameHistoryEntryDocument ToDocument(GameHistoryEntry entry) => entry switch
+    {
+        MoveHistoryEntry move => new GameHistoryEntryDocument
+        {
+            Type = "Move",
+            Row = move.Row,
+            Column = move.Column,
+            PreviousValue = move.PreviousValue,
+            NewValue = move.NewValue,
+            PeerEliminations = move.PeerEliminations
+                .Select(p => new PeerEliminationDocument { Row = p.Row, Column = p.Column, Value = p.Value })
+                .ToList()
+        },
+        PossibleValueAddedEntry added => new GameHistoryEntryDocument
+        {
+            Type = "Added",
+            Row = added.Row,
+            Column = added.Column,
+            Value = added.Value
+        },
+        PossibleValueRemovedEntry removed => new GameHistoryEntryDocument
+        {
+            Type = "Removed",
+            Row = removed.Row,
+            Column = removed.Column,
+            Value = removed.Value
+        },
+        PossibleValuesClearedEntry cleared => new GameHistoryEntryDocument
+        {
+            Type = "Cleared",
+            Row = cleared.Row,
+            Column = cleared.Column,
+            PreviousValues = cleared.PreviousValues.ToList()
+        },
+        _ => throw new InvalidOperationException($"Unknown history entry type: {entry.GetType().Name}")
+    };
+
+    private static GameHistoryEntry ToDomain(GameHistoryEntryDocument document) => document.Type switch
+    {
+        "Move" => new MoveHistoryEntry(
+            document.Row,
+            document.Column,
+            document.PreviousValue,
+            document.NewValue,
+            document.PeerEliminations.Select(p => new PeerElimination(p.Row, p.Column, p.Value)).ToList()),
+        "Added" => new PossibleValueAddedEntry(document.Row, document.Column, document.Value ?? 0),
+        "Removed" => new PossibleValueRemovedEntry(document.Row, document.Column, document.Value ?? 0),
+        "Cleared" => new PossibleValuesClearedEntry(document.Row, document.Column, document.PreviousValues),
+        _ => throw new InvalidOperationException($"Unknown history entry type: {document.Type}")
+    };
 
     private static CellDocument ToDocument(this Cell cell)
     {

--- a/src/backend/Sudoku.Infrastructure/Models/SudokuGameDocument.cs
+++ b/src/backend/Sudoku.Infrastructure/Models/SudokuGameDocument.cs
@@ -38,6 +38,9 @@ public class SudokuGameDocument
     [JsonProperty("moveHistory")]
     public List<MoveHistoryDocument> MoveHistory { get; set; } = [];
 
+    [JsonProperty("history")]
+    public List<GameHistoryEntryDocument> History { get; set; } = [];
+
     [JsonProperty("createdAt")]
     public DateTime CreatedAt { get; set; }
 
@@ -93,6 +96,11 @@ public class GameStatisticsDocument
     public DateTime? LastMoveAt { get; set; }
 }
 
+/// <summary>
+/// Legacy shape kept only so pre-existing Cosmos documents (saved before the unified
+/// <see cref="GameHistoryEntryDocument"/> changelog) can still be read. New saves use
+/// <see cref="SudokuGameDocument.History"/> exclusively.
+/// </summary>
 public class MoveHistoryDocument
 {
     [JsonProperty("row")]
@@ -106,4 +114,43 @@ public class MoveHistoryDocument
 
     [JsonProperty("newValue")]
     public int? NewValue { get; set; }
+}
+
+public class GameHistoryEntryDocument
+{
+    [JsonProperty("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonProperty("row")]
+    public int Row { get; set; }
+
+    [JsonProperty("column")]
+    public int Column { get; set; }
+
+    [JsonProperty("previousValue")]
+    public int? PreviousValue { get; set; }
+
+    [JsonProperty("newValue")]
+    public int? NewValue { get; set; }
+
+    [JsonProperty("value")]
+    public int? Value { get; set; }
+
+    [JsonProperty("previousValues")]
+    public List<int> PreviousValues { get; set; } = [];
+
+    [JsonProperty("peerEliminations")]
+    public List<PeerEliminationDocument> PeerEliminations { get; set; } = [];
+}
+
+public class PeerEliminationDocument
+{
+    [JsonProperty("row")]
+    public int Row { get; set; }
+
+    [JsonProperty("column")]
+    public int Column { get; set; }
+
+    [JsonProperty("value")]
+    public int Value { get; set; }
 }

--- a/src/backend/Tests/Domain/SudokuGameMoveHistoryTests.cs
+++ b/src/backend/Tests/Domain/SudokuGameMoveHistoryTests.cs
@@ -79,10 +79,10 @@ public class SudokuGameMoveHistoryTests : MoqBaseTestByType<SudokuGame>
     {
         // Arrange
         var cells = CellsFactory.CreateEmptyCells();
-        var moveHistory = new List<MoveHistory>
+        var moveHistory = new List<GameHistoryEntry>
         {
-            new(0, 0, null, 5),
-            new(1, 1, null, 3)
+            new MoveHistoryEntry(0, 0, null, 5, []),
+            new MoveHistoryEntry(1, 1, null, 3, [])
         };
 
         // Act

--- a/src/backend/Tests/Domain/SudokuGamePeerEliminationTests.cs
+++ b/src/backend/Tests/Domain/SudokuGamePeerEliminationTests.cs
@@ -1,0 +1,321 @@
+using DepenMock.Attributes;
+using Sudoku.Domain.Entities;
+using Sudoku.Domain.ValueObjects;
+using UnitTests.Helpers.Factories;
+
+namespace UnitTests.Domain;
+
+[LogOutput(LogOutputTiming.Always)]
+public class SudokuGamePeerEliminationTests : MoqBaseTestByType<SudokuGame>
+{
+    [Fact]
+    public void MakeMove_WithValue_RemovesValueFromRowPeerPossibleValues()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        sut.AddPossibleValue(0, 5, 5);
+
+        // Act
+        sut.MakeMove(0, 0, 5);
+
+        // Assert
+        sut.GetCell(0, 5).PossibleValues.Should().NotContain(5);
+    }
+
+    [Fact]
+    public void MakeMove_WithValue_RemovesValueFromColumnPeerPossibleValues()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        sut.AddPossibleValue(5, 0, 5);
+
+        // Act
+        sut.MakeMove(0, 0, 5);
+
+        // Assert
+        sut.GetCell(5, 0).PossibleValues.Should().NotContain(5);
+    }
+
+    [Fact]
+    public void MakeMove_WithValue_RemovesValueFromBoxPeerPossibleValues()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        sut.AddPossibleValue(1, 1, 5);
+
+        // Act
+        sut.MakeMove(0, 0, 5);
+
+        // Assert
+        sut.GetCell(1, 1).PossibleValues.Should().NotContain(5);
+    }
+
+    [Fact]
+    public void MakeMove_WithValue_DoesNotAffectUnrelatedCellPossibleValues()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        sut.AddPossibleValue(4, 4, 5);
+
+        // Act
+        sut.MakeMove(0, 0, 5);
+
+        // Assert
+        sut.GetCell(4, 4).PossibleValues.Should().Contain(5);
+    }
+
+    [Fact]
+    public void MakeMove_WithValue_DoesNotThrow_WhenPeerCellAlreadyHasValue()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        sut.MakeMove(0, 5, 3);
+
+        // Act
+        var act = () => sut.MakeMove(0, 0, 5);
+
+        // Assert
+        act.Should().NotThrow();
+        sut.GetCell(0, 5).Value.Should().Be(3);
+    }
+
+    [Fact]
+    public void MakeMove_ClearingCell_DoesNotEliminatePeerCandidates()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        sut.MakeMove(0, 0, 5);
+        sut.AddPossibleValue(0, 5, 5);
+
+        // Act
+        sut.MakeMove(0, 0, null);
+
+        // Assert
+        sut.GetCell(0, 5).PossibleValues.Should().Contain(5);
+    }
+
+    [Fact]
+    public void MakeMove_RecordsPeerEliminationsInHistoryEntry()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        sut.AddPossibleValue(0, 5, 5);
+        sut.AddPossibleValue(5, 0, 5);
+        sut.AddPossibleValue(1, 1, 5);
+
+        // Act
+        sut.MakeMove(0, 0, 5);
+
+        // Assert
+        var moveEntry = sut.GetHistory().Last().Should().BeOfType<MoveHistoryEntry>().Subject;
+        moveEntry.PeerEliminations.Should().HaveCount(3);
+        moveEntry.PeerEliminations.Should().Contain(p => p.Row == 0 && p.Column == 5 && p.Value == 5);
+        moveEntry.PeerEliminations.Should().Contain(p => p.Row == 5 && p.Column == 0 && p.Value == 5);
+        moveEntry.PeerEliminations.Should().Contain(p => p.Row == 1 && p.Column == 1 && p.Value == 5);
+    }
+
+    [Fact]
+    public void RevealHint_RemovesValueFromRowPeerPossibleValues()
+    {
+        // Arrange - leave row 0 entirely empty/unlocked so the hint target is
+        // guaranteed to land there, and seed every digit as a candidate on every
+        // row-0 cell so whichever column gets picked, its row peers still have
+        // the revealed value to eliminate.
+        var sut = CreateGameWithEmptyRowZero();
+        for (var col = 0; col < 9; col++)
+        {
+            for (var digit = 1; digit <= 9; digit++)
+            {
+                sut.AddPossibleValue(0, col, digit);
+            }
+        }
+
+        // Act
+        var (row, column, value) = sut.RevealHint(PuzzleFactory.GetSolvedPuzzle());
+
+        // Assert
+        for (var col = 0; col < 9; col++)
+        {
+            if (col == column)
+            {
+                continue;
+            }
+
+            sut.GetCell(row, col).PossibleValues.Should().NotContain(value);
+        }
+    }
+
+    [Fact]
+    public void RevealHint_DoesNotPushEliminationsToHistory()
+    {
+        // Arrange
+        var sut = CreateGameWithEmptyRowZero();
+        for (var col = 0; col < 9; col++)
+        {
+            sut.AddPossibleValue(0, col, 1);
+        }
+
+        var historyCountBeforeHint = sut.GetHistory().Count;
+
+        // Act
+        sut.RevealHint(PuzzleFactory.GetSolvedPuzzle());
+
+        // Assert
+        sut.GetHistory().Should().HaveCount(historyCountBeforeHint);
+        sut.GetHistory().Should().NotContain(e => e is MoveHistoryEntry);
+    }
+
+    [Fact]
+    public void UndoLastMove_RestoresCascadedPeerEliminationsAtomically()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        sut.AddPossibleValue(0, 5, 5);
+        sut.AddPossibleValue(5, 0, 5);
+        sut.AddPossibleValue(1, 1, 5);
+        sut.MakeMove(0, 0, 5);
+
+        // Act
+        sut.UndoLastMove();
+
+        // Assert
+        sut.GetCell(0, 0).HasValue.Should().BeFalse();
+        sut.GetCell(0, 5).PossibleValues.Should().Contain(5);
+        sut.GetCell(5, 0).PossibleValues.Should().Contain(5);
+        sut.GetCell(1, 1).PossibleValues.Should().Contain(5);
+    }
+
+    [Fact]
+    public void UndoLastMove_WhenLastEntryIsPencilMarkEdit_DoesNotChangeStatistics()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        sut.MakeMove(0, 0, 5);
+        sut.AddPossibleValue(1, 1, 3);
+        var totalMovesBeforeUndo = sut.Statistics.TotalMoves;
+        var validMovesBeforeUndo = sut.Statistics.ValidMoves;
+
+        // Act
+        sut.UndoLastMove();
+
+        // Assert
+        sut.Statistics.TotalMoves.Should().Be(totalMovesBeforeUndo);
+        sut.Statistics.ValidMoves.Should().Be(validMovesBeforeUndo);
+        sut.GetCell(1, 1).PossibleValues.Should().NotContain(3);
+    }
+
+    [Fact]
+    public void UndoLastMove_UndoingManualAdd_RemovesThePossibleValue()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        sut.AddPossibleValue(2, 2, 7);
+
+        // Act
+        sut.UndoLastMove();
+
+        // Assert
+        sut.GetCell(2, 2).PossibleValues.Should().NotContain(7);
+    }
+
+    [Fact]
+    public void UndoLastMove_UndoingManualRemove_RestoresThePossibleValue()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        sut.AddPossibleValue(2, 2, 7);
+        sut.RemovePossibleValue(2, 2, 7);
+
+        // Act
+        sut.UndoLastMove();
+
+        // Assert
+        sut.GetCell(2, 2).PossibleValues.Should().Contain(7);
+    }
+
+    [Fact]
+    public void UndoLastMove_UndoingClear_RestoresAllPreviousPossibleValues()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        sut.AddPossibleValue(2, 2, 7);
+        sut.AddPossibleValue(2, 2, 8);
+        sut.ClearPossibleValues(2, 2);
+
+        // Act
+        sut.UndoLastMove();
+
+        // Assert
+        sut.GetCell(2, 2).PossibleValues.Should().Contain(7);
+        sut.GetCell(2, 2).PossibleValues.Should().Contain(8);
+    }
+
+    [Fact]
+    public void AddPossibleValue_PushesEntryToHistory()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+
+        // Act
+        sut.AddPossibleValue(3, 3, 4);
+
+        // Assert
+        var entry = sut.GetHistory().Last().Should().BeOfType<PossibleValueAddedEntry>().Subject;
+        entry.Row.Should().Be(3);
+        entry.Column.Should().Be(3);
+        entry.Value.Should().Be(4);
+    }
+
+    [Fact]
+    public void RemovePossibleValue_PushesEntryToHistory()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        sut.AddPossibleValue(3, 3, 4);
+
+        // Act
+        sut.RemovePossibleValue(3, 3, 4);
+
+        // Assert
+        var entry = sut.GetHistory().Last().Should().BeOfType<PossibleValueRemovedEntry>().Subject;
+        entry.Row.Should().Be(3);
+        entry.Column.Should().Be(3);
+        entry.Value.Should().Be(4);
+    }
+
+    [Fact]
+    public void ClearPossibleValues_PushesEntryWithPreviousValuesToHistory()
+    {
+        // Arrange
+        var sut = CreateStartedEmptyGame();
+        sut.AddPossibleValue(3, 3, 4);
+        sut.AddPossibleValue(3, 3, 6);
+
+        // Act
+        sut.ClearPossibleValues(3, 3);
+
+        // Assert
+        var entry = sut.GetHistory().Last().Should().BeOfType<PossibleValuesClearedEntry>().Subject;
+        entry.PreviousValues.Should().BeEquivalentTo([4, 6]);
+    }
+
+    private static SudokuGame CreateStartedEmptyGame()
+    {
+        var game = GameFactory.CreateGameWithCells(CellsFactory.CreateEmptyCells());
+        game.StartGame();
+        return game;
+    }
+
+    private static SudokuGame CreateGameWithEmptyRowZero()
+    {
+        var cells = CellsFactory.CreateCompletedCells()
+            .Select(c => c.Row == 0
+                ? Cell.CreateEmpty(c.Row, c.Column, BoardSize.Nine)
+                : Cell.CreateFixed(c.Row, c.Column, c.Value!.Value, BoardSize.Nine))
+            .ToList();
+
+        var game = GameFactory.CreateGameWithCells(cells);
+        game.StartGame();
+        return game;
+    }
+}

--- a/src/backend/Tests/Infrastructure/Mappers/SudokuGameMapperTests.cs
+++ b/src/backend/Tests/Infrastructure/Mappers/SudokuGameMapperTests.cs
@@ -1,4 +1,5 @@
 using DepenMock.Attributes;
+using Sudoku.Domain.Entities;
 using Sudoku.Domain.Exceptions;
 using Sudoku.Domain.ValueObjects;
 using Sudoku.Infrastructure.Mappers;
@@ -10,6 +11,89 @@ namespace UnitTests.Infrastructure.Mappers;
 [LogOutput(LogOutputTiming.Always)]
 public class SudokuGameMapperTests : MoqBaseTestByType<SudokuGameDocument>
 {
+    [Fact]
+    public void RoundTrip_PreservesMoveHistoryWithPeerEliminations()
+    {
+        // Arrange
+        var game = GameFactory.CreateGameWithCells(CellsFactory.CreateEmptyCells());
+        game.StartGame();
+        game.AddPossibleValue(0, 5, 5);
+        game.MakeMove(0, 0, 5);
+
+        // Act
+        var document = SudokuGameMapper.ToDocument(game);
+        var restored = SudokuGameMapper.ToDomain(document);
+
+        // Assert
+        var moveEntry = restored.GetHistory().OfType<MoveHistoryEntry>().Single(m => m.Row == 0 && m.Column == 0);
+        moveEntry.PeerEliminations.Should().ContainSingle(p => p.Row == 0 && p.Column == 5 && p.Value == 5);
+
+        restored.UndoLastMove();
+        restored.GetCell(0, 0).HasValue.Should().BeFalse();
+        restored.GetCell(0, 5).PossibleValues.Should().Contain(5);
+    }
+
+    [Fact]
+    public void RoundTrip_PreservesPencilMarkEditHistory()
+    {
+        // Arrange
+        var game = GameFactory.CreateGameWithCells(CellsFactory.CreateEmptyCells());
+        game.StartGame();
+        game.AddPossibleValue(2, 2, 7);
+        game.RemovePossibleValue(2, 2, 7);
+        game.AddPossibleValue(3, 3, 4);
+        game.ClearPossibleValues(3, 3);
+        var totalMovesBeforeRoundTrip = game.Statistics.TotalMoves;
+
+        // Act
+        var document = SudokuGameMapper.ToDocument(game);
+        var restored = SudokuGameMapper.ToDomain(document);
+
+        // Assert - undoing the most recent (pencil-mark) entry must not touch move statistics
+        restored.UndoLastMove();
+        restored.GetCell(3, 3).PossibleValues.Should().Contain(4);
+        restored.Statistics.TotalMoves.Should().Be(totalMovesBeforeRoundTrip);
+    }
+
+    [Fact]
+    public void ToDomain_WithLegacyMoveHistoryDocumentAndNoHistoryField_SynthesizesMoveEntriesWithEmptyPeerEliminations()
+    {
+        // Arrange - simulates a document saved before the unified changelog existed
+        var game = GameFactory.CreateGameWithCells(CellsFactory.CreateEmptyCells());
+        game.StartGame();
+        game.MakeMove(0, 0, 5);
+        var document = SudokuGameMapper.ToDocument(game);
+        document.History = [];
+        document.MoveHistory = [new MoveHistoryDocument { Row = 0, Column = 0, PreviousValue = null, NewValue = 5 }];
+
+        // Act
+        var restored = SudokuGameMapper.ToDomain(document);
+
+        // Assert
+        var moveEntry = restored.GetHistory().OfType<MoveHistoryEntry>().Single();
+        moveEntry.Row.Should().Be(0);
+        moveEntry.Column.Should().Be(0);
+        moveEntry.NewValue.Should().Be(5);
+        moveEntry.PeerEliminations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToDomain_WithEmptyHistoryAndEmptyLegacyMoveHistory_ReturnsEmptyHistory()
+    {
+        // Arrange
+        var game = GameFactory.CreateGameWithCells(CellsFactory.CreateEmptyCells());
+        game.StartGame();
+        var document = SudokuGameMapper.ToDocument(game);
+        document.History = [];
+        document.MoveHistory = [];
+
+        // Act
+        var restored = SudokuGameMapper.ToDomain(document);
+
+        // Assert
+        restored.GetHistory().Should().BeEmpty();
+    }
+
     [Theory]
     [InlineData("Easy")]
     [InlineData("Medium")]


### PR DESCRIPTION
## Description

When a player enters a number in a cell, it now automatically removes that number from the pencil marks (candidate notes) of every peer cell in the same row, column, and box — matching standard Sudoku app behavior. Revealing a hint does the same. Undo correctly reverses this.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `MakeMove` and `RevealHint` eliminate the placed value from row/column/box peers' pencil marks (`SudokuGame.EliminatePeerCandidates`).
- `SudokuGame`'s move history is replaced by a small polymorphic changelog (`GameHistoryEntry` → `MoveHistoryEntry` / `PossibleValueAddedEntry` / `PossibleValueRemovedEntry` / `PossibleValuesClearedEntry`), so `UndoLastMove` can:
  - Revert a move's cell value **and** all of its cascaded peer eliminations atomically, in one Undo click.
  - Separately revert manual pencil-mark edits (add/remove/clear), without ever resurrecting a note the player deliberately erased.
  - Only decrement move statistics when undoing an actual move, never a pencil-mark-only undo.
- The public API contract is unchanged: `GameDto.MoveHistory` still reflects only real moves (pencil-mark changelog entries stay internal).
- `SudokuGameDocument`/`SudokuGameMapper` persist the new changelog for `CosmosDbGameRepository`, with a backward-compatible fallback for documents saved before this change (old `moveHistory` field still reads correctly). `AzureBlobGameRepository` is unaffected — it already can't round-trip `SudokuGame`'s private state (pre-existing, unrelated gap in that legacy store).

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

- 786/786 backend unit/integration tests pass (excluding the pre-existing `SlowGeneration`-tagged suite).
- 21 new tests: 17 domain tests (`SudokuGamePeerEliminationTests`) covering peer elimination on move/hint, atomic undo restoration, and pencil-mark-edit undo/statistics behavior; 4 new Cosmos mapper round-trip tests, including a legacy-document backward-compatibility case.
- Verified end-to-end against the running app (API + Cosmos/Azurite emulators + React UI) via a scripted browser flow: placing a number visibly clears peer pencil marks, Undo restores the move and all cascaded eliminations in one click, undoing a manual pencil-mark edit leaves move statistics untouched, and a revealed hint eliminates peer candidates but is not itself undoable.

## Screenshots (if applicable)

N/A (verified via automated browser script, not visual screenshots)

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation (if necessary)