### PR TITLE
Disable Hard and Expert difficulties for 16x16 boards

### DIFF
--- a/src/backend/Sudoku.Application/Handlers/CreateGameCommandHandler.cs
+++ b/src/backend/Sudoku.Application/Handlers/CreateGameCommandHandler.cs
@@ -23,6 +23,13 @@ public class CreateGameCommandHandler(
             var difficulty = GameDifficulty.FromName(request.Difficulty);
             var size = BoardSize.FromValue(request.Size);
 
+            // Checked before dequeuing so an unsupported request never consumes a pooled puzzle.
+            if (!size.Supports(difficulty))
+            {
+                logger.LogWarning("Rejected game creation: {Difficulty} is not supported for {Size}", difficulty.Name, size);
+                return Result<string>.Failure($"{difficulty.Name} is not available for {size} boards.");
+            }
+
             var puzzle = await puzzlePoolService.DequeueAsync(size, difficulty);
 
             if (puzzle is null)

--- a/src/backend/Sudoku.Domain/Entities/SudokuGame.cs
+++ b/src/backend/Sudoku.Domain/Entities/SudokuGame.cs
@@ -26,6 +26,11 @@ public class SudokuGame : AggregateRoot
 
     public static SudokuGame Create(ProfileId profileId, PlayerAlias displayName, GameDifficulty difficulty, BoardSize size, IEnumerable<Cell> initialCells)
     {
+        if (!size.Supports(difficulty))
+        {
+            throw new UnsupportedDifficultyException(size, difficulty);
+        }
+
         var game = new SudokuGame
         {
             Id = GameId.New(),

--- a/src/backend/Sudoku.Domain/Exceptions/UnsupportedDifficultyException.cs
+++ b/src/backend/Sudoku.Domain/Exceptions/UnsupportedDifficultyException.cs
@@ -1,0 +1,6 @@
+using Sudoku.Domain.ValueObjects;
+
+namespace Sudoku.Domain.Exceptions;
+
+public class UnsupportedDifficultyException(BoardSize size, GameDifficulty difficulty)
+    : DomainException($"{difficulty.Name} is not available for {size} boards.");

--- a/src/backend/Sudoku.Domain/ValueObjects/BoardSize.cs
+++ b/src/backend/Sudoku.Domain/ValueObjects/BoardSize.cs
@@ -4,8 +4,17 @@ namespace Sudoku.Domain.ValueObjects;
 
 public record BoardSize
 {
-    public static readonly BoardSize Nine = new(9, 3, 17, 3);
-    public static readonly BoardSize Sixteen = new(16, 4, 55, 6);
+    // Declared before the board instances so the static initializers below see populated arrays.
+    private static readonly GameDifficulty[] AllDifficulties =
+        [GameDifficulty.Easy, GameDifficulty.Medium, GameDifficulty.Hard, GameDifficulty.Expert];
+
+    // Hard/Expert digging on a 256-cell grid runs for minutes per puzzle and is highly
+    // seed-dependent, so the pool can never be kept stocked. Those two are not offered at 16x16.
+    private static readonly GameDifficulty[] SixteenDifficulties =
+        [GameDifficulty.Easy, GameDifficulty.Medium];
+
+    public static readonly BoardSize Nine = new(9, 3, 17, 3, AllDifficulties);
+    public static readonly BoardSize Sixteen = new(16, 4, 55, 6, SixteenDifficulties);
 
     public int Size { get; }
     public int BoxSize { get; }
@@ -13,14 +22,18 @@ public record BoardSize
     public int MaxHints { get; }
     public int CellCount => Size * Size;
     public IEnumerable<int> AllValues => Enumerable.Range(1, Size);
+    public IReadOnlyList<GameDifficulty> SupportedDifficulties { get; }
 
-    private BoardSize(int size, int boxSize, int minimumClues, int maxHints)
+    private BoardSize(int size, int boxSize, int minimumClues, int maxHints, IReadOnlyList<GameDifficulty> supportedDifficulties)
     {
         Size = size;
         BoxSize = boxSize;
         MinimumClues = minimumClues;
         MaxHints = maxHints;
+        SupportedDifficulties = supportedDifficulties;
     }
+
+    public bool Supports(GameDifficulty difficulty) => SupportedDifficulties.Contains(difficulty);
 
     public static BoardSize FromValue(int value) => value switch
     {

--- a/src/backend/Sudoku.Functions/Services/PuzzlePoolSeeder.cs
+++ b/src/backend/Sudoku.Functions/Services/PuzzlePoolSeeder.cs
@@ -16,18 +16,13 @@ public class PuzzlePoolSeeder(IPuzzlePoolService puzzlePoolService, ILogger<Puzz
     /// </summary>
     public static readonly TimeSpan TimeBudget = TimeSpan.FromMinutes(4);
 
-    // Fast/cheap combinations first so a single invocation reliably tops up the 9x9 pools even
-    // if it runs out of budget partway through the slower 16x16 Hard/Expert generation.
+    // Driven off BoardSize.SupportedDifficulties so the pools stay in step with what players can
+    // actually start. Fast/cheap 9x9 combinations run first so a single invocation reliably tops
+    // those up even if it runs out of budget partway through the slower 16x16 generation.
     private static readonly (BoardSize Size, GameDifficulty Difficulty, int Target)[] Combinations =
     [
-        (BoardSize.Nine, GameDifficulty.Easy, TargetPoolSize),
-        (BoardSize.Nine, GameDifficulty.Medium, TargetPoolSize),
-        (BoardSize.Nine, GameDifficulty.Hard, TargetPoolSize),
-        (BoardSize.Nine, GameDifficulty.Expert, TargetPoolSize),
-        (BoardSize.Sixteen, GameDifficulty.Easy, TargetPoolSizeSixteen),
-        (BoardSize.Sixteen, GameDifficulty.Medium, TargetPoolSizeSixteen),
-        (BoardSize.Sixteen, GameDifficulty.Hard, TargetPoolSizeSixteen),
-        (BoardSize.Sixteen, GameDifficulty.Expert, TargetPoolSizeSixteen)
+        .. BoardSize.Nine.SupportedDifficulties.Select(d => (BoardSize.Nine, d, TargetPoolSize)),
+        .. BoardSize.Sixteen.SupportedDifficulties.Select(d => (BoardSize.Sixteen, d, TargetPoolSizeSixteen))
     ];
 
     public async Task<int> SeedPoolAsync()

--- a/src/backend/Tests/Application/Handlers/CreateGameCommandHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/CreateGameCommandHandlerTests.cs
@@ -209,7 +209,7 @@ public class CreateGameCommandHandlerTests : MoqBaseTestByAbstraction<CreateGame
     public async Task Handle_When16x16PoolEmpty_ReturnsFailureWithPoolEmptyErrorCodeAndDoesNotCallGenerator()
     {
         // Arrange
-        var command = new CreateGameCommand(Guid.NewGuid().ToString(), "TestPlayer", "Expert", 16);
+        var command = new CreateGameCommand(Guid.NewGuid().ToString(), "TestPlayer", "Medium", 16);
 
         _mockPuzzlePoolService.SetupDequeueReturnsEmpty();
 
@@ -244,6 +244,48 @@ public class CreateGameCommandHandlerTests : MoqBaseTestByAbstraction<CreateGame
         // Assert
         result.IsSuccess.Should().BeTrue();
         _mockPuzzleGenerator.VerifyGeneratePuzzleAsyncCalledOnce(difficulty, BoardSize.Nine);
+    }
+
+    [Theory]
+    [InlineData("Hard")]
+    [InlineData("Expert")]
+    public async Task Handle_With16x16AndUnsupportedDifficulty_ReturnsFailureAndNeverTouchesThePool(string difficulty)
+    {
+        // Arrange
+        var command = new CreateGameCommand(Guid.NewGuid().ToString(), "TestPlayer", difficulty, 16);
+
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be($"{difficulty} is not available for 16x16 boards.");
+        result.ErrorCode.Should().BeNull();
+        _mockPuzzlePoolService.VerifyDequeueNotCalled();
+        _mockPuzzleGenerator.VerifyGeneratePuzzleAsyncNeverCalled();
+        _mockGameRepository.VerifySaveNeverCalled();
+    }
+
+    [Theory]
+    [InlineData("Hard")]
+    [InlineData("Expert")]
+    public async Task Handle_With9x9AndHigherDifficulties_StillCreatesGame(string difficulty)
+    {
+        // Arrange — regression: the 16x16 restriction must not leak onto the classic board
+        var puzzle = CreateTestPuzzle();
+        var command = new CreateGameCommand(Guid.NewGuid().ToString(), "TestPlayer", difficulty, 9);
+
+        _mockPuzzlePoolService.SetupDequeueReturns(puzzle);
+
+        var sut = ResolveSut();
+
+        // Act
+        var result = await sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
     }
 
     [Fact]

--- a/src/backend/Tests/Application/Handlers/GetPlayerStatsQueryHandlerTests.cs
+++ b/src/backend/Tests/Application/Handlers/GetPlayerStatsQueryHandlerTests.cs
@@ -192,7 +192,7 @@ public class GetPlayerStatsQueryHandlerTests
         // Arrange
         _mockCompletionRepository.SetupGetByProfileId([]);
         _mockGameRepository.SetupGetByProfileId([
-            GameFactory.CreateGameWithDifficulty(GameDifficulty.Hard, BoardSize.Sixteen)
+            GameFactory.CreateLegacyGame(GameDifficulty.Hard, BoardSize.Sixteen)
         ]);
         var sut = ResolveSut();
 

--- a/src/backend/Tests/Domain/BoardSizeTests.cs
+++ b/src/backend/Tests/Domain/BoardSizeTests.cs
@@ -1,0 +1,55 @@
+using DepenMock.Attributes;
+using Sudoku.Domain.ValueObjects;
+
+namespace UnitTests.Domain;
+
+[LogOutput(LogOutputTiming.Always)]
+public class BoardSizeTests : MoqBaseTestByType<BoardSize>
+{
+    [Theory]
+    [MemberData(nameof(AllDifficulties))]
+    public void Supports_ForNine_AllowsEveryDifficulty(GameDifficulty difficulty)
+    {
+        // Act / Assert
+        BoardSize.Nine.Supports(difficulty).Should().BeTrue();
+    }
+
+    [Theory]
+    [MemberData(nameof(SixteenSupportedDifficulties))]
+    public void Supports_ForSixteen_AllowsEasyAndMedium(GameDifficulty difficulty)
+    {
+        // Act / Assert
+        BoardSize.Sixteen.Supports(difficulty).Should().BeTrue();
+    }
+
+    [Theory]
+    [MemberData(nameof(SixteenUnsupportedDifficulties))]
+    public void Supports_ForSixteen_RejectsHardAndExpert(GameDifficulty difficulty)
+    {
+        // Act / Assert
+        BoardSize.Sixteen.Supports(difficulty).Should().BeFalse();
+    }
+
+    [Fact]
+    public void SupportedDifficulties_ForNine_ContainsAllFourDifficulties()
+    {
+        // Act / Assert
+        BoardSize.Nine.SupportedDifficulties.Should().HaveCount(4);
+    }
+
+    [Fact]
+    public void SupportedDifficulties_ForSixteen_ContainsOnlyEasyAndMedium()
+    {
+        // Act / Assert
+        BoardSize.Sixteen.SupportedDifficulties.Should().BeEquivalentTo([GameDifficulty.Easy, GameDifficulty.Medium]);
+    }
+
+    public static TheoryData<GameDifficulty> AllDifficulties =>
+        [GameDifficulty.Easy, GameDifficulty.Medium, GameDifficulty.Hard, GameDifficulty.Expert];
+
+    public static TheoryData<GameDifficulty> SixteenSupportedDifficulties =>
+        [GameDifficulty.Easy, GameDifficulty.Medium];
+
+    public static TheoryData<GameDifficulty> SixteenUnsupportedDifficulties =>
+        [GameDifficulty.Hard, GameDifficulty.Expert];
+}

--- a/src/backend/Tests/Domain/SudokuGameTests.cs
+++ b/src/backend/Tests/Domain/SudokuGameTests.cs
@@ -109,6 +109,23 @@ public class SudokuGameTests : MoqBaseTestByType<SudokuGame>
         evt.DisplayName.Should().Be(displayName);
     }
 
+    [Theory]
+    [InlineData(3)]
+    [InlineData(4)]
+    public void Create_WithDifficultyUnsupportedByTheBoardSize_ThrowsUnsupportedDifficultyException(int difficultyValue)
+    {
+        // Arrange
+        var difficulty = GameDifficulty.FromValue(difficultyValue);
+        var cells = GenerateEmptyCells();
+
+        // Act
+        Action act = () => SudokuGame.Create(ProfileId.New(), PlayerAlias.Create("TestPlayer"), difficulty, BoardSize.Sixteen, cells);
+
+        // Assert
+        act.Should().Throw<UnsupportedDifficultyException>()
+            .WithMessage($"{difficulty.Name} is not available for 16x16 boards.");
+    }
+
     [Fact]
     public void IsGameComplete_WithAllCellsFilledCorrectly_ReturnsTrue()
     {

--- a/src/backend/Tests/Functions/PuzzlePoolSeederTests.cs
+++ b/src/backend/Tests/Functions/PuzzlePoolSeederTests.cs
@@ -54,7 +54,7 @@ public class PuzzlePoolSeederTests : MoqBaseTestByAbstraction<PuzzlePoolSeeder, 
     }
 
     [Fact]
-    public async Task SeedPoolAsync_ChecksEachOfTheEightCombinationsExactlyOnce()
+    public async Task SeedPoolAsync_ChecksEachSupportedCombinationExactlyOnce()
     {
         // Arrange
         SetupAllCounts(nineCount: TargetPoolSizeNine, sixteenCount: TargetPoolSizeSixteen);
@@ -71,9 +71,27 @@ public class PuzzlePoolSeederTests : MoqBaseTestByAbstraction<PuzzlePoolSeeder, 
         _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(BoardSize.Nine, GameDifficulty.Expert);
         _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(BoardSize.Sixteen, GameDifficulty.Easy);
         _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(BoardSize.Sixteen, GameDifficulty.Medium);
-        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(BoardSize.Sixteen, GameDifficulty.Hard);
-        _mockPuzzlePoolService.VerifyGetAvailableCountCalledOnce(BoardSize.Sixteen, GameDifficulty.Expert);
     }
+
+    [Theory]
+    [MemberData(nameof(UnsupportedSixteenDifficulties))]
+    public async Task SeedPoolAsync_ForUnsupportedSixteenDifficulty_NeverInspectsOrSeedsThePool(GameDifficulty difficulty)
+    {
+        // Arrange — every pool is empty, so only the unsupported combinations should be skipped
+        SetupAllCounts(nineCount: TargetPoolSizeNine, sixteenCount: 0);
+
+        var sut = ResolveSut();
+
+        // Act
+        await sut.SeedPoolAsync();
+
+        // Assert
+        _mockPuzzlePoolService.VerifyGetAvailableCountNeverCalled(BoardSize.Sixteen, difficulty);
+        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Sixteen, difficulty, 1, 0);
+    }
+
+    public static TheoryData<GameDifficulty> UnsupportedSixteenDifficulties =>
+        [GameDifficulty.Hard, GameDifficulty.Expert];
 
     [Theory]
     [InlineData(0, 10)]
@@ -116,8 +134,6 @@ public class PuzzlePoolSeederTests : MoqBaseTestByAbstraction<PuzzlePoolSeeder, 
         // Assert
         _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Sixteen, GameDifficulty.Easy, 1, 2);
         _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Sixteen, GameDifficulty.Medium, 1, 0);
-        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Sixteen, GameDifficulty.Hard, 1, 0);
-        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Sixteen, GameDifficulty.Expert, 1, 0);
         _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Nine, GameDifficulty.Easy, 1, 0);
     }
 
@@ -146,7 +162,5 @@ public class PuzzlePoolSeederTests : MoqBaseTestByAbstraction<PuzzlePoolSeeder, 
         _mockPuzzlePoolService.SetupGetAvailableCountReturns(BoardSize.Nine, GameDifficulty.Expert, nineCount);
         _mockPuzzlePoolService.SetupGetAvailableCountReturns(BoardSize.Sixteen, GameDifficulty.Easy, sixteenCount);
         _mockPuzzlePoolService.SetupGetAvailableCountReturns(BoardSize.Sixteen, GameDifficulty.Medium, sixteenCount);
-        _mockPuzzlePoolService.SetupGetAvailableCountReturns(BoardSize.Sixteen, GameDifficulty.Hard, sixteenCount);
-        _mockPuzzlePoolService.SetupGetAvailableCountReturns(BoardSize.Sixteen, GameDifficulty.Expert, sixteenCount);
     }
 }

--- a/src/backend/Tests/Helpers/Factories/GameFactory.cs
+++ b/src/backend/Tests/Helpers/Factories/GameFactory.cs
@@ -1,4 +1,5 @@
 using Sudoku.Domain.Entities;
+using Sudoku.Domain.Enums;
 using Sudoku.Domain.ValueObjects;
 
 namespace UnitTests.Helpers.Factories;
@@ -66,6 +67,29 @@ public static class GameFactory
         game.StartGame();
 
         return game;
+    }
+
+    /// <summary>
+    /// Rebuilds a game the way a repository does, bypassing the <see cref="SudokuGame.Create"/>
+    /// invariants. Use this for size/difficulty combinations that are no longer offered but may
+    /// still exist in storage from before they were retired (e.g. 16x16 Hard/Expert).
+    /// </summary>
+    public static SudokuGame CreateLegacyGame(GameDifficulty difficulty, BoardSize size)
+    {
+        return SudokuGame.Reconstitute(
+            GameId.New(),
+            ProfileId.New(),
+            PlayerAlias.Create("DefaultPlayer"),
+            difficulty,
+            size,
+            GameStatusEnum.InProgress,
+            GameStatistics.Create(),
+            CellsFactory.CreateIncompleteCells(),
+            [],
+            DateTime.UtcNow,
+            DateTime.UtcNow,
+            null,
+            null);
     }
 
     public static SudokuGame CreateInvalidGame()

--- a/src/backend/Tests/Infrastructure/Services/UniqueSolutionPuzzleGeneratorTests.cs
+++ b/src/backend/Tests/Infrastructure/Services/UniqueSolutionPuzzleGeneratorTests.cs
@@ -17,6 +17,11 @@ public class UniqueSolutionPuzzleGeneratorTests : MoqBaseTestByAbstraction<Uniqu
         [GameDifficulty.Expert],
     ];
 
+    // 16x16 only offers what BoardSize.Sixteen supports; Hard/Expert digging at that size runs
+    // for minutes per puzzle and is no longer reachable from the app.
+    public static IEnumerable<object[]> SixteenDifficulties =>
+        BoardSize.Sixteen.SupportedDifficulties.Select(d => new object[] { d });
+
     [Theory]
     [MemberData(nameof(Difficulties))]
     public async Task GeneratePuzzleAsync_ForAnyDifficulty_ProducesAValidPuzzle(GameDifficulty difficulty)
@@ -90,9 +95,10 @@ public class UniqueSolutionPuzzleGeneratorTests : MoqBaseTestByAbstraction<Uniqu
     // Generation at 16x16 is inherently far more expensive than 9x9 (256 cells vs 81), and
     // gets steeply more expensive as the empty-cell target grows (Phase 2 measurement: see
     // UniqueSolutionPuzzleGenerator's remarks). Easy is fast enough to run unconditionally
-    // as a smoke test; Medium/Hard/Expert are tagged SlowGeneration and excluded from the
-    // default CI run (`--filter Category!=SlowGeneration`) so the fast unit-test suite stays
-    // fast, per the spec's testing-strategy guidance. Run them on demand or nightly.
+    // as a smoke test; Medium is tagged SlowGeneration and excluded from the default CI run
+    // (`--filter Category!=SlowGeneration`) so the fast unit-test suite stays fast, per the
+    // spec's testing-strategy guidance. Run it on demand or nightly. Hard/Expert are not
+    // covered at 16x16 — BoardSize.Sixteen no longer offers them.
 
     [Fact]
     public async Task GeneratePuzzleAsync_SixteenEasy_ProducesAValidUniqueSolutionPuzzleQuickly()
@@ -112,7 +118,7 @@ public class UniqueSolutionPuzzleGeneratorTests : MoqBaseTestByAbstraction<Uniqu
 
     [Theory]
     [Trait("Category", "SlowGeneration")]
-    [MemberData(nameof(Difficulties))]
+    [MemberData(nameof(SixteenDifficulties))]
     public async Task GeneratePuzzleAsync_ForAnySixteenDifficulty_ProducesAValidPuzzle(GameDifficulty difficulty)
     {
         var sut = ResolveSut();
@@ -126,7 +132,7 @@ public class UniqueSolutionPuzzleGeneratorTests : MoqBaseTestByAbstraction<Uniqu
 
     [Theory]
     [Trait("Category", "SlowGeneration")]
-    [MemberData(nameof(Difficulties))]
+    [MemberData(nameof(SixteenDifficulties))]
     public async Task GeneratePuzzleAsync_ForAnySixteenDifficulty_ProducesExactlyOneSolution(GameDifficulty difficulty)
     {
         var sut = ResolveSut();
@@ -139,7 +145,7 @@ public class UniqueSolutionPuzzleGeneratorTests : MoqBaseTestByAbstraction<Uniqu
 
     [Theory]
     [Trait("Category", "SlowGeneration")]
-    [MemberData(nameof(Difficulties))]
+    [MemberData(nameof(SixteenDifficulties))]
     public async Task GeneratePuzzleAsync_ForAnySixteenDifficulty_RemainingCluesAreFixed(GameDifficulty difficulty)
     {
         var sut = ResolveSut();
@@ -152,7 +158,7 @@ public class UniqueSolutionPuzzleGeneratorTests : MoqBaseTestByAbstraction<Uniqu
 
     [Theory]
     [Trait("Category", "SlowGeneration")]
-    [MemberData(nameof(Difficulties))]
+    [MemberData(nameof(SixteenDifficulties))]
     public async Task GeneratePuzzleAsync_ForAnySixteenDifficulty_ClueCountStaysWithinDifficultyBand(GameDifficulty difficulty)
     {
         var sut = ResolveSut();

--- a/src/backend/Tests/Mocks/MockPuzzlePoolServiceExtensions.cs
+++ b/src/backend/Tests/Mocks/MockPuzzlePoolServiceExtensions.cs
@@ -55,6 +55,11 @@ public static class MockPuzzlePoolServiceExtensions
             mock.Verify(x => x.GetAvailableCountAsync(size, difficulty), Times.Once);
         }
 
+        public void VerifyGetAvailableCountNeverCalled(BoardSize size, GameDifficulty difficulty)
+        {
+            mock.Verify(x => x.GetAvailableCountAsync(size, difficulty), Times.Never);
+        }
+
         public void VerifySeedCalledOnce(BoardSize size, GameDifficulty difficulty, int expectedCount)
         {
             mock.Verify(x => x.SeedAsync(size, difficulty, expectedCount), Times.Once);

--- a/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.module.css
+++ b/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.module.css
@@ -48,6 +48,14 @@
   color: var(--accent-ink);
 }
 
+.sizeNote {
+  font-family: 'Newsreader', serif;
+  font-style: italic;
+  font-size: 14px;
+  color: var(--ink-soft);
+  margin: -8px 0 16px 2px;
+}
+
 .options {
   display: flex;
   flex-direction: column;

--- a/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.test.tsx
+++ b/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.test.tsx
@@ -75,8 +75,34 @@ describe('SelectDifficultyPage', () => {
     const user = userEvent.setup();
     renderPage();
     await user.click(screen.getByRole('button', { name: /Giant 16×16/i }));
-    await user.click(screen.getByRole('button', { name: /Expert/i }));
-    expect(mockNavigate).toHaveBeenCalledWith('/new/Expert?size=16');
+    await user.click(screen.getByRole('button', { name: /Medium/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/new/Medium?size=16');
+  });
+
+  it('hides Hard and Expert when Giant 16x16 is selected', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole('button', { name: /Giant 16×16/i }));
+    expect(screen.getByRole('button', { name: /Easy/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Medium/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Hard/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Expert/i })).not.toBeInTheDocument();
+  });
+
+  it('explains the reduced difficulty choice when Giant 16x16 is selected', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole('button', { name: /Giant 16×16/i }));
+    expect(screen.getByText(/Easy and Medium/i)).toBeInTheDocument();
+  });
+
+  it('restores Hard and Expert when switching back to Classic 9x9', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole('button', { name: /Giant 16×16/i }));
+    await user.click(screen.getByRole('button', { name: /Classic 9×9/i }));
+    expect(screen.getByRole('button', { name: /Hard/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Expert/i })).toBeInTheDocument();
   });
 
   it('navigates to / when the header back affordance is clicked', async () => {

--- a/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/SelectDifficultyPage.tsx
@@ -11,6 +11,10 @@ const DIFFICULTIES = [
   { name: 'Expert', subtitle: 'For the deep end', dots: '····' },
 ] as const;
 
+// Mirrors BoardSize.SupportedDifficulties on the server: generating a Hard or Expert 16x16
+// grid takes minutes, so those combinations are not offered.
+const SIXTEEN_DIFFICULTIES: readonly string[] = ['Easy', 'Medium'];
+
 export default function SelectDifficultyPage() {
   const navigate = useNavigate();
   const { isNewPlayer } = usePlayerService();
@@ -19,6 +23,11 @@ export default function SelectDifficultyPage() {
   useEffect(() => {
     if (isNewPlayer) navigate('/');
   }, [isNewPlayer, navigate]);
+
+  const difficulties =
+    selectedSize === 16
+      ? DIFFICULTIES.filter(({ name }) => SIXTEEN_DIFFICULTIES.includes(name))
+      : DIFFICULTIES;
 
   return (
     <Layout title="New game">
@@ -45,8 +54,12 @@ export default function SelectDifficultyPage() {
           </button>
         </div>
 
+        {selectedSize === 16 && (
+          <p className={styles.sizeNote}>Giant boards come in Easy and Medium.</p>
+        )}
+
         <div className={styles.options}>
-          {DIFFICULTIES.map(({ name, subtitle, dots }) => (
+          {difficulties.map(({ name, subtitle, dots }) => (
             <button
               key={name}
               type="button"


### PR DESCRIPTION
## Description

16x16 Hard/Expert puzzle generation digs 256 cells and routinely takes minutes per puzzle, with cost dominated by which random seed is drawn rather than smoothly by the target depth. `PuzzlePoolSeeder` could not keep those two pools stocked within its 4-minute time budget, so players selecting them hit an empty pool and a "try again shortly" message instead of a game.

This restricts 16x16 to Easy and Medium.

The rule has a single home — `BoardSize.SupportedDifficulties` in the Domain — and every other layer derives from it rather than repeating the list, so the pools, the API, and the UI cannot drift apart.

**Existing games are unaffected.** `SudokuGame.Reconstitute` deliberately skips the new guard, so any 16x16 Hard/Expert game created before this change still loads, still plays, and still counts in player stats. The stats query continues to return all eight size/difficulty rows so historical completions stay visible.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [ ] Other (please describe):

## Changes Made

- **Domain** — `BoardSize` gains `SupportedDifficulties` and `Supports(difficulty)`; 16x16 declares Easy/Medium only. New `UnsupportedDifficultyException`.
- **Domain** — `SudokuGame.Create` enforces the invariant. `Reconstitute` intentionally does not, so stored games keep loading.
- **Application** — `CreateGameCommandHandler` rejects the combination *before* `DequeueAsync`, so a rejected request never consumes and deletes a pooled puzzle. Returns `Result.Failure` → 400, not the 503 pool-empty path.
- **Functions** — `PuzzlePoolSeeder` builds its combination list from `SupportedDifficulties`, dropping the two pools it could never fill. 9x9 still runs first so the fast pools top up reliably.
- **Frontend** — `SelectDifficultyPage` filters the difficulty cards when 16x16 is selected and explains why ("Giant boards come in Easy and Medium").
- **Tests** — new `BoardSizeTests`; handler tests for the rejection and a 9x9 regression guard; seeder tests assert the retired combinations are never even inspected; new `GameFactory.CreateLegacyGame` (via `Reconstitute`) so the stats test can still model a pre-existing 16x16 Hard game.
- **Tests** — narrowed the `SlowGeneration` 16x16 generator theories to the supported difficulties, removing the slowest tests in the repo now that Hard/Expert are unreachable.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

Backend: **804 passed, 0 failed** via `dotnet test --filter "Category!=SlowGeneration"` (the filter CI uses).
Frontend: **233 passed**, plus `npm run build` clean including `tsc -b`.

One real regression was caught and fixed during this work: `GetPlayerStatsQueryHandlerTests` built a 16x16 Hard game through `Create`. Rather than weaken the test, the factory now rebuilds it the way repositories do, since that scenario stays valid for existing data.

## Screenshots (if applicable)

n/a — the change removes two cards from the difficulty list when 16x16 is selected and adds a one-line explanation.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation (if necessary)

### Note

Any 16x16 Hard/Expert puzzles already sitting in blob storage will simply go unused. They are harmless; cleanup can be a separate follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
