### PR TITLE
Fix local 16x16 game creation and unclip the 16x16 board

### DIFF
--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -44,8 +44,22 @@ Skip that and you'll silently land back on the home page and your selectors won'
   concurrency guard, so **every new game POSTs twice and creates two games** in dev. This is
   not difficulty-specific and not a regression — don't chase it as a bug in your change.
   (A production build won't double-invoke.)
-- **A fresh local puzzle pool is empty**, so the first game per difficulty takes the on-demand
-  generation fallback and is slower than prod (where the blob pool is pre-seeded).
+- **A fresh local puzzle pool is empty.** At 9x9 that only costs speed — the first game per
+  difficulty falls back to on-demand generation. **At 16x16 there is no fallback**, so creating
+  a game returns `503 PUZZLE_POOL_EMPTY` and the UI parks on "Preparing puzzles — try again in
+  a moment" forever. Nothing seeds the pool for you locally: the seed Function is a 02:00 timer
+  and the replenish Function is Event Grid, which Azurite never fires. Seed it yourself:
+
+  ```bash
+  # find the port: it's the --port arg on the `func start` process
+  curl -X POST "http://localhost:<funcPort>/api/seed-puzzle-pool?size=16&difficulty=Easy"
+  ```
+
+  Omit the query params to top up the whole matrix (~11s from empty). Local auth is not
+  enforced, so no function key is needed. The emulator now has a data volume, so a seeded pool
+  survives AppHost restarts — but each created game still consumes one puzzle with no
+  replenishment, and StrictMode's double-create burns two per UI run, so re-seed when a
+  previously working flow starts 503ing.
 - Ground truth for a board is the API payload, not the DOM: `GET /api/players/{pid}/games/{id}`
   → count `cells` where `value === null`.
 

--- a/src/backend/Sudoku.AppHost/Program.cs
+++ b/src/backend/Sudoku.AppHost/Program.cs
@@ -21,7 +21,11 @@ try
     logger.LogInformation("Starting Sudoku Distributed Application...");
 
     var cosmosDb = builder.AddAzureCosmosDB("CosmosDb").RunAsEmulator();
-    var storage = builder.AddAzureStorage("storage").RunAsEmulator();
+
+    // A data volume keeps the seeded puzzle pool across AppHost restarts. Without it the
+    // emulator starts empty every run, and because 16x16 has no on-demand generation
+    // fallback, creating a 16x16 game fails with 503 until the pool is seeded by hand.
+    var storage = builder.AddAzureStorage("storage").RunAsEmulator(emulator => emulator.WithDataVolume());
     var puzzleBlobs = storage.AddBlobs("blobs");
 
     logger.LogInformation("Configuring Sudoku API project...");

--- a/src/backend/Sudoku.Functions/Functions/PuzzlePoolSeedHttpFunction.cs
+++ b/src/backend/Sudoku.Functions/Functions/PuzzlePoolSeedHttpFunction.cs
@@ -1,7 +1,10 @@
 using System.Net;
+using System.Web;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
+using Sudoku.Domain.Exceptions;
+using Sudoku.Domain.ValueObjects;
 using Sudoku.Functions.Services;
 
 namespace Sudoku.Functions.Functions;
@@ -11,6 +14,12 @@ namespace Sudoku.Functions.Functions;
 /// same pool top-up as the nightly timer, but can be invoked on demand for testing.
 /// Secured at <see cref="AuthorizationLevel.Function"/> — callers must supply the function key.
 /// </summary>
+/// <remarks>
+/// Accepts optional <c>size</c>, <c>difficulty</c> and <c>count</c> query parameters to narrow the
+/// run, e.g. <c>?size=16&amp;difficulty=Easy</c>. This is the fastest way to unblock local
+/// development: the emulator starts with an empty pool and 16x16 has no on-demand generation
+/// fallback, so a 16x16 game cannot be created until its pool is seeded.
+/// </remarks>
 public class PuzzlePoolSeedHttpFunction(IPuzzlePoolSeeder seeder, ILogger<PuzzlePoolSeedHttpFunction> logger)
 {
     [Function("PuzzlePoolSeedHttpFunction")]
@@ -19,13 +28,93 @@ public class PuzzlePoolSeedHttpFunction(IPuzzlePoolSeeder seeder, ILogger<Puzzle
     {
         logger.LogInformation("Puzzle pool seed (HTTP) triggered at {Time}", DateTime.UtcNow);
 
-        var seeded = await seeder.SeedPoolAsync();
+        PuzzlePoolSeedFilter? filter;
+        try
+        {
+            filter = ParseFilter(request);
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogWarning("Rejected puzzle pool seed request: {Error}", ex.Message);
+            return await WriteJsonAsync(request, HttpStatusCode.BadRequest, $"{{\"error\":\"{ex.Message}\"}}");
+        }
+
+        var seeded = await seeder.SeedPoolAsync(filter);
 
         logger.LogInformation("Puzzle pool seed (HTTP) completed, seeded {Count} puzzles", seeded);
 
-        var response = request.CreateResponse(HttpStatusCode.OK);
+        return await WriteJsonAsync(request, HttpStatusCode.OK, $"{{\"seeded\":{seeded}}}");
+    }
+
+    private static PuzzlePoolSeedFilter? ParseFilter(HttpRequestData request)
+    {
+        var query = HttpUtility.ParseQueryString(request.Url?.Query ?? string.Empty);
+        var size = ParseSize(query["size"]);
+        var difficulty = ParseDifficulty(query["difficulty"]);
+        var target = ParseTarget(query["count"]);
+
+        return size is null && difficulty is null && target is null
+            ? null
+            : new PuzzlePoolSeedFilter(size, difficulty, target);
+    }
+
+    private static BoardSize? ParseSize(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        try
+        {
+            return BoardSize.FromValue(int.Parse(value));
+        }
+        catch (Exception ex) when (ex is FormatException or OverflowException or InvalidBoardSizeException)
+        {
+            throw new ArgumentException($"Invalid size '{value}'; expected 9 or 16.");
+        }
+    }
+
+    private static GameDifficulty? ParseDifficulty(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        try
+        {
+            return GameDifficulty.FromName(value);
+        }
+        catch (InvalidGameDifficultyException)
+        {
+            throw new ArgumentException($"Invalid difficulty '{value}'; expected Easy, Medium, Hard or Expert.");
+        }
+    }
+
+    private static int? ParseTarget(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        if (!int.TryParse(value, out var target) || target < 0)
+        {
+            throw new ArgumentException($"Invalid count '{value}'; expected a non-negative integer.");
+        }
+
+        return target;
+    }
+
+    private static async Task<HttpResponseData> WriteJsonAsync(HttpRequestData request, HttpStatusCode status, string body)
+    {
+        // CreateResponse() rather than the CreateResponse(HttpStatusCode) overload: the latter is
+        // virtual and returns null against a loose mock, which would break the function tests.
+        var response = request.CreateResponse();
+        response.StatusCode = status;
         response.Headers.Add("Content-Type", "application/json; charset=utf-8");
-        await response.WriteStringAsync($"{{\"seeded\":{seeded}}}");
+        await response.WriteStringAsync(body);
 
         return response;
     }

--- a/src/backend/Sudoku.Functions/Services/IPuzzlePoolSeeder.cs
+++ b/src/backend/Sudoku.Functions/Services/IPuzzlePoolSeeder.cs
@@ -3,8 +3,12 @@ namespace Sudoku.Functions.Services;
 public interface IPuzzlePoolSeeder
 {
     /// <summary>
-    /// Tops every difficulty's pool back up to the target size.
-    /// Returns the total number of puzzles seeded across all difficulties.
+    /// Tops the pools back up to their target size.
+    /// Returns the total number of puzzles seeded across every combination that ran.
     /// </summary>
-    Task<int> SeedPoolAsync();
+    /// <param name="filter">
+    /// Optionally narrows the run to a single board size and/or difficulty and overrides the
+    /// target pool size. Null tops up the whole supported matrix.
+    /// </param>
+    Task<int> SeedPoolAsync(PuzzlePoolSeedFilter? filter = null);
 }

--- a/src/backend/Sudoku.Functions/Services/PuzzlePoolSeedFilter.cs
+++ b/src/backend/Sudoku.Functions/Services/PuzzlePoolSeedFilter.cs
@@ -1,0 +1,14 @@
+using Sudoku.Domain.ValueObjects;
+
+namespace Sudoku.Functions.Services;
+
+/// <summary>
+/// Narrows a seeding run to a subset of the board-size/difficulty matrix. Every member is
+/// optional; a null member means "no restriction on this dimension". Used by the on-demand
+/// HTTP seed so a developer can top up a single pool (e.g. 16x16 Easy) without waiting for
+/// the whole matrix.
+/// </summary>
+/// <param name="Size">Restrict to a single board size, or null for every size.</param>
+/// <param name="Difficulty">Restrict to a single difficulty, or null for every difficulty.</param>
+/// <param name="Target">Override the per-combination target pool size, or null for the default.</param>
+public record PuzzlePoolSeedFilter(BoardSize? Size = null, GameDifficulty? Difficulty = null, int? Target = null);

--- a/src/backend/Sudoku.Functions/Services/PuzzlePoolSeeder.cs
+++ b/src/backend/Sudoku.Functions/Services/PuzzlePoolSeeder.cs
@@ -25,12 +25,12 @@ public class PuzzlePoolSeeder(IPuzzlePoolService puzzlePoolService, ILogger<Puzz
         .. BoardSize.Sixteen.SupportedDifficulties.Select(d => (BoardSize.Sixteen, d, TargetPoolSizeSixteen))
     ];
 
-    public async Task<int> SeedPoolAsync()
+    public async Task<int> SeedPoolAsync(PuzzlePoolSeedFilter? filter = null)
     {
         var totalSeeded = 0;
         var stopwatch = Stopwatch.StartNew();
 
-        foreach (var (size, difficulty, target) in Combinations)
+        foreach (var (size, difficulty, target) in Filter(filter))
         {
             var currentCount = await puzzlePoolService.GetAvailableCountAsync(size, difficulty);
 
@@ -59,4 +59,13 @@ public class PuzzlePoolSeeder(IPuzzlePoolService puzzlePoolService, ILogger<Puzz
 
         return totalSeeded;
     }
+
+    // Filtering the supported matrix rather than building combinations from the filter keeps the
+    // BoardSize.SupportedDifficulties guarantee intact: asking for an unsupported pairing such as
+    // 16x16 Hard simply matches nothing instead of generating a puzzle players can never start.
+    private static IEnumerable<(BoardSize Size, GameDifficulty Difficulty, int Target)> Filter(PuzzlePoolSeedFilter? filter) =>
+        Combinations
+            .Where(c => filter?.Size is null || c.Size == filter.Size)
+            .Where(c => filter?.Difficulty is null || c.Difficulty == filter.Difficulty)
+            .Select(c => (c.Size, c.Difficulty, filter?.Target ?? c.Target));
 }

--- a/src/backend/Tests/Functions/PuzzlePoolSeedHttpFunctionTests.cs
+++ b/src/backend/Tests/Functions/PuzzlePoolSeedHttpFunctionTests.cs
@@ -3,6 +3,7 @@ using DepenMock.Attributes;
 using DepenMock.Moq;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
+using Sudoku.Domain.ValueObjects;
 using Sudoku.Functions.Functions;
 using Sudoku.Functions.Services;
 
@@ -32,6 +33,76 @@ public class PuzzlePoolSeedHttpFunctionTests : MoqBaseTestByType<PuzzlePoolSeedH
     }
 
     [Fact]
+    public async Task Run_WithNoQueryParameters_SeedsTheWholeMatrix()
+    {
+        // Arrange
+        var sut = ResolveSut();
+
+        // Act
+        await sut.Run(CreateHttpRequest());
+
+        // Assert — a null filter means "top up every supported combination"
+        _mockSeeder.VerifySeedPoolCalledWithoutFilter();
+    }
+
+    [Fact]
+    public async Task Run_WithSizeAndDifficulty_PassesMatchingFilterToSeeder()
+    {
+        // Arrange
+        var sut = ResolveSut();
+
+        // Act
+        await sut.Run(CreateHttpRequest("?size=16&difficulty=Easy"));
+
+        // Assert
+        _mockSeeder.VerifySeedPoolCalledWith(new PuzzlePoolSeedFilter(BoardSize.Sixteen, GameDifficulty.Easy));
+    }
+
+    [Fact]
+    public async Task Run_WithCount_PassesTargetOverrideToSeeder()
+    {
+        // Arrange
+        var sut = ResolveSut();
+
+        // Act
+        await sut.Run(CreateHttpRequest("?size=16&count=3"));
+
+        // Assert
+        _mockSeeder.VerifySeedPoolCalledWith(new PuzzlePoolSeedFilter(BoardSize.Sixteen, Target: 3));
+    }
+
+    [Theory]
+    [InlineData("?size=12")]
+    [InlineData("?size=abc")]
+    [InlineData("?difficulty=Impossible")]
+    [InlineData("?count=-1")]
+    [InlineData("?count=notanumber")]
+    public async Task Run_WithInvalidQueryParameter_ReturnsBadRequest(string query)
+    {
+        // Arrange
+        var sut = ResolveSut();
+
+        // Act
+        var response = await sut.Run(CreateHttpRequest(query));
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task Run_WithInvalidQueryParameter_DoesNotInvokeSeeder()
+    {
+        // Arrange
+        var sut = ResolveSut();
+
+        // Act
+        await sut.Run(CreateHttpRequest("?size=12"));
+
+        // Assert
+        _mockSeeder.VerifySeedPoolNeverCalled();
+    }
+
+    [Fact]
     public async Task Run_ReturnsOkStatus()
     {
         // Arrange
@@ -58,7 +129,7 @@ public class PuzzlePoolSeedHttpFunctionTests : MoqBaseTestByType<PuzzlePoolSeedH
         ReadBody(response).Should().Contain("\"seeded\":5");
     }
 
-    private static HttpRequestData CreateHttpRequest()
+    private static HttpRequestData CreateHttpRequest(string query = "")
     {
         var context = new Mock<FunctionContext>().Object;
         var request = new Mock<HttpRequestData>(context);
@@ -68,6 +139,7 @@ public class PuzzlePoolSeedHttpFunctionTests : MoqBaseTestByType<PuzzlePoolSeedH
         response.Setup(r => r.Headers).Returns(new HttpHeadersCollection());
         response.Setup(r => r.Body).Returns(new MemoryStream());
         request.Setup(r => r.CreateResponse()).Returns(response.Object);
+        request.Setup(r => r.Url).Returns(new Uri($"http://localhost/api/seed-puzzle-pool{query}"));
 
         return request.Object;
     }

--- a/src/backend/Tests/Functions/PuzzlePoolSeederTests.cs
+++ b/src/backend/Tests/Functions/PuzzlePoolSeederTests.cs
@@ -154,6 +154,84 @@ public class PuzzlePoolSeederTests : MoqBaseTestByAbstraction<PuzzlePoolSeeder, 
         totalSeeded.Should().Be(expectedTotal);
     }
 
+    [Fact]
+    public async Task SeedPoolAsync_WithSizeFilter_OnlySeedsThatBoardSize()
+    {
+        // Arrange — every pool empty so an unfiltered run would touch all six combinations
+        SetupAllCounts(nineCount: 0, sixteenCount: 0);
+
+        var sut = ResolveSut();
+
+        // Act
+        await sut.SeedPoolAsync(new PuzzlePoolSeedFilter(BoardSize.Sixteen));
+
+        // Assert
+        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Sixteen, GameDifficulty.Easy, 1, TargetPoolSizeSixteen);
+        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Nine, GameDifficulty.Easy, 1, 0);
+    }
+
+    [Fact]
+    public async Task SeedPoolAsync_WithSizeAndDifficultyFilter_OnlySeedsThatCombination()
+    {
+        // Arrange
+        SetupAllCounts(nineCount: 0, sixteenCount: 0);
+
+        var sut = ResolveSut();
+
+        // Act
+        await sut.SeedPoolAsync(new PuzzlePoolSeedFilter(BoardSize.Sixteen, GameDifficulty.Easy));
+
+        // Assert
+        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Sixteen, GameDifficulty.Easy, 1, TargetPoolSizeSixteen);
+        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Sixteen, GameDifficulty.Medium, 1, 0);
+    }
+
+    [Fact]
+    public async Task SeedPoolAsync_WithTargetOverride_SeedsUpToTheOverriddenTarget()
+    {
+        // Arrange
+        SetupAllCounts(nineCount: 0, sixteenCount: 0);
+
+        var sut = ResolveSut();
+
+        // Act
+        await sut.SeedPoolAsync(new PuzzlePoolSeedFilter(BoardSize.Sixteen, GameDifficulty.Easy, Target: 2));
+
+        // Assert
+        _mockPuzzlePoolService.VerifySeedCalledTimes(BoardSize.Sixteen, GameDifficulty.Easy, 1, 2);
+    }
+
+    [Theory]
+    [MemberData(nameof(UnsupportedSixteenDifficulties))]
+    public async Task SeedPoolAsync_WithFilterForUnsupportedCombination_SeedsNothing(GameDifficulty difficulty)
+    {
+        // Arrange — the filter narrows the supported matrix, it never widens it
+        SetupAllCounts(nineCount: 0, sixteenCount: 0);
+
+        var sut = ResolveSut();
+
+        // Act
+        var totalSeeded = await sut.SeedPoolAsync(new PuzzlePoolSeedFilter(BoardSize.Sixteen, difficulty));
+
+        // Assert
+        totalSeeded.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SeedPoolAsync_WithNullFilter_SeedsTheWholeSupportedMatrix()
+    {
+        // Arrange
+        SetupAllCounts(nineCount: 0, sixteenCount: 0);
+
+        var sut = ResolveSut();
+
+        // Act
+        var totalSeeded = await sut.SeedPoolAsync(null);
+
+        // Assert
+        totalSeeded.Should().Be((TargetPoolSizeNine * 4) + (TargetPoolSizeSixteen * 2));
+    }
+
     private void SetupAllCounts(int nineCount, int sixteenCount)
     {
         _mockPuzzlePoolService.SetupGetAvailableCountReturns(BoardSize.Nine, GameDifficulty.Easy, nineCount);

--- a/src/backend/Tests/Mocks/MockPuzzlePoolSeederExtensions.cs
+++ b/src/backend/Tests/Mocks/MockPuzzlePoolSeederExtensions.cs
@@ -8,12 +8,27 @@ public static class MockPuzzlePoolSeederExtensions
     {
         public void SetupSeedPoolReturns(int seeded)
         {
-            mock.Setup(x => x.SeedPoolAsync()).ReturnsAsync(seeded);
+            mock.Setup(x => x.SeedPoolAsync(It.IsAny<PuzzlePoolSeedFilter?>())).ReturnsAsync(seeded);
         }
 
         public void VerifySeedPoolCalledOnce()
         {
-            mock.Verify(x => x.SeedPoolAsync(), Times.Once);
+            mock.Verify(x => x.SeedPoolAsync(It.IsAny<PuzzlePoolSeedFilter?>()), Times.Once);
+        }
+
+        public void VerifySeedPoolCalledWithoutFilter()
+        {
+            mock.Verify(x => x.SeedPoolAsync(null), Times.Once);
+        }
+
+        public void VerifySeedPoolCalledWith(PuzzlePoolSeedFilter expected)
+        {
+            mock.Verify(x => x.SeedPoolAsync(expected), Times.Once);
+        }
+
+        public void VerifySeedPoolNeverCalled()
+        {
+            mock.Verify(x => x.SeedPoolAsync(It.IsAny<PuzzlePoolSeedFilter?>()), Times.Never);
         }
     }
 }

--- a/src/frontend/Sudoku.React/src/components/CellInput.module.css
+++ b/src/frontend/Sudoku.React/src/components/CellInput.module.css
@@ -5,6 +5,10 @@
   justify-content: center;
   padding: 0;
   aspect-ratio: 1 / 1;
+  /* Grid items default to min-width/min-height: auto, which would let a cell
+     overflow its track on dense boards. Pairs with the board's minmax(0, 1fr). */
+  min-width: 0;
+  min-height: 0;
   border: none;
   border-right: 1px solid var(--line);
   border-bottom: 1px solid var(--line);

--- a/src/frontend/Sudoku.React/src/components/GameBoard.module.css
+++ b/src/frontend/Sudoku.React/src/components/GameBoard.module.css
@@ -5,8 +5,12 @@
 
 .board {
   display: grid;
-  grid-template-columns: repeat(var(--grid-size, 9), 1fr);
-  grid-template-rows: repeat(var(--grid-size, 9), 1fr);
+  /* minmax(0, ...) rather than a bare 1fr: a 1fr track floors at the item's
+     min-content size, and a cell's min-content (font + aspect-ratio) exceeds
+     1/16th of the board. At 16x16 that pushed the grid past its own square
+     box and `overflow: hidden` silently clipped the last rows and columns. */
+  grid-template-columns: repeat(var(--grid-size, 9), minmax(0, 1fr));
+  grid-template-rows: repeat(var(--grid-size, 9), minmax(0, 1fr));
   width: 100%;
   max-width: 440px;
   aspect-ratio: 1 / 1;

--- a/src/frontend/Sudoku.React/src/components/GameControls.module.css
+++ b/src/frontend/Sudoku.React/src/components/GameControls.module.css
@@ -18,6 +18,19 @@
   gap: 6px;
 }
 
+/* On a widened 16x16 layout the keys get ~75px of column, and the square-ish
+   default ratio would make them 86px tall around a 28px glyph. Flatten them so
+   the pad stays edge-aligned with the board without the dead space. */
+.numberPad16 .numBtn {
+  aspect-ratio: 1 / 0.72;
+}
+
+@media (max-width: 480px) {
+  .numberPad16 .numBtn {
+    aspect-ratio: 1 / 1.15;
+  }
+}
+
 @media (max-width: 480px) {
   .numberPad16 {
     grid-template-columns: repeat(4, 1fr);

--- a/src/frontend/Sudoku.React/src/components/Layout.module.css
+++ b/src/frontend/Sudoku.React/src/components/Layout.module.css
@@ -15,6 +15,13 @@
   min-height: 100vh;
 }
 
+/* 16x16 needs room for 16 legible cells. 640px of board + .main's 28px side
+   padding; below ~622px viewport the padding clamps down and `width: 100%`
+   takes over, so narrow screens are unaffected. */
+.columnWide {
+  max-width: 696px;
+}
+
 .header {
   display: flex;
   align-items: center;

--- a/src/frontend/Sudoku.React/src/components/Layout.test.tsx
+++ b/src/frontend/Sudoku.React/src/components/Layout.test.tsx
@@ -43,4 +43,29 @@ describe('Layout', () => {
     expect(screen.queryByRole('button', { name: /switch to (dark|light) theme/i })).not.toBeInTheDocument();
     expect(screen.getByText('only child')).toBeInTheDocument();
   });
+
+  it('widens the content column when wide is set', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <Layout wide>
+          <span>wide child</span>
+        </Layout>
+      </MemoryRouter>
+    );
+    // CSS Modules hash class names, so match on the stable prefix.
+    const column = container.querySelector('[class*="column"]');
+    expect(column?.className).toMatch(/columnWide/);
+  });
+
+  it('does not widen the content column by default', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <Layout>
+          <span>narrow child</span>
+        </Layout>
+      </MemoryRouter>
+    );
+    const column = container.querySelector('[class*="column"]');
+    expect(column?.className).not.toMatch(/columnWide/);
+  });
 });

--- a/src/frontend/Sudoku.React/src/components/Layout.tsx
+++ b/src/frontend/Sudoku.React/src/components/Layout.tsx
@@ -13,9 +13,11 @@ interface LayoutProps {
   onBack?: () => void;
   /** Label for the back affordance (default "Home"). */
   backLabel?: string;
+  /** Widen the content column for dense content (the 16x16 board). */
+  wide?: boolean;
 }
 
-export default function Layout({ children, hideHeader = false, title, onBack, backLabel = 'Home' }: LayoutProps) {
+export default function Layout({ children, hideHeader = false, title, onBack, backLabel = 'Home', wide = false }: LayoutProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const { theme, toggleTheme } = useTheme();
@@ -25,7 +27,7 @@ export default function Layout({ children, hideHeader = false, title, onBack, ba
 
   return (
     <div className={styles.page}>
-      <div className={styles.column}>
+      <div className={wide ? `${styles.column} ${styles.columnWide}` : styles.column}>
         {!hideHeader && (
           <header className={styles.header}>
             <div className={styles.left}>

--- a/src/frontend/Sudoku.React/src/pages/GamePage.module.css
+++ b/src/frontend/Sudoku.React/src/pages/GamePage.module.css
@@ -6,3 +6,9 @@
   max-width: 440px;
   animation: sd-fadeup 0.4s ease both;
 }
+
+/* Lets .boardLarge's 640px cap actually apply — at 440px the 16x16 grid was
+   squeezed to 25px cells. Pairs with Layout's `wide` column. */
+.gameViewLarge {
+  max-width: 640px;
+}

--- a/src/frontend/Sudoku.React/src/pages/GamePage.tsx
+++ b/src/frontend/Sudoku.React/src/pages/GamePage.tsx
@@ -306,10 +306,11 @@ export default function GamePage() {
     ? game.difficulty.charAt(0).toUpperCase() + game.difficulty.slice(1)
     : '';
   const size = game.size ?? deriveSize(game.cells);
+  const isLargeBoard = size === 16;
 
   return (
-    <Layout title={difficultyLabel} onBack={handleHome}>
-      <div className={styles.gameView}>
+    <Layout title={difficultyLabel} onBack={handleHome} wide={isLargeBoard}>
+      <div className={isLargeBoard ? `${styles.gameView} ${styles.gameViewLarge}` : styles.gameView}>
         <GameStats
           statistics={game.statistics}
           elapsedSeconds={elapsedSeconds}


### PR DESCRIPTION
## Description

Reported as "I can't create a 16x16 game locally, so I can't view the 16x16 board." Investigation turned up **two independent defects** — one blocks creation locally, the other means the board was never fully visible even once created.

**1. The 16x16 board was clipped (affects production too).** `GameBoard.module.css` sized its tracks with `repeat(var(--grid-size), 1fr)`. A bare `1fr` track floors at the grid item's min-content size, and a cell's min-content (font + `aspect-ratio: 1/1`) exceeds 1/16th of the board. At 16x16 the grid laid out **464×467px inside its own 400×400 `aspect-ratio: 1/1` box**, and `overflow: hidden` silently clipped the last ~2.3 rows *and* columns. Those cells were invisible and unclickable. 9x9 was unaffected because 1/9th of the board is larger than a cell's min-content.

**2. Nothing seeds the 16x16 pool locally.** The seed Function is a `0 0 2 * * *` timer, the replenish Function is Event Grid — which Azurite never fires — and `CreateGameCommandHandler` deliberately has no on-demand generation fallback for 16x16. So `POST /api/players/{id}/games/Easy?size=16` returned `503 PUZZLE_POOL_EMPTY` and `NewGamePage` parked on "Preparing puzzles — try again in a moment" with a Retry button that could never succeed. Compounding it, the storage emulator had no data volume, so even a hand-seeded pool was wiped on every AppHost restart.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- `GameBoard.module.css` — `minmax(0, 1fr)` instead of `1fr` for both track lists, so tracks can shrink below the cell's min-content instead of overflowing the clipped box.
- `CellInput.module.css` — `min-width: 0; min-height: 0` on `.cell`, since grid items default to `min-*: auto` and would otherwise overflow their track.
- **Widened the layout for 16x16.** `.boardLarge`'s `max-width: 640px` was dead — `.gameView` capped at 440px and `.column` at 460px, so giant boards were squeezed into 25px cells. Added a `wide` prop on `Layout` (`.columnWide`, 696px = 640px board + `.main`'s 28px side padding) and a `.gameViewLarge` modifier, both applied only when `size === 16`. The 16x16 board now renders at 640px with **40px cells**, against 44px for 9x9.
- `GameControls.module.css` — flattened the 16-key pad's buttons to `aspect-ratio: 1 / 0.72` above 480px. At the wider layout each key gets ~75px of column, and the near-square default made them 86px tall around a 28px glyph; they are now 75×54 and stay edge-aligned with the board. Narrow viewports keep the original ratio for the 4×4 pad.
- `Sudoku.AppHost/Program.cs` — `RunAsEmulator(e => e.WithDataVolume())` on storage, so a seeded pool survives AppHost restarts.
- `PuzzlePoolSeedHttpFunction` — optional `size`, `difficulty` and `count` query parameters (`?size=16&difficulty=Easy`), with `400` + a JSON error for invalid values. Seeds one pool in ~0.6s versus ~11s for the whole matrix.
- `PuzzlePoolSeedFilter` (new) + `IPuzzlePoolSeeder.SeedPoolAsync(filter)` — the filter **narrows** the supported matrix rather than building combinations from scratch, so it can't seed an unsupported pairing such as 16x16 Hard (verified: returns `{"seeded":0}`).
- `.claude/skills/verify/SKILL.md` — corrected the stale "empty pool just means slower" note, which is true at 9x9 but a hard block at 16x16, and documented the seed command.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

Backend: 50/50 Functions tests pass (`--filter "Category!=SlowGeneration"`). 11 new tests covering filter narrowing, target override, unsupported-combination rejection, query parsing and `400` handling.

Frontend: 233/233 tests pass, `npm run build` clean. Lint shows 8 pre-existing problems, identical on `main` (verified by stashing) and in files this PR doesn't touch.

Verified end-to-end against the running stack:

| Check | Before | After |
|---|---|---|
| `POST .../games/Easy?size=16` on fresh local env | `503` | `201` |
| Same, after an AppHost restart with no re-seed | `503` | `201` |
| 16x16 grid content vs. its box | 464×467 in a 400×400 box (clipped) | fits, last cell inside bounds |
| Rows / columns rendered | 14 / 14 | 16 / 16 |
| Bottom-right cell (row 16, col 16) | unreachable | clickable |
| 16x16 board width / cell size @1440px | 404px / 25px | 640px / 40px |
| 16x16 number-pad key | n/a | 75×54 (was 75×86 before flattening) |
| 16x16 @390px mobile | — | 354px board, no horizontal page scroll |
| 9x9 board | 9×9, 44px cells, no overflow | unchanged |
| Targeted seed `?size=16&difficulty=Easy` | n/a | `{"seeded":5}` in 0.59s |
| `?size=12` | n/a | `400` with JSON error |
| `?size=16&difficulty=Hard` (unsupported) | n/a | `{"seeded":0}` |

## Screenshots (if applicable)

Attach from `scratchpad/pr/`:

- `16x16-before-clipped.png` — bottom and right edges clipped, only 14×14 of the grid visible
- `16x16-after-complete.png` — full 16×16 grid with 4×4 box separators, bottom-right cell selected
- `9x9-unchanged.png` — 9x9 regression check

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have updated the documentation (if necessary)

## Notes for the reviewer

- The widening is opt-in per page (`Layout wide={size === 16}`), so every other screen keeps the existing 460px zen column. Only `GamePage` passes it.
- 696px was chosen so the board lands exactly on `.boardLarge`'s existing 640px cap once `.main`'s 28px side padding is subtracted. Below a ~622px viewport that padding clamps down and `width: 100%` takes over, so narrow screens are untouched — verified at 390px.
- The pool still has no local replenishment: each created game consumes a puzzle, and StrictMode's double-create burns two per UI run. Re-seed when a previously working flow starts 503ing. Documented in the verify skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
