### PR TITLE
Highlight pencil marks matching the selected cell value

### DIFF
--- a/src/frontend/Sudoku.React/src/components/CellInput.module.css
+++ b/src/frontend/Sudoku.React/src/components/CellInput.module.css
@@ -97,13 +97,18 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: color 0.16s ease;
+  transition: background-color 0.16s ease, color 0.16s ease;
 }
 
-/* Candidate matching the selected cell's value. Weight carries the signal
-   alongside color so it survives low contrast and color-vision differences. */
+/* Candidate matching the selected cell's value. A filled chip rather than a
+   recolored glyph: at clamp(7px, 2.1vw, 10px) the digit is too small for hue
+   and weight alone to register, so the slot itself carries the signal. Fill
+   and ink match the accent-button pattern used elsewhere in the app. */
 .pencilMatch {
-  color: var(--accent);
+  margin: 1px;
+  border-radius: 3px;
+  background-color: var(--accent);
+  color: var(--accent-ink);
   font-weight: 700;
 }
 
@@ -124,4 +129,12 @@
   font-size: clamp(6px, 1.6vw, 7px);
   font-weight: 500;
   overflow: hidden;
+}
+
+/* In the wrapped layout an entry is only as wide as its glyph, so the chip
+   needs its own padding to read as a block. Margin is dropped because the
+   flex gap already separates entries. */
+.pencilValuesWrapped .pencilMatch {
+  margin: 0;
+  padding: 0 2px;
 }

--- a/src/frontend/Sudoku.React/src/components/CellInput.module.css
+++ b/src/frontend/Sudoku.React/src/components/CellInput.module.css
@@ -97,6 +97,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  transition: color 0.16s ease;
+}
+
+/* Candidate matching the selected cell's value. Weight carries the signal
+   alongside color so it survives low contrast and color-vision differences. */
+.pencilMatch {
+  color: var(--accent);
+  font-weight: 700;
 }
 
 /* 16x16 non-positional wrapped pencil marks — a positional 4x4 grid at ~30px

--- a/src/frontend/Sudoku.React/src/components/CellInput.test.tsx
+++ b/src/frontend/Sudoku.React/src/components/CellInput.test.tsx
@@ -68,6 +68,39 @@ describe('CellInput - editable cell', () => {
   });
 });
 
+describe('CellInput - pencil mark highlighting', () => {
+  it('emphasizes the candidate matching the selected value', () => {
+    const cell = makeCell({ hasValue: false, possibleValues: [1, 3, 5] });
+    render(<CellInput cell={cell} {...baseProps} selectedValue={5} />);
+    expect(screen.getByText('5').className).toMatch(/pencilMatch/);
+  });
+
+  it('leaves non-matching candidates unemphasized', () => {
+    const cell = makeCell({ hasValue: false, possibleValues: [1, 3, 5] });
+    render(<CellInput cell={cell} {...baseProps} selectedValue={5} />);
+    expect(screen.getByText('3').className).not.toMatch(/pencilMatch/);
+  });
+
+  it('does not emphasize an empty positional slot whose digit matches', () => {
+    const cell = makeCell({ hasValue: false, possibleValues: [1, 3] });
+    const { container } = render(<CellInput cell={cell} {...baseProps} selectedValue={5} />);
+    expect(container.querySelectorAll('[class*="pencilMatch"]')).toHaveLength(0);
+  });
+
+  it('emphasizes nothing when no value is selected', () => {
+    const cell = makeCell({ hasValue: false, possibleValues: [1, 3, 5] });
+    const { container } = render(<CellInput cell={cell} {...baseProps} />);
+    expect(container.querySelectorAll('[class*="pencilMatch"]')).toHaveLength(0);
+  });
+
+  it('emphasizes the matching candidate in the 16x16 wrapped layout', () => {
+    const cell = makeCell({ hasValue: false, possibleValues: [3, 10, 16] });
+    render(<CellInput cell={cell} {...baseProps} selectedValue={10} size={16} boxSize={4} />);
+    expect(screen.getByText('A').className).toMatch(/pencilMatch/);
+    expect(screen.getByText('3').className).not.toMatch(/pencilMatch/);
+  });
+});
+
 describe('CellInput at size 16 (boxSize 4)', () => {
   it('renders values 10-16 as letters A-G', () => {
     const cell = makeCell({ isFixed: true, value: 16, hasValue: true });

--- a/src/frontend/Sudoku.React/src/components/CellInput.tsx
+++ b/src/frontend/Sudoku.React/src/components/CellInput.tsx
@@ -8,6 +8,7 @@ interface CellInputProps {
   isHighlighted: boolean;
   isSameNumber: boolean;
   isInvalid: boolean;
+  selectedValue?: number | null;
   size?: number;
   boxSize?: number;
   onSelect: () => void;
@@ -19,6 +20,7 @@ export default function CellInput({
   isHighlighted,
   isSameNumber,
   isInvalid,
+  selectedValue = null,
   size = 9,
   boxSize = 3,
   onSelect,
@@ -53,6 +55,11 @@ export default function CellInput({
 
   const showPencil = cell.possibleValues.length > 0 && !cell.hasValue;
 
+  // A noted candidate matching the selected cell's value is emphasized so the
+  // "where can this number still go?" scan doesn't have to be done by eye.
+  const pencilClass = (n: number): string =>
+    n === selectedValue ? `${styles.pencilEntry} ${styles.pencilMatch}` : styles.pencilEntry;
+
   return (
     <button
       type="button"
@@ -70,18 +77,21 @@ export default function CellInput({
             {[...cell.possibleValues]
               .sort((a, b) => a - b)
               .map(n => (
-                <span key={n} className={styles.pencilEntry}>
+                <span key={n} className={pencilClass(n)}>
                   {valueToSymbol(n)}
                 </span>
               ))}
           </span>
         ) : (
           <span className={styles.pencilValues}>
-            {[1, 2, 3, 4, 5, 6, 7, 8, 9].map(n => (
-              <span key={n} className={styles.pencilEntry}>
-                {cell.possibleValues.includes(n) ? valueToSymbol(n) : ''}
-              </span>
-            ))}
+            {[1, 2, 3, 4, 5, 6, 7, 8, 9].map(n => {
+              const isNoted = cell.possibleValues.includes(n);
+              return (
+                <span key={n} className={isNoted ? pencilClass(n) : styles.pencilEntry}>
+                  {isNoted ? valueToSymbol(n) : ''}
+                </span>
+              );
+            })}
           </span>
         )
       ) : null}

--- a/src/frontend/Sudoku.React/src/components/GameBoard.test.tsx
+++ b/src/frontend/Sudoku.React/src/components/GameBoard.test.tsx
@@ -49,6 +49,33 @@ describe('GameBoard', () => {
   });
 });
 
+describe('GameBoard - pencil mark highlighting', () => {
+  const boardWithNotes = () => {
+    const cells = make81Cells();
+    cells[0] = makeCell({ row: 0, column: 0, value: 5, hasValue: true, isFixed: true });
+    cells[40] = makeCell({ row: 4, column: 4, possibleValues: [2, 5] });
+    return cells;
+  };
+
+  it('emphasizes candidates matching the selected cell value', () => {
+    const { container } = renderBoard({
+      cells: boardWithNotes(),
+      selectedCell: { row: 0, column: 0 },
+    });
+    const matches = container.querySelectorAll('[class*="pencilMatch"]');
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toHaveTextContent('5');
+  });
+
+  it('emphasizes no candidates when the selected cell is empty', () => {
+    const { container } = renderBoard({
+      cells: boardWithNotes(),
+      selectedCell: { row: 4, column: 4 },
+    });
+    expect(container.querySelectorAll('[class*="pencilMatch"]')).toHaveLength(0);
+  });
+});
+
 describe('GameBoard at size 16', () => {
   it('renders 256 cell buttons', () => {
     renderBoard({ cells: makeCells(16), size: 16 });

--- a/src/frontend/Sudoku.React/src/components/GameBoard.tsx
+++ b/src/frontend/Sudoku.React/src/components/GameBoard.tsx
@@ -76,6 +76,7 @@ export default function GameBoard({
                 isHighlighted={isHighlighted(r, c)}
                 isSameNumber={isSameNumber(cell)}
                 isInvalid={isInvalid(r, c)}
+                selectedValue={selectedValue}
                 onSelect={() => onCellSelect(r, c)}
               />
             );


### PR DESCRIPTION
## Description

Selecting a filled cell already tints every other cell holding that same value (`.same` background). Pencil marks were excluded — `isSameNumber` in `GameBoard.tsx` requires `cell.hasValue` — so the candidate notes, which are exactly where *"where can this number still go?"* gets answered, got no treatment at all.

`GameBoard` already computed `selectedValue`; it just never reached the component that renders the notes. This threads it into `CellInput` and accents the matching candidate.

Purely presentational and frontend-only — no API, domain, or persistence changes.

**Follow-up after review feedback:** the first pass only recolored the digit glyph (`var(--accent)` + weight 700), which was still hard to see. At `clamp(7px, 2.1vw, 10px)` the candidate is ~8px on a 9x9 board, so hue was carrying the entire signal on a very small mark — and in the light palette `--accent` (L=0.60) is barely darker than `--ink-soft` (L=0.53), leaving almost no luminance step. The matching slot now paints a **filled accent chip** instead, so the block carries the signal rather than the glyph.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## Changes Made

- `CellInput.tsx` — new optional `selectedValue` prop (defaults to `null`); a `pencilClass(n)` helper applies `.pencilMatch` to the candidate equal to it. Covers both layouts: the positional 9x9 grid (empty placeholder slots never pick up the class) and the wrapped 16x16 row.
- `GameBoard.tsx` — threads the already-computed `selectedValue` down to `CellInput`.
- `CellInput.module.css` — `.pencilMatch` fills its slot with `var(--accent)` and sets `var(--accent-ink)` on the digit, at `border-radius: 3px` with a 1px margin so the chip insets from the cell borders. This reuses the accent-button treatment already used in `GameControls`, `HomePage`, `NewGamePage`, and `GameListPage` rather than introducing a new one. Also adds `background-color` to the `.pencilEntry` transition so the chip fades in like `.cell` does, plus a `.pencilValuesWrapped .pencilMatch` override that swaps margin for padding — in the 16x16 wrapped layout each entry is only as wide as its glyph, so a margin-inset chip would hug the digit instead of reading as a block.
- Tests — 5 new `CellInput` cases and 2 new `GameBoard` cases (that file had no highlight coverage at all before). They assert on class presence rather than color, so they cover the styling change unchanged.

Two behaviors deliberately left alone:
- **Cell backgrounds are untouched**, so the existing `selected > invalid > same > highlight` precedence is unchanged. Tinting the whole containing cell was considered and rejected — with full notes on an early-game board, most cells would light up at once.
- **The trigger rule is unchanged**: highlighting is driven by the selected cell's value, and only when that cell has one. No number-pad "active number" concept was introduced.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [x] I have added new tests (if applicable)

`npm test` → 242 passed / 23 files. `npm run build` (which is `tsc -b`, so it type-checks tests too) clean. `npm run lint` shows 8 problems, all pre-existing and none in `CellInput` — the follow-up commit is CSS-only.

Driven end-to-end against the full Aspire stack with Playwright, on a real 9x9 Easy game:

| Check | Light | Dark |
|---|---|---|
| Chip fill | `oklch(0.6 0.11 45)` | `oklch(0.73 0.11 58)` |
| Digit ink | `oklch(0.99 0.006 78)` | `oklch(0.2 0.02 50)` |
| Weight / radius | 700 / 3px | 700 / 3px |
| Chip box | 12.5x13.0 in a 44.4px cell | same |
| Empty cell selected | 0 `pencilMatch` spans | — |

Slot geometry was measured to confirm the chip lands in the right place in the positional grid: with `1`, `5`, `9` noted and a filled `5` selected, the match is slot[4] at (15.5, 15.2) in a 44.4px cell — dead center — with `1` at (0, 0) and `9` at (29, 29.2).

## Screenshots (if applicable)

Selected cell holds `5`; the noted cell shows `5` on a filled accent chip with the sibling `9` left untouched in grey. Other filled `5`s keep their pre-existing `.same` tint. Verified in both light and dark themes.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation (if necessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
